### PR TITLE
feat(multi-agents):Add Summary Assistant Agent According to User's Question

### DIFF
--- a/dbgpt/agent/agents/expand/summary_assistant_agent.py
+++ b/dbgpt/agent/agents/expand/summary_assistant_agent.py
@@ -74,7 +74,7 @@ class SummaryAssistantAgent(ConversableAgent):
         else:
             try:
                 vis_client = ApiCall()
-                content = "The generated summary is shown above."
+                content = message
                 view = content
             except Exception as e:
                 fail_reason += f"Return summarization error，{str(e)}"

--- a/dbgpt/agent/agents/expand/summary_assistant_agent.py
+++ b/dbgpt/agent/agents/expand/summary_assistant_agent.py
@@ -1,0 +1,89 @@
+from typing import Callable, Dict, Literal, Optional, Union
+
+from dbgpt._private.config import Config
+from dbgpt.agent.agents.base_agent import ConversableAgent
+from dbgpt.agent.plugin.commands.command_mange import ApiCall
+
+from ...memory.gpts_memory import GptsMemory
+from ..agent import Agent, AgentContext
+
+
+class SummaryAssistantAgent(ConversableAgent):
+    """(In preview) Assistant agent, designed to solve a task with LLM.
+
+    AssistantAgent is a subclass of ConversableAgent configured with a default system message.
+    The default system message is designed to solve a task with LLM,
+    including suggesting python code blocks and debugging.
+    `human_input_mode` is default to "NEVER"
+    and `code_execution_config` is default to False.
+    This agent doesn't execute code by default, and expects the user to execute the code.
+    """
+
+    DEFAULT_SYSTEM_MESSAGE = """You are a great summary writter to summarize the provided text content according to user questions.
+           Please complete this task step by step following instructions below:
+           1. You need to first detect user's question that you need to answer with your summarization.
+           2. Output the extracted user's question with the format - The User's Question: user's question.
+           3. Then you need to summarize the historical messages 
+           4. Output the summarization only related to user's question with the format - The Summarization: the summarization.
+        """
+
+    DEFAULT_DESCRIBE = """Summarize provided text content according to user's questions and output the summaraization."""
+
+    NAME = "Summarizer"
+
+    def __init__(
+        self,
+        memory: GptsMemory,
+        agent_context: AgentContext,
+        describe: Optional[str] = DEFAULT_DESCRIBE,
+        is_termination_msg: Optional[Callable[[Dict], bool]] = None,
+        max_consecutive_auto_reply: Optional[int] = None,
+        human_input_mode: Optional[str] = "NEVER",
+        **kwargs,
+    ):
+        super().__init__(
+            name=self.NAME,
+            memory=memory,
+            describe=describe,
+            system_message=self.DEFAULT_SYSTEM_MESSAGE,
+            is_termination_msg=is_termination_msg,
+            max_consecutive_auto_reply=max_consecutive_auto_reply,
+            human_input_mode=human_input_mode,
+            agent_context=agent_context,
+            **kwargs,
+        )
+        self.register_reply(Agent, SummaryAssistantAgent.generate_summary_reply)
+        self.agent_context = agent_context
+
+    async def generate_summary_reply(
+        self,
+        message: Optional[str] = None,
+        sender: Optional[Agent] = None,
+        reviewer: Optional[Agent] = None,
+        config: Optional[Union[Dict, Literal[False]]] = None,
+    ):
+        """Generate a reply with summary."""
+
+        response_success = True
+        view = None
+        content = None
+        if message is None:
+            # Answer failed, turn on automatic repair
+            fail_reason += f"Nothing is summarized, please check your input."
+            response_success = False
+        else:
+            try:
+                vis_client = ApiCall()
+                content = "The generated summary is shown above."
+                view = content
+            except Exception as e:
+                fail_reason += f"Return summarization error，{str(e)}"
+                response_success = False
+
+        if not response_success:
+            content = fail_reason
+        return True, {
+            "is_exe_success": response_success,
+            "content": content,
+            "view": view,
+        }

--- a/examples/agents/single_summary_agent_dialogue_example.py
+++ b/examples/agents/single_summary_agent_dialogue_example.py
@@ -1,0 +1,74 @@
+"""Agents: single agents about CodeAssistantAgent?
+
+    Examples:
+     
+        Execute the following command in the terminal:
+        Set env params.
+        .. code-block:: shell
+
+            export OPENAI_API_KEY=sk-xx
+            export OPENAI_API_BASE=https://xx:80/v1
+
+        run example.
+        ..code-block:: shell
+            python examples/agents/single_agent_dialogue_example.py
+"""
+
+import asyncio
+import os
+
+from dbgpt.agent.agents.agent import AgentContext
+from dbgpt.agent.agents.expand.summary_assistant_agent import SummaryAssistantAgent
+from dbgpt.agent.agents.user_proxy_agent import UserProxyAgent
+from dbgpt.agent.memory.gpts_memory import GptsMemory
+from dbgpt.core.interface.llm import ModelMetadata
+
+if __name__ == "__main__":
+    from dbgpt.model import OpenAILLMClient
+
+    llm_client = OpenAILLMClient()
+    context: AgentContext = AgentContext(conv_id="summarize", llm_provider=llm_client)
+    context.llm_models = [ModelMetadata(model="gpt-3.5-turbo")]
+
+    default_memory = GptsMemory()
+    summarizer = SummaryAssistantAgent(memory=default_memory, agent_context=context)
+
+    user_proxy = UserProxyAgent(memory=default_memory, agent_context=context)
+
+    asyncio.run(
+        user_proxy.a_initiate_chat(
+            recipient=summarizer,
+            reviewer=user_proxy,
+            message="""I want to summarize advantages of Nuclear Power according to the following content.
+
+            Nuclear power in space is the use of nuclear power in outer space, typically either small fission systems or radioactive decay for electricity or heat. Another use is for scientific observation, as in a Mössbauer spectrometer. The most common type is a radioisotope thermoelectric generator, which has been used on many space probes and on crewed lunar missions. Small fission reactors for Earth observation satellites, such as the TOPAZ nuclear reactor, have also been flown.[1] A radioisotope heater unit is powered by radioactive decay and can keep components from becoming too cold to function, potentially over a span of decades.[2]
+
+            The United States tested the SNAP-10A nuclear reactor in space for 43 days in 1965,[3] with the next test of a nuclear reactor power system intended for space use occurring on 13 September 2012 with the Demonstration Using Flattop Fission (DUFF) test of the Kilopower reactor.[4]
+
+            After a ground-based test of the experimental 1965 Romashka reactor, which used uranium and direct thermoelectric conversion to electricity,[5] the USSR sent about 40 nuclear-electric satellites into space, mostly powered by the BES-5 reactor. The more powerful TOPAZ-II reactor produced 10 kilowatts of electricity.[3]
+
+            Examples of concepts that use nuclear power for space propulsion systems include the nuclear electric rocket (nuclear powered ion thruster(s)), the radioisotope rocket, and radioisotope electric propulsion (REP).[6] One of the more explored concepts is the nuclear thermal rocket, which was ground tested in the NERVA program. Nuclear pulse propulsion was the subject of Project Orion.[7]
+
+            Regulation and hazard prevention[edit]
+            After the ban of nuclear weapons in space by the Outer Space Treaty in 1967, nuclear power has been discussed at least since 1972 as a sensitive issue by states.[8] Particularly its potential hazards to Earth's environment and thus also humans has prompted states to adopt in the U.N. General Assembly the Principles Relevant to the Use of Nuclear Power Sources in Outer Space (1992), particularly introducing safety principles for launches and to manage their traffic.[8]
+
+            Benefits
+
+            Both the Viking 1 and Viking 2 landers used RTGs for power on the surface of Mars. (Viking launch vehicle pictured)
+            While solar power is much more commonly used, nuclear power can offer advantages in some areas. Solar cells, although efficient, can only supply energy to spacecraft in orbits where the solar flux is sufficiently high, such as low Earth orbit and interplanetary destinations close enough to the Sun. Unlike solar cells, nuclear power systems function independently of sunlight, which is necessary for deep space exploration. Nuclear-based systems can have less mass than solar cells of equivalent power, allowing more compact spacecraft that are easier to orient and direct in space. In the case of crewed spaceflight, nuclear power concepts that can power both life support and propulsion systems may reduce both cost and flight time.[9]
+
+            Selected applications and/or technologies for space include:
+
+            Radioisotope thermoelectric generator
+            Radioisotope heater unit
+            Radioisotope piezoelectric generator
+            Radioisotope rocket
+            Nuclear thermal rocket
+            Nuclear pulse propulsion
+            Nuclear electric rocket
+            """, 
+        )
+    )
+
+    ## dbgpt-vis message infos
+    print(asyncio.run(default_memory.one_plan_chat_competions("summarize")))

--- a/examples/agents/single_summary_agent_dialogue_example.py
+++ b/examples/agents/single_summary_agent_dialogue_example.py
@@ -11,7 +11,7 @@
 
         run example.
         ..code-block:: shell
-            python examples/agents/single_agent_dialogue_example.py
+            python examples/agents/single_summary_agent_dialogue_example.py
 """
 
 import asyncio
@@ -66,7 +66,7 @@ if __name__ == "__main__":
             Nuclear thermal rocket
             Nuclear pulse propulsion
             Nuclear electric rocket
-            """, 
+            """,
         )
     )
 


### PR DESCRIPTION
## What did I do
Add summary assistant agent `DB-GPT/dbgpt/agent/agents/expand/summary_assistant_agent.py` and the example of summary assistant agent `DB-GPT/examples/agents/single_summary_agent_dialogue_example.py`. The summary assistant can generate summary according to the questions provided by user's. Currently, it only support GPT series.

## How did I test the code
Please just run `python examples/agents/single_summary_agent_dialogue_example.py`, and you will get the following result:

![Screen Shot 2024-01-04 at 7 41 53 PM](https://github.com/eosphoros-ai/DB-GPT/assets/10005367/0b9c130c-c0c7-44c5-9e78-b2d926c4c92a)

## Did I rebase the submitted code
Yes. 
