### PR TITLE
fix(ChatExcel): Fix ERROR!LLM Response Can't Parser! bug in chat excel scene

### DIFF
--- a/pilot/scene/chat_data/chat_excel/excel_analyze/chat.py
+++ b/pilot/scene/chat_data/chat_excel/excel_analyze/chat.py
@@ -20,7 +20,7 @@ CFG = Config()
 
 class ChatExcel(BaseChat):
     chat_scene: str = ChatScene.ChatExcel.value()
-    chat_retention_rounds = 1
+    chat_retention_rounds = 2
 
     def __init__(self, chat_param: Dict):
         chat_mode = ChatScene.ChatExcel


### PR DESCRIPTION
1. Expand chat excel retention rounds to 2 to include ChatExcel prompt
2. Fix typo in `base_chat.py`: `histroy` => `history`