### PR TITLE
Fix wenxin config in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -180,7 +180,7 @@ TONGYI_PROXY_API_KEY={your-tongyi-sk}
 ## Baidu wenxin
 #WEN_XIN_MODEL_VERSION={version}
 #WEN_XIN_API_KEY={your-wenxin-sk}
-#WEN_XIN_SECRET_KEY={your-wenxin-sct}
+#WEN_XIN_API_SECRET={your-wenxin-sct}
 
 ## Zhipu
 #ZHIPU_MODEL_VERSION={version}

--- a/docs/docs/installation/sourcecode.md
+++ b/docs/docs/installation/sourcecode.md
@@ -174,13 +174,12 @@ or
 git clone https://huggingface.co/moka-ai/m3e-large
 ```
 
-Configure the proxy and modify LLM_MODEL, PROXY_API_URL and API_KEY in the `.env`file
+Configure the proxy and modify LLM_MODEL, MODEL_VERSION, API_KEY and API_SECRET in the `.env`file
 
 ```python
 # .env
 LLM_MODEL=wenxin_proxyllm
-PROXY_SERVER_URL={your_service_url}
-WEN_XIN_MODEL_VERSION={version}
+WEN_XIN_MODEL_VERSION={version} # ERNIE-Bot or ERNIE-Bot-turbo
 WEN_XIN_API_KEY={your-wenxin-sk}
 WEN_XIN_API_SECRET={your-wenxin-sct}
 ```


### PR DESCRIPTION
Fix wenxin config in .env.template

In dbgpt/_private/config.py, os.getenv("WEN_XIN_API_SECRET") is used to get API_SECRET.
But in .env.template WEN_XIN_SECRET_KEY is set.
Thus config.py cannot get correct API_KEY.

And PROXY_API is not needed because dbgpt/model/proxy/llms/wenxin.py automatically choose api url.
https://github.com/eosphoros-ai/DB-GPT/blob/d9065227bd61359e4ab71a499c33ace7f61520f8/dbgpt/model/proxy/llms/wenxin.py#L63-L83

Refer to issue #964 