### PR TITLE
fix: default proxyllm generator function

### DIFF
--- a/dbgpt/model/llm_out/proxy_llm.py
+++ b/dbgpt/model/llm_out/proxy_llm.py
@@ -34,7 +34,7 @@ def proxyllm_generate_stream(
     model_name = model_params.model_name
     default_error_message = f"{model_name} LLM is not supported"
     generator_function = generator_mapping.get(
-        model_name, lambda: default_error_message
+        model_name, lambda *args: [default_error_message]
     )
 
     yield from generator_function(model, tokenizer, params, device, context_len)


### PR DESCRIPTION
fix the error of default proxyllm generator function: proxyllm_generate_stream.<locals>.<lambda>() takes 0 positional arguments but 5 were given