### PR TITLE
fix(ChatKnowledge): delete Chroma by vector ids did not success

### DIFF
--- a/dbgpt/storage/vector_store/chroma_store.py
+++ b/dbgpt/storage/vector_store/chroma_store.py
@@ -113,8 +113,10 @@ class ChromaStore(VectorStoreBase):
 
     def delete_by_ids(self, ids):
         logger.info(f"begin delete chroma ids...")
-        collection = self.vector_store_client._collection
-        collection.delete(ids=ids)
+        ids = ids.split(",")
+        if len(ids) > 0:
+            collection = self.vector_store_client._collection
+            collection.delete(ids=ids)
 
     def _clean_persist_folder(self):
         for root, dirs, files in os.walk(self.persist_dir, topdown=False):


### PR DESCRIPTION
- Fixed the issue where vectors in the ChromaDB were not being deleted when a document was removed.

Close #1021