### PR TITLE
bugfix(Azure): fix index out of range error due to Azure Openai reponses an empty chunk at first

### DIFF
--- a/pilot/model/proxy/llms/chatgpt.py
+++ b/pilot/model/proxy/llms/chatgpt.py
@@ -172,6 +172,11 @@ def chatgpt_generate_stream(
         res = client.chat.completions.create(messages=history, **payloads)
         text = ""
         for r in res:
+            # logger.info(str(r))
+            # Azure Openai reponse may have empty choices body in the first chunk
+            # to avoid index out of range error
+            if not r.get('choices'):
+                continue
             if r.choices[0].delta.content is not None:
                 content = r.choices[0].delta.content
                 text += content
@@ -186,6 +191,8 @@ def chatgpt_generate_stream(
 
         text = ""
         for r in res:
+            if not r.get('choices'):
+                continue
             if r["choices"][0]["delta"].get("content") is not None:
                 content = r["choices"][0]["delta"]["content"]
                 text += content
@@ -220,6 +227,8 @@ async def async_chatgpt_generate_stream(
         res = await client.chat.completions.create(messages=history, **payloads)
         text = ""
         for r in res:
+            if not r.get('choices'):
+                continue
             if r.choices[0].delta.content is not None:
                 content = r.choices[0].delta.content
                 text += content
@@ -233,6 +242,8 @@ async def async_chatgpt_generate_stream(
 
         text = ""
         async for r in res:
+            if not r.get('choices'):
+                continue
             if r["choices"][0]["delta"].get("content") is not None:
                 content = r["choices"][0]["delta"]["content"]
                 text += content

--- a/pilot/model/proxy/llms/chatgpt.py
+++ b/pilot/model/proxy/llms/chatgpt.py
@@ -175,7 +175,7 @@ def chatgpt_generate_stream(
             # logger.info(str(r))
             # Azure Openai reponse may have empty choices body in the first chunk
             # to avoid index out of range error
-            if not r.get('choices'):
+            if not r.get("choices"):
                 continue
             if r.choices[0].delta.content is not None:
                 content = r.choices[0].delta.content
@@ -191,7 +191,7 @@ def chatgpt_generate_stream(
 
         text = ""
         for r in res:
-            if not r.get('choices'):
+            if not r.get("choices"):
                 continue
             if r["choices"][0]["delta"].get("content") is not None:
                 content = r["choices"][0]["delta"]["content"]
@@ -227,7 +227,7 @@ async def async_chatgpt_generate_stream(
         res = await client.chat.completions.create(messages=history, **payloads)
         text = ""
         for r in res:
-            if not r.get('choices'):
+            if not r.get("choices"):
                 continue
             if r.choices[0].delta.content is not None:
                 content = r.choices[0].delta.content
@@ -242,7 +242,7 @@ async def async_chatgpt_generate_stream(
 
         text = ""
         async for r in res:
-            if not r.get('choices'):
+            if not r.get("choices"):
                 continue
             if r["choices"][0]["delta"].get("content") is not None:
                 content = r["choices"][0]["delta"]["content"]


### PR DESCRIPTION
### Description
<img width="757" alt="image" src="https://github.com/eosphoros-ai/DB-GPT/assets/1787565/bf30b70e-b6ef-4ec7-9f19-531cdfcf3400">

Azure Openai reponse may have an empty chunk at the first streming response, i.e. the "choices" key have an empty list.
This will cause the error from reponse json parser.

You can see the  ` "choices": []` at the first response.
<img width="740" alt="image" src="https://github.com/eosphoros-ai/DB-GPT/assets/1787565/150ac662-92f5-43c5-996e-76da96cdcc62">

### Solution
Do a empty/None check before parse the response json.