### PR TITLE
feat(awel): New MessageConverter and more AWEL operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,7 @@ thirdparty
 # typescript
 *.tsbuildinfo
 /web/next-env.d.ts
+
+# Ignore awel DAG visualization files
+/examples/**/*.gv
+/examples/**/*.gv.pdf

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ pre-commit: fmt test ## Run formatting and unit tests before committing
 test: $(VENV)/.testenv ## Run unit tests
 	$(VENV_BIN)/pytest dbgpt
 
+.PHONY: test-doc
+test-doc: testenv ## Run doctests
+	# -k "not test_" skips tests that are not doctests.
+	$(VENV_BIN)/pytest --doctest-modules -k "not test_" dbgpt/core
+
 .PHONY: coverage
 coverage: setup ## Run tests and report coverage
 	$(VENV_BIN)/pytest dbgpt --cov=dbgpt

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test: $(VENV)/.testenv ## Run unit tests
 	$(VENV_BIN)/pytest dbgpt
 
 .PHONY: test-doc
-test-doc: testenv ## Run doctests
+test-doc: $(VENV)/.testenv ## Run doctests
 	# -k "not test_" skips tests that are not doctests.
 	$(VENV_BIN)/pytest --doctest-modules -k "not test_" dbgpt/core
 

--- a/dbgpt/app/scene/base_chat.py
+++ b/dbgpt/app/scene/base_chat.py
@@ -102,6 +102,11 @@ class BaseChat(ABC):
             is_stream=True, dag_name="llm_stream_model_dag"
         )
 
+        # Get the message version, default is v1 in app
+        # In v1, we will transform the message to compatible format of specific model
+        # In the future, we will upgrade the message version to v2, and the message will be compatible with all models
+        self._message_version = chat_param.get("message_version", "v1")
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -185,6 +190,7 @@ class BaseChat(ABC):
             "temperature": float(self.prompt_template.temperature),
             "max_new_tokens": int(self.prompt_template.max_new_tokens),
             "echo": self.llm_echo,
+            "version": self._message_version,
         }
         return payload
 

--- a/dbgpt/core/__init__.py
+++ b/dbgpt/core/__init__.py
@@ -6,7 +6,10 @@ from dbgpt.core.interface.cache import (
     CacheValue,
 )
 from dbgpt.core.interface.llm import (
+    DefaultMessageConverter,
     LLMClient,
+    MessageConverter,
+    ModelExtraMedata,
     ModelInferenceMetrics,
     ModelMetadata,
     ModelOutput,
@@ -14,19 +17,28 @@ from dbgpt.core.interface.llm import (
     ModelRequestContext,
 )
 from dbgpt.core.interface.message import (
+    AIMessage,
+    BaseMessage,
     ConversationIdentifier,
+    HumanMessage,
     MessageIdentifier,
     MessageStorageItem,
     ModelMessage,
     ModelMessageRoleType,
     OnceConversation,
     StorageConversation,
+    SystemMessage,
 )
 from dbgpt.core.interface.output_parser import BaseOutputParser, SQLOutputParser
 from dbgpt.core.interface.prompt import (
+    BasePromptTemplate,
+    ChatPromptTemplate,
+    HumanPromptTemplate,
+    MessagesPlaceholder,
     PromptManager,
     PromptTemplate,
     StoragePromptTemplate,
+    SystemPromptTemplate,
 )
 from dbgpt.core.interface.serialization import Serializable, Serializer
 from dbgpt.core.interface.storage import (
@@ -49,14 +61,26 @@ __ALL__ = [
     "ModelMessage",
     "LLMClient",
     "ModelMessageRoleType",
+    "ModelExtraMedata",
+    "MessageConverter",
+    "DefaultMessageConverter",
     "OnceConversation",
     "StorageConversation",
+    "BaseMessage",
+    "SystemMessage",
+    "AIMessage",
+    "HumanMessage",
     "MessageStorageItem",
     "ConversationIdentifier",
     "MessageIdentifier",
     "PromptTemplate",
     "PromptManager",
     "StoragePromptTemplate",
+    "BasePromptTemplate",
+    "ChatPromptTemplate",
+    "MessagesPlaceholder",
+    "SystemPromptTemplate",
+    "HumanPromptTemplate",
     "BaseOutputParser",
     "SQLOutputParser",
     "Serializable",

--- a/dbgpt/core/awel/__init__.py
+++ b/dbgpt/core/awel/__init__.py
@@ -132,9 +132,14 @@ def setup_dev_environment(
 
     for dag in dags:
         if show_dag_graph:
-            dag_graph_file = dag.visualize_dag()
-            if dag_graph_file:
-                logger.info(f"Visualize DAG {str(dag)} to {dag_graph_file}")
+            try:
+                dag_graph_file = dag.visualize_dag()
+                if dag_graph_file:
+                    logger.info(f"Visualize DAG {str(dag)} to {dag_graph_file}")
+            except Exception as e:
+                logger.warning(
+                    f"Visualize DAG {str(dag)} failed: {e}, if your system has no graphviz, you can install it by `pip install graphviz` or `sudo apt install graphviz`"
+                )
         for trigger in dag.trigger_nodes:
             trigger_manager.register_trigger(trigger)
     trigger_manager.after_register()

--- a/dbgpt/core/awel/__init__.py
+++ b/dbgpt/core/awel/__init__.py
@@ -7,6 +7,7 @@ The stability of this API cannot be guaranteed at present.
 
 """
 
+import logging
 from typing import List, Optional
 
 from dbgpt.component import SystemApp
@@ -38,6 +39,8 @@ from .task.task_impl import (
     _is_async_iterator,
 )
 from .trigger.http_trigger import HttpTrigger
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "initialize_awel",
@@ -89,14 +92,24 @@ def initialize_awel(system_app: SystemApp, dag_dirs: List[str]):
 
 def setup_dev_environment(
     dags: List[DAG],
-    host: Optional[str] = "0.0.0.0",
+    host: Optional[str] = "127.0.0.1",
     port: Optional[int] = 5555,
     logging_level: Optional[str] = None,
     logger_filename: Optional[str] = None,
+    show_dag_graph: Optional[bool] = True,
 ) -> None:
     """Setup a development environment for AWEL.
 
     Just using in development environment, not production environment.
+
+    Args:
+        dags (List[DAG]): The DAGs.
+        host (Optional[str], optional): The host. Defaults to "127.0.0.1"
+        port (Optional[int], optional): The port. Defaults to 5555.
+        logging_level (Optional[str], optional): The logging level. Defaults to None.
+        logger_filename (Optional[str], optional): The logger filename. Defaults to None.
+        show_dag_graph (Optional[bool], optional): Whether show the DAG graph. Defaults to True.
+            If True, the DAG graph will be saved to a file and open it automatically.
     """
     import uvicorn
     from fastapi import FastAPI
@@ -118,6 +131,10 @@ def setup_dev_environment(
     system_app.register_instance(trigger_manager)
 
     for dag in dags:
+        if show_dag_graph:
+            dag_graph_file = dag.visualize_dag()
+            if dag_graph_file:
+                logger.info(f"Visualize DAG {str(dag)} to {dag_graph_file}")
         for trigger in dag.trigger_nodes:
             trigger_manager.register_trigger(trigger)
     trigger_manager.after_register()

--- a/dbgpt/core/awel/runner/local_runner.py
+++ b/dbgpt/core/awel/runner/local_runner.py
@@ -19,17 +19,21 @@ class DefaultWorkflowRunner(WorkflowRunner):
         node: BaseOperator,
         call_data: Optional[CALL_DATA] = None,
         streaming_call: bool = False,
+        dag_ctx: Optional[DAGContext] = None,
     ) -> DAGContext:
         # Save node output
         # dag = node.dag
-        node_outputs: Dict[str, TaskContext] = {}
         job_manager = JobManager.build_from_end_node(node, call_data)
-        # Create DAG context
-        dag_ctx = DAGContext(
-            streaming_call=streaming_call,
-            node_to_outputs=node_outputs,
-            node_name_to_ids=job_manager._node_name_to_ids,
-        )
+        if not dag_ctx:
+            # Create DAG context
+            node_outputs: Dict[str, TaskContext] = {}
+            dag_ctx = DAGContext(
+                streaming_call=streaming_call,
+                node_to_outputs=node_outputs,
+                node_name_to_ids=job_manager._node_name_to_ids,
+            )
+        else:
+            node_outputs = dag_ctx._node_to_outputs
         logger.info(
             f"Begin run workflow from end operator, id: {node.node_id}, call_data: {call_data}"
         )

--- a/dbgpt/core/interface/message.py
+++ b/dbgpt/core/interface/message.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from dbgpt._private.pydantic import BaseModel, Field
-from dbgpt.core.awel import MapOperator
 from dbgpt.core.interface.storage import (
     InMemoryStorage,
     ResourceIdentifier,
@@ -114,6 +113,50 @@ class ModelMessage(BaseModel):
     content: str
     round_index: Optional[int] = 0
 
+    @property
+    def pass_to_model(self) -> bool:
+        """Whether the message will be passed to the model
+
+        The view message will not be passed to the model
+
+        Returns:
+            bool: Whether the message will be passed to the model
+        """
+        return self.role in [
+            ModelMessageRoleType.SYSTEM,
+            ModelMessageRoleType.HUMAN,
+            ModelMessageRoleType.AI,
+        ]
+
+    @staticmethod
+    def from_base_messages(messages: List[BaseMessage]) -> List["ModelMessage"]:
+        result = []
+        for message in messages:
+            content, round_index = message.content, message.round_index
+            if isinstance(message, HumanMessage):
+                result.append(
+                    ModelMessage(
+                        role=ModelMessageRoleType.HUMAN,
+                        content=content,
+                        round_index=round_index,
+                    )
+                )
+            elif isinstance(message, AIMessage):
+                result.append(
+                    ModelMessage(
+                        role=ModelMessageRoleType.AI,
+                        content=content,
+                        round_index=round_index,
+                    )
+                )
+            elif isinstance(message, SystemMessage):
+                result.append(
+                    ModelMessage(
+                        role=ModelMessageRoleType.SYSTEM, content=message.content
+                    )
+                )
+        return result
+
     @staticmethod
     def from_openai_messages(
         messages: Union[str, List[Dict[str, str]]]
@@ -142,9 +185,15 @@ class ModelMessage(BaseModel):
         return result
 
     @staticmethod
-    def to_openai_messages(messages: List["ModelMessage"]) -> List[Dict[str, str]]:
+    def to_openai_messages(
+        messages: List["ModelMessage"], convert_to_compatible_format: bool = False
+    ) -> List[Dict[str, str]]:
         """Convert to OpenAI message format and
         hugggingface [Templates of Chat Models](https://huggingface.co/docs/transformers/v4.34.1/en/chat_templating)
+
+        Args:
+            messages (List["ModelMessage"]): The model messages
+            convert_to_compatible_format (bool): Whether to convert to compatible format
         """
         history = []
         # Add history conversation
@@ -157,15 +206,16 @@ class ModelMessage(BaseModel):
                 history.append({"role": "assistant", "content": message.content})
             else:
                 pass
-        # Move the last user's information to the end
-        last_user_input_index = None
-        for i in range(len(history) - 1, -1, -1):
-            if history[i]["role"] == "user":
-                last_user_input_index = i
-                break
-        if last_user_input_index:
-            last_user_input = history.pop(last_user_input_index)
-            history.append(last_user_input)
+        if convert_to_compatible_format:
+            # Move the last user's information to the end
+            last_user_input_index = None
+            for i in range(len(history) - 1, -1, -1):
+                if history[i]["role"] == "user":
+                    last_user_input_index = i
+                    break
+            if last_user_input_index:
+                last_user_input = history.pop(last_user_input_index)
+                history.append(last_user_input)
         return history
 
     @staticmethod
@@ -189,8 +239,8 @@ class ModelMessage(BaseModel):
         return str_msg
 
 
-_SingleRoundMessage = List[ModelMessage]
-_MultiRoundMessageMapper = Callable[[List[_SingleRoundMessage]], List[ModelMessage]]
+_SingleRoundMessage = List[BaseMessage]
+_MultiRoundMessageMapper = Callable[[List[_SingleRoundMessage]], List[BaseMessage]]
 
 
 def _message_to_dict(message: BaseMessage) -> Dict:
@@ -338,7 +388,8 @@ class OnceConversation:
         """Start a new round of conversation
 
         Example:
-            >>> conversation = OnceConversation()
+
+            >>> conversation = OnceConversation("chat_normal")
             >>> # The chat order will be 0, then we start a new round of conversation
             >>> assert conversation.chat_order == 0
             >>> conversation.start_new_round()
@@ -583,6 +634,20 @@ class OnceConversation:
                         round_index=message.round_index,
                     )
                 )
+        return messages
+
+    def get_history_message(self) -> List[BaseMessage]:
+        """Get the history message
+
+        Not include the system messages.
+
+        Returns:
+            List[BaseMessage]: The history messages
+        """
+        messages = []
+        for message in self.messages:
+            if message.pass_to_model and message.type != "system":
+                messages.append(message)
         return messages
 
 

--- a/dbgpt/core/interface/message.py
+++ b/dbgpt/core/interface/message.py
@@ -636,18 +636,26 @@ class OnceConversation:
                 )
         return messages
 
-    def get_history_message(self) -> List[BaseMessage]:
+    def get_history_message(
+        self, include_system_message: bool = False
+    ) -> List[BaseMessage]:
         """Get the history message
 
         Not include the system messages.
+
+        Args:
+            include_system_message (bool): Whether to include the system message
 
         Returns:
             List[BaseMessage]: The history messages
         """
         messages = []
         for message in self.messages:
-            if message.pass_to_model and message.type != "system":
-                messages.append(message)
+            if message.pass_to_model:
+                if include_system_message:
+                    messages.append(message)
+                elif message.type != "system":
+                    messages.append(message)
         return messages
 
 

--- a/dbgpt/core/interface/operator/composer_operator.py
+++ b/dbgpt/core/interface/operator/composer_operator.py
@@ -1,0 +1,114 @@
+import dataclasses
+from typing import Any, Dict, List, Optional
+
+from dbgpt.core import (
+    ChatPromptTemplate,
+    MessageStorageItem,
+    ModelMessage,
+    ModelRequest,
+    StorageConversation,
+    StorageInterface,
+)
+from dbgpt.core.awel import (
+    DAG,
+    BaseOperator,
+    InputOperator,
+    JoinOperator,
+    MapOperator,
+    SimpleCallDataInputSource,
+)
+from dbgpt.core.interface.operator.prompt_operator import HistoryPromptBuilderOperator
+
+from .message_operator import (
+    BufferedConversationMapperOperator,
+    ChatHistoryLoadType,
+    PreChatHistoryLoadOperator,
+)
+
+
+@dataclasses.dataclass
+class ChatComposerInput:
+    """The composer input."""
+
+    prompt_dict: Dict[str, Any]
+    model_dict: Dict[str, Any]
+    context: ChatHistoryLoadType
+
+
+class ChatHistoryPromptComposerOperator(MapOperator[ChatComposerInput, ModelRequest]):
+    """The chat history prompt composer operator.
+
+    For simple use, you can use this operator to compose the chat history prompt.
+    """
+
+    def __init__(
+        self,
+        prompt_template: ChatPromptTemplate,
+        history_key: str = "chat_history",
+        last_k_round: int = 2,
+        storage: Optional[StorageInterface[StorageConversation, Any]] = None,
+        message_storage: Optional[StorageInterface[MessageStorageItem, Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._prompt_template = prompt_template
+        self._history_key = history_key
+        self._last_k_round = last_k_round
+        self._storage = storage
+        self._message_storage = message_storage
+        self._sub_compose_dag = self._build_composer_dag()
+
+    async def map(self, input_value: ChatComposerInput) -> ModelRequest:
+        end_node: BaseOperator = self._sub_compose_dag.leaf_nodes[0]
+        # Sub dag, use the same dag context in the parent dag
+        return await end_node.call(
+            call_data={"data": input_value}, dag_ctx=self.current_dag_context
+        )
+
+    def _build_composer_dag(self) -> DAG:
+        with DAG("dbgpt_awel_chat_history_prompt_composer") as composer_dag:
+            input_task = InputOperator(input_source=SimpleCallDataInputSource())
+            # Load and store chat history, default use InMemoryStorage.
+            chat_history_load_task = PreChatHistoryLoadOperator(
+                storage=self._storage, message_storage=self._message_storage
+            )
+            # History transform task, here we keep last 5 round messages
+            history_transform_task = BufferedConversationMapperOperator(
+                last_k_round=self._last_k_round
+            )
+            history_prompt_build_task = HistoryPromptBuilderOperator(
+                prompt=self._prompt_template, history_key=self._history_key
+            )
+            model_request_build_task = JoinOperator(self._build_model_request)
+
+            # Build composer dag
+            (
+                input_task
+                >> MapOperator(lambda x: x.context)
+                >> chat_history_load_task
+                >> history_transform_task
+                >> history_prompt_build_task
+            )
+            (
+                input_task
+                >> MapOperator(lambda x: x.prompt_dict)
+                >> history_prompt_build_task
+            )
+
+            history_prompt_build_task >> model_request_build_task
+            (
+                input_task
+                >> MapOperator(lambda x: x.model_dict)
+                >> model_request_build_task
+            )
+
+        return composer_dag
+
+    def _build_model_request(
+        self, messages: List[ModelMessage], model_dict: Dict[str, Any]
+    ) -> ModelRequest:
+        return ModelRequest.build_request(messages=messages, **model_dict)
+
+    async def after_dag_end(self):
+        # Should call after_dag_end() of sub dag
+        await self._sub_compose_dag._after_dag_end()

--- a/dbgpt/core/interface/operator/prompt_operator.py
+++ b/dbgpt/core/interface/operator/prompt_operator.py
@@ -1,0 +1,255 @@
+from abc import ABC
+from typing import Any, Dict, List, Optional, Union
+
+from dbgpt.core import (
+    BasePromptTemplate,
+    ChatPromptTemplate,
+    ModelMessage,
+    ModelMessageRoleType,
+    ModelOutput,
+    StorageConversation,
+)
+from dbgpt.core.awel import JoinOperator, MapOperator
+from dbgpt.core.interface.message import BaseMessage
+from dbgpt.core.interface.operator.llm_operator import BaseLLM
+from dbgpt.core.interface.operator.message_operator import BaseConversationOperator
+from dbgpt.core.interface.prompt import HumanPromptTemplate, MessageType
+from dbgpt.util.function_utils import rearrange_args_by_type
+
+
+class BasePromptBuilderOperator(BaseConversationOperator, ABC):
+    """The base prompt builder operator."""
+
+    def __init__(self, check_storage: bool, **kwargs):
+        super().__init__(check_storage=check_storage, **kwargs)
+
+    async def format_prompt(
+        self, prompt: ChatPromptTemplate, prompt_dict: Dict[str, Any]
+    ) -> List[ModelMessage]:
+        """Format the prompt.
+
+        Args:
+            prompt (ChatPromptTemplate): The prompt.
+            prompt_dict (Dict[str, Any]): The prompt dict.
+
+        Returns:
+            List[ModelMessage]: The formatted prompt.
+        """
+        kwargs = {}
+        kwargs.update(prompt_dict)
+        pass_kwargs = {k: v for k, v in kwargs.items() if k in prompt.input_variables}
+        messages = prompt.format_messages(**pass_kwargs)
+        messages = ModelMessage.from_base_messages(messages)
+        # Start new round conversation, and save user message to storage
+        await self.start_new_round_conv(messages)
+        return messages
+
+    async def start_new_round_conv(self, messages: List[ModelMessage]) -> None:
+        """Start a new round conversation.
+
+        Args:
+            messages (List[ModelMessage]): The messages.
+        """
+
+        lass_user_message = None
+        for message in messages[::-1]:
+            if message.role == ModelMessageRoleType.HUMAN:
+                lass_user_message = message.content
+                break
+        if not lass_user_message:
+            raise ValueError("No user message")
+        storage_conv: StorageConversation = await self.get_storage_conversation()
+        if not storage_conv:
+            return
+        # Start new round
+        storage_conv.start_new_round()
+        storage_conv.add_user_message(lass_user_message)
+
+    async def after_dag_end(self):
+        """The callback after DAG end"""
+        # TODO remove this to start_new_round()
+        # Save the storage conversation to storage after the whole DAG finished
+        storage_conv: StorageConversation = await self.get_storage_conversation()
+        if not storage_conv:
+            return
+        model_output: ModelOutput = await self.current_dag_context.get_from_share_data(
+            BaseLLM.SHARE_DATA_KEY_MODEL_OUTPUT
+        )
+        if model_output:
+            # Save model output message to storage
+            storage_conv.add_ai_message(model_output.text)
+            # End current conversation round and flush to storage
+            storage_conv.end_current_round()
+
+
+PromptTemplateType = Union[ChatPromptTemplate, BasePromptTemplate, MessageType, str]
+
+
+class PromptBuilderOperator(
+    BasePromptBuilderOperator, MapOperator[Dict[str, Any], List[ModelMessage]]
+):
+    """The operator to build the prompt with static prompt.
+
+    Examples:
+
+        .. code-block:: python
+
+            import asyncio
+            from dbgpt.core.awel import DAG
+            from dbgpt.core import (
+                ModelMessage,
+                HumanMessage,
+                SystemMessage,
+                HumanPromptTemplate,
+                SystemPromptTemplate,
+                ChatPromptTemplate,
+            )
+            from dbgpt.core.operator import PromptBuilderOperator
+
+            with DAG("prompt_test") as dag:
+                str_prompt = PromptBuilderOperator(
+                    "Please write a {dialect} SQL count the length of a field"
+                )
+                tp_prompt = PromptBuilderOperator(
+                    HumanPromptTemplate.from_template(
+                        "Please write a {dialect} SQL count the length of a field"
+                    )
+                )
+                chat_prompt = PromptBuilderOperator(
+                    ChatPromptTemplate(
+                        messages=[
+                            HumanPromptTemplate.from_template(
+                                "Please write a {dialect} SQL count the length of a field"
+                            )
+                        ]
+                    )
+                )
+                with_sys_prompt = PromptBuilderOperator(
+                    ChatPromptTemplate(
+                        messages=[
+                            SystemPromptTemplate.from_template(
+                                "You are a {dialect} SQL expert"
+                            ),
+                            HumanPromptTemplate.from_template(
+                                "Please write a {dialect} SQL count the length of a field"
+                            ),
+                        ],
+                    )
+                )
+
+            single_input = {"data": {"dialect": "mysql"}}
+            single_expected_messages = [
+                ModelMessage(
+                    content="Please write a mysql SQL count the length of a field",
+                    role="human",
+                )
+            ]
+            with_sys_expected_messages = [
+                ModelMessage(content="You are a mysql SQL expert", role="system"),
+                ModelMessage(
+                    content="Please write a mysql SQL count the length of a field",
+                    role="human",
+                ),
+            ]
+            assert (
+                asyncio.run(str_prompt.call(call_data=single_input))
+                == single_expected_messages
+            )
+            assert (
+                asyncio.run(tp_prompt.call(call_data=single_input))
+                == single_expected_messages
+            )
+            assert (
+                asyncio.run(chat_prompt.call(call_data=single_input))
+                == single_expected_messages
+            )
+            assert (
+                asyncio.run(with_sys_prompt.call(call_data=single_input))
+                == with_sys_expected_messages
+            )
+
+    """
+
+    def __init__(self, prompt: PromptTemplateType, **kwargs):
+        if isinstance(prompt, str):
+            prompt = ChatPromptTemplate(
+                messages=[HumanPromptTemplate.from_template(prompt)]
+            )
+        elif isinstance(prompt, BasePromptTemplate) and not isinstance(
+            prompt, ChatPromptTemplate
+        ):
+            prompt = ChatPromptTemplate(
+                messages=[HumanPromptTemplate.from_template(prompt.template)]
+            )
+        elif isinstance(prompt, MessageType):
+            prompt = ChatPromptTemplate(messages=[prompt])
+        self._prompt = prompt
+
+        super().__init__(check_storage=False, **kwargs)
+        MapOperator.__init__(self, map_function=self.merge_prompt, **kwargs)
+
+    @rearrange_args_by_type
+    async def merge_prompt(self, prompt_dict: Dict[str, Any]) -> List[ModelMessage]:
+        return await self.format_prompt(self._prompt, prompt_dict)
+
+
+class DynamicPromptBuilderOperator(
+    BasePromptBuilderOperator, JoinOperator[List[ModelMessage]]
+):
+    """The operator to build the prompt with dynamic prompt.
+
+    The prompt template is dynamic, and it created by parent operator.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(check_storage=False, **kwargs)
+        JoinOperator.__init__(self, combine_function=self.merge_prompt, **kwargs)
+
+    @rearrange_args_by_type
+    async def merge_prompt(
+        self, prompt: ChatPromptTemplate, prompt_dict: Dict[str, Any]
+    ) -> List[ModelMessage]:
+        return await self.format_prompt(prompt, prompt_dict)
+
+
+class HistoryPromptBuilderOperator(
+    BasePromptBuilderOperator, JoinOperator[List[ModelMessage]]
+):
+    def __init__(
+        self, prompt: ChatPromptTemplate, history_key: Optional[str] = None, **kwargs
+    ):
+        self._prompt = prompt
+        self._history_key = history_key
+
+        JoinOperator.__init__(self, combine_function=self.merge_history, **kwargs)
+
+    @rearrange_args_by_type
+    async def merge_history(
+        self, history: List[BaseMessage], prompt_dict: Dict[str, Any]
+    ) -> List[ModelMessage]:
+        prompt_dict[self._history_key] = history
+        return await self.format_prompt(self._prompt, prompt_dict)
+
+
+class HistoryDynamicPromptBuilderOperator(
+    BasePromptBuilderOperator, JoinOperator[List[ModelMessage]]
+):
+    """The operator to build the prompt with dynamic prompt.
+
+    The prompt template is dynamic, and it created by parent operator.
+    """
+
+    def __init__(self, history_key: Optional[str] = None, **kwargs):
+        self._history_key = history_key
+
+        JoinOperator.__init__(self, combine_function=self.merge_history, **kwargs)
+
+    @rearrange_args_by_type
+    async def merge_history(
+        self,
+        prompt: ChatPromptTemplate,
+        history: List[BaseMessage],
+        prompt_dict: Dict[str, Any],
+    ) -> List[ModelMessage]:
+        prompt_dict[self._history_key] = history
+        return await self.format_prompt(prompt, prompt_dict)

--- a/dbgpt/core/interface/tests/test_message.py
+++ b/dbgpt/core/interface/tests/test_message.py
@@ -413,13 +413,18 @@ def test_to_openai_messages(
         {"role": "user", "content": human_model_message.content},
     ]
 
+
+def test_to_openai_messages_convert_to_compatible_format(
+    human_model_message, ai_model_message, system_model_message
+):
     shuffle_messages = ModelMessage.to_openai_messages(
         [
             system_model_message,
             human_model_message,
             human_model_message,
             ai_model_message,
-        ]
+        ],
+        convert_to_compatible_format=True,
     )
     assert shuffle_messages == [
         {"role": "system", "content": system_model_message.content},

--- a/dbgpt/core/interface/tests/test_prompt.py
+++ b/dbgpt/core/interface/tests/test_prompt.py
@@ -99,12 +99,6 @@ class TestPromptTemplate:
         formatted_output = prompt.format(response="hello")
         assert "Response: " in formatted_output
 
-    def test_from_template(self):
-        template_str = "Hello {name}"
-        prompt = PromptTemplate.from_template(template_str)
-        assert prompt._prompt_template.template == template_str
-        assert prompt._prompt_template.input_variables == []
-
     def test_format_missing_variable(self):
         template_str = "Hello {name}"
         prompt = PromptTemplate(

--- a/dbgpt/core/operator/__init__.py
+++ b/dbgpt/core/operator/__init__.py
@@ -1,31 +1,41 @@
+from dbgpt.core.interface.operator.composer_operator import (
+    ChatComposerInput,
+    ChatHistoryPromptComposerOperator,
+)
 from dbgpt.core.interface.operator.llm_operator import (
     BaseLLM,
+    BaseLLMOperator,
+    BaseStreamingLLMOperator,
     LLMBranchOperator,
-    LLMOperator,
-    RequestBuildOperator,
-    StreamingLLMOperator,
+    RequestBuilderOperator,
 )
 from dbgpt.core.interface.operator.message_operator import (
     BaseConversationOperator,
     BufferedConversationMapperOperator,
     ConversationMapperOperator,
-    PostConversationOperator,
-    PostStreamingConversationOperator,
-    PreConversationOperator,
+    PreChatHistoryLoadOperator,
 )
-from dbgpt.core.interface.prompt import PromptTemplateOperator
+from dbgpt.core.interface.operator.prompt_operator import (
+    DynamicPromptBuilderOperator,
+    HistoryDynamicPromptBuilderOperator,
+    HistoryPromptBuilderOperator,
+    PromptBuilderOperator,
+)
 
 __ALL__ = [
     "BaseLLM",
     "LLMBranchOperator",
-    "LLMOperator",
-    "RequestBuildOperator",
-    "StreamingLLMOperator",
+    "BaseLLMOperator",
+    "RequestBuilderOperator",
+    "BaseStreamingLLMOperator",
     "BaseConversationOperator",
     "BufferedConversationMapperOperator",
     "ConversationMapperOperator",
-    "PostConversationOperator",
-    "PostStreamingConversationOperator",
-    "PreConversationOperator",
-    "PromptTemplateOperator",
+    "PreChatHistoryLoadOperator",
+    "PromptBuilderOperator",
+    "DynamicPromptBuilderOperator",
+    "HistoryPromptBuilderOperator",
+    "HistoryDynamicPromptBuilderOperator",
+    "ChatComposerInput",
+    "ChatHistoryPromptComposerOperator",
 ]

--- a/dbgpt/model/__init__.py
+++ b/dbgpt/model/__init__.py
@@ -1,13 +1,7 @@
 from dbgpt.model.cluster.client import DefaultLLMClient
-from dbgpt.model.utils.chatgpt_utils import (
-    OpenAILLMClient,
-    OpenAIStreamingOperator,
-    MixinLLMOperator,
-)
+from dbgpt.model.utils.chatgpt_utils import OpenAILLMClient
 
 __ALL__ = [
     "DefaultLLMClient",
     "OpenAILLMClient",
-    "OpenAIStreamingOperator",
-    "MixinLLMOperator",
 ]

--- a/dbgpt/model/adapter/base.py
+++ b/dbgpt/model/adapter/base.py
@@ -148,7 +148,7 @@ class LLMModelAdapter(ABC):
                 self.model_name, self.model_path
             )
             return conv_template.sep
-        except RuntimeError:
+        except Exception:
             return "\n"
 
     def transform_model_messages(

--- a/dbgpt/model/adapter/base.py
+++ b/dbgpt/model/adapter/base.py
@@ -148,11 +148,11 @@ class LLMModelAdapter(ABC):
                 self.model_name, self.model_path
             )
             return conv_template.sep
-        except Exception:
+        except RuntimeError:
             return "\n"
 
     def transform_model_messages(
-        self, messages: List[ModelMessage]
+        self, messages: List[ModelMessage], convert_to_compatible_format: bool = False
     ) -> List[Dict[str, str]]:
         """Transform the model messages
 
@@ -174,15 +174,19 @@ class LLMModelAdapter(ABC):
                 ]
         Args:
             messages (List[ModelMessage]): The model messages
+            convert_to_compatible_format (bool, optional): Whether to convert to compatible format. Defaults to False.
 
         Returns:
             List[Dict[str, str]]: The transformed model messages
         """
         logger.info(f"support_system_message: {self.support_system_message}")
-        if not self.support_system_message:
+        if not self.support_system_message and convert_to_compatible_format:
+            # We will not do any transform in the future
             return self._transform_to_no_system_messages(messages)
         else:
-            return ModelMessage.to_openai_messages(messages)
+            return ModelMessage.to_openai_messages(
+                messages, convert_to_compatible_format=convert_to_compatible_format
+            )
 
     def _transform_to_no_system_messages(
         self, messages: List[ModelMessage]
@@ -237,6 +241,7 @@ class LLMModelAdapter(ABC):
         messages: List[ModelMessage],
         tokenizer: Any,
         prompt_template: str = None,
+        convert_to_compatible_format: bool = False,
     ) -> Optional[str]:
         """Get the string prompt from the given parameters and messages
 
@@ -247,6 +252,7 @@ class LLMModelAdapter(ABC):
             messages (List[ModelMessage]): The model messages
             tokenizer (Any): The tokenizer of model, in huggingface chat model, we can create the prompt by tokenizer
             prompt_template (str, optional): The prompt template. Defaults to None.
+            convert_to_compatible_format (bool, optional): Whether to convert to compatible format. Defaults to False.
 
         Returns:
             Optional[str]: The string prompt
@@ -262,6 +268,7 @@ class LLMModelAdapter(ABC):
         model_context: Dict,
         prompt_template: str = None,
     ):
+        convert_to_compatible_format = params.get("convert_to_compatible_format")
         conv: ConversationAdapter = self.get_default_conv_template(
             model_name, model_path
         )
@@ -277,6 +284,72 @@ class LLMModelAdapter(ABC):
             return None, None, None
 
         conv = conv.copy()
+        if convert_to_compatible_format:
+            # In old version, we will convert the messages to compatible format
+            conv = self._set_conv_converted_messages(conv, messages)
+        else:
+            # In new version, we will use the messages directly
+            conv = self._set_conv_messages(conv, messages)
+
+        # Add a blank message for the assistant.
+        conv.append_message(conv.roles[1], None)
+        new_prompt = conv.get_prompt()
+        return new_prompt, conv.stop_str, conv.stop_token_ids
+
+    def _set_conv_messages(
+        self, conv: ConversationAdapter, messages: List[ModelMessage]
+    ) -> ConversationAdapter:
+        """Set the messages to the conversation template
+
+        Args:
+            conv (ConversationAdapter): The conversation template
+            messages (List[ModelMessage]): The model messages
+
+        Returns:
+            ConversationAdapter: The conversation template with messages
+        """
+        system_messages = []
+        for message in messages:
+            if isinstance(message, ModelMessage):
+                role = message.role
+                content = message.content
+            elif isinstance(message, dict):
+                role = message["role"]
+                content = message["content"]
+            else:
+                raise ValueError(f"Invalid message type: {message}")
+
+            if role == ModelMessageRoleType.SYSTEM:
+                system_messages.append(content)
+            elif role == ModelMessageRoleType.HUMAN:
+                conv.append_message(conv.roles[0], content)
+            elif role == ModelMessageRoleType.AI:
+                conv.append_message(conv.roles[1], content)
+            else:
+                raise ValueError(f"Unknown role: {role}")
+        if len(system_messages) > 1:
+            raise ValueError(
+                f"Your system messages have more than one message: {system_messages}"
+            )
+        if system_messages:
+            conv.set_system_message(system_messages[0])
+        return conv
+
+    def _set_conv_converted_messages(
+        self, conv: ConversationAdapter, messages: List[ModelMessage]
+    ) -> ConversationAdapter:
+        """Set the messages to the conversation template
+
+        In the old version, we will convert the messages to compatible format.
+        This method will be deprecated in the future.
+
+        Args:
+            conv (ConversationAdapter): The conversation template
+            messages (List[ModelMessage]): The model messages
+
+        Returns:
+            ConversationAdapter: The conversation template with messages
+        """
         system_messages = []
         user_messages = []
         ai_messages = []
@@ -295,10 +368,8 @@ class LLMModelAdapter(ABC):
                 # Support for multiple system messages
                 system_messages.append(content)
             elif role == ModelMessageRoleType.HUMAN:
-                # conv.append_message(conv.roles[0], content)
                 user_messages.append(content)
             elif role == ModelMessageRoleType.AI:
-                # conv.append_message(conv.roles[1], content)
                 ai_messages.append(content)
             else:
                 raise ValueError(f"Unknown role: {role}")
@@ -320,10 +391,7 @@ class LLMModelAdapter(ABC):
 
         # TODO join all system messages may not be a good idea
         conv.set_system_message("".join(can_use_systems))
-        # Add a blank message for the assistant.
-        conv.append_message(conv.roles[1], None)
-        new_prompt = conv.get_prompt()
-        return new_prompt, conv.stop_str, conv.stop_token_ids
+        return conv
 
     def model_adaptation(
         self,
@@ -335,6 +403,15 @@ class LLMModelAdapter(ABC):
     ) -> Tuple[Dict, Dict]:
         """Params adaptation"""
         messages = params.get("messages")
+        convert_to_compatible_format = params.get("convert_to_compatible_format")
+        message_version = params.get("version", "v2").lower()
+        logger.info(f"Message version is {message_version}")
+        if convert_to_compatible_format is None:
+            # Support convert messages to compatible format when message version is v1
+            convert_to_compatible_format = message_version == "v1"
+        # Save to params
+        params["convert_to_compatible_format"] = convert_to_compatible_format
+
         # Some model context to dbgpt server
         model_context = {"prompt_echo_len_char": -1, "has_format_prompt": False}
         if messages:
@@ -345,7 +422,9 @@ class LLMModelAdapter(ABC):
             ]
             params["messages"] = messages
 
-        new_prompt = self.get_str_prompt(params, messages, tokenizer, prompt_template)
+        new_prompt = self.get_str_prompt(
+            params, messages, tokenizer, prompt_template, convert_to_compatible_format
+        )
         conv_stop_str, conv_stop_token_ids = None, None
         if not new_prompt:
             (

--- a/dbgpt/model/adapter/hf_adapter.py
+++ b/dbgpt/model/adapter/hf_adapter.py
@@ -87,6 +87,7 @@ class NewHFChatModelAdapter(LLMModelAdapter, ABC):
         messages: List[ModelMessage],
         tokenizer: Any,
         prompt_template: str = None,
+        convert_to_compatible_format: bool = False,
     ) -> Optional[str]:
         from transformers import AutoTokenizer
 
@@ -94,7 +95,7 @@ class NewHFChatModelAdapter(LLMModelAdapter, ABC):
             raise ValueError("tokenizer is is None")
         tokenizer: AutoTokenizer = tokenizer
 
-        messages = self.transform_model_messages(messages)
+        messages = self.transform_model_messages(messages, convert_to_compatible_format)
         logger.debug(f"The messages after transform: \n{messages}")
         str_prompt = tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True

--- a/dbgpt/model/cluster/base.py
+++ b/dbgpt/model/cluster/base.py
@@ -22,6 +22,8 @@ class PromptRequest(BaseModel):
     span_id: str = None
     metrics: bool = False
     """Whether to return metrics of inference"""
+    version: str = "v2"
+    """Message version, default to v2"""
 
 
 class EmbeddingsRequest(BaseModel):

--- a/dbgpt/model/cluster/client.py
+++ b/dbgpt/model/cluster/client.py
@@ -1,20 +1,35 @@
-from typing import AsyncIterator, List
 import asyncio
-from dbgpt.core.interface.llm import LLMClient, ModelRequest, ModelOutput, ModelMetadata
-from dbgpt.model.parameter import WorkerType
+from typing import AsyncIterator, List, Optional
+
+from dbgpt.core.interface.llm import (
+    LLMClient,
+    MessageConverter,
+    ModelMetadata,
+    ModelOutput,
+    ModelRequest,
+)
 from dbgpt.model.cluster.manager_base import WorkerManager
+from dbgpt.model.parameter import WorkerType
 
 
 class DefaultLLMClient(LLMClient):
     def __init__(self, worker_manager: WorkerManager):
         self._worker_manager = worker_manager
 
-    async def generate(self, request: ModelRequest) -> ModelOutput:
+    async def generate(
+        self,
+        request: ModelRequest,
+        message_converter: Optional[MessageConverter] = None,
+    ) -> ModelOutput:
+        request = await self.covert_message(request, message_converter)
         return await self._worker_manager.generate(request.to_dict())
 
     async def generate_stream(
-        self, request: ModelRequest
+        self,
+        request: ModelRequest,
+        message_converter: Optional[MessageConverter] = None,
     ) -> AsyncIterator[ModelOutput]:
+        request = await self.covert_message(request, message_converter)
         async for output in self._worker_manager.generate_stream(request.to_dict()):
             yield output
 

--- a/dbgpt/model/cluster/worker/default_worker.py
+++ b/dbgpt/model/cluster/worker/default_worker.py
@@ -8,7 +8,12 @@ import traceback
 from dbgpt.configs.model_config import get_device
 from dbgpt.model.adapter.base import LLMModelAdapter
 from dbgpt.model.adapter.model_adapter import get_llm_model_adapter
-from dbgpt.core import ModelOutput, ModelInferenceMetrics, ModelMetadata
+from dbgpt.core import (
+    ModelOutput,
+    ModelInferenceMetrics,
+    ModelMetadata,
+    ModelExtraMedata,
+)
 from dbgpt.model.loader import ModelLoader, _get_model_real_path
 from dbgpt.model.parameter import ModelParameters
 from dbgpt.model.cluster.worker_base import ModelWorker
@@ -196,9 +201,13 @@ class DefaultModelWorker(ModelWorker):
         raise NotImplementedError
 
     def get_model_metadata(self, params: Dict) -> ModelMetadata:
+        ext_metadata = ModelExtraMedata(
+            prompt_sep=self.llm_adapter.get_default_message_separator()
+        )
         return ModelMetadata(
             model=self.model_name,
             context_length=self.context_len,
+            ext_metadata=ext_metadata,
         )
 
     async def async_get_model_metadata(self, params: Dict) -> ModelMetadata:

--- a/dbgpt/model/cluster/worker/remote_worker.py
+++ b/dbgpt/model/cluster/worker/remote_worker.py
@@ -122,7 +122,7 @@ class RemoteModelWorker(ModelWorker):
                 json=params,
                 timeout=self.timeout,
             )
-            return ModelMetadata(**response.json())
+            return ModelMetadata.from_dict(response.json())
 
     def get_model_metadata(self, params: Dict) -> ModelMetadata:
         """Get model metadata"""

--- a/dbgpt/model/operator/__init__.py
+++ b/dbgpt/model/operator/__init__.py
@@ -1,0 +1,13 @@
+from dbgpt.model.operator.llm_operator import (
+    LLMOperator,
+    MixinLLMOperator,
+    StreamingLLMOperator,
+)
+from dbgpt.model.utils.chatgpt_utils import OpenAIStreamingOutputOperator
+
+__ALL__ = [
+    "MixinLLMOperator",
+    "LLMOperator",
+    "StreamingLLMOperator",
+    "OpenAIStreamingOutputOperator",
+]

--- a/dbgpt/model/operator/llm_operator.py
+++ b/dbgpt/model/operator/llm_operator.py
@@ -1,0 +1,75 @@
+import logging
+from abc import ABC
+from typing import Optional
+
+from dbgpt.component import ComponentType
+from dbgpt.core import LLMClient
+from dbgpt.core.awel import BaseOperator
+from dbgpt.core.operator import BaseLLM, BaseLLMOperator, BaseStreamingLLMOperator
+from dbgpt.model.cluster import WorkerManagerFactory
+
+logger = logging.getLogger(__name__)
+
+
+class MixinLLMOperator(BaseLLM, BaseOperator, ABC):
+    """Mixin class for LLM operator.
+
+    This class extends BaseOperator by adding LLM capabilities.
+    """
+
+    def __init__(self, default_client: Optional[LLMClient] = None, **kwargs):
+        super().__init__(default_client)
+        self._default_llm_client = default_client
+
+    @property
+    def llm_client(self) -> LLMClient:
+        if not self._llm_client:
+            worker_manager_factory: WorkerManagerFactory = (
+                self.system_app.get_component(
+                    ComponentType.WORKER_MANAGER_FACTORY,
+                    WorkerManagerFactory,
+                    default_component=None,
+                )
+            )
+            if worker_manager_factory:
+                from dbgpt.model.cluster.client import DefaultLLMClient
+
+                self._llm_client = DefaultLLMClient(worker_manager_factory.create())
+            else:
+                if self._default_llm_client is None:
+                    from dbgpt.model.utils.chatgpt_utils import OpenAILLMClient
+
+                    self._default_llm_client = OpenAILLMClient()
+                logger.info(
+                    f"Can't find worker manager factory, use default llm client {self._default_llm_client}."
+                )
+                self._llm_client = self._default_llm_client
+        return self._llm_client
+
+
+class LLMOperator(MixinLLMOperator, BaseLLMOperator):
+    """Default LLM operator.
+
+    Args:
+        llm_client (Optional[LLMClient], optional): The LLM client. Defaults to None.
+            If llm_client is None, we will try to connect to the model serving cluster deploy by DB-GPT,
+            and if we can't connect to the model serving cluster, we will use the :class:`OpenAILLMClient` as the llm_client.
+    """
+
+    def __init__(self, llm_client: Optional[LLMClient] = None, **kwargs):
+        super().__init__(llm_client)
+        BaseLLMOperator.__init__(self, llm_client, **kwargs)
+
+
+class StreamingLLMOperator(MixinLLMOperator, BaseStreamingLLMOperator):
+    """Default streaming LLM operator.
+
+    Args:
+        llm_client (Optional[LLMClient], optional): The LLM client. Defaults to None.
+            If llm_client is None, we will try to connect to the model serving cluster deploy by DB-GPT,
+            and if we can't connect to the model serving cluster, we will use the :class:`OpenAILLMClient` as the llm_client.
+    """
+
+    def __init__(self, llm_client: Optional[LLMClient] = None, **kwargs):
+        super().__init__(llm_client)
+        BaseStreamingLLMOperator.__init__(self, llm_client, **kwargs)

--- a/dbgpt/model/operator/model_operator.py
+++ b/dbgpt/model/operator/model_operator.py
@@ -1,17 +1,18 @@
-from typing import AsyncIterator, Dict, List, Union
 import logging
+from typing import AsyncIterator, Dict, List, Union
+
+from dbgpt.component import ComponentType
+from dbgpt.core import ModelOutput
 from dbgpt.core.awel import (
     BranchFunc,
-    StreamifyAbsOperator,
     BranchOperator,
     MapOperator,
+    StreamifyAbsOperator,
     TransformStreamAbsOperator,
 )
-from dbgpt.component import ComponentType
 from dbgpt.core.awel.operator.base import BaseOperator
-from dbgpt.core import ModelOutput
 from dbgpt.model.cluster import WorkerManager, WorkerManagerFactory
-from dbgpt.storage.cache import LLMCacheClient, CacheManager, LLMCacheKey, LLMCacheValue
+from dbgpt.storage.cache import CacheManager, LLMCacheClient, LLMCacheKey, LLMCacheValue
 
 logger = logging.getLogger(__name__)
 

--- a/dbgpt/model/proxy/llms/bard.py
+++ b/dbgpt/model/proxy/llms/bard.py
@@ -13,6 +13,8 @@ def bard_generate_stream(
     proxy_api_key = model_params.proxy_api_key
     proxy_server_url = model_params.proxy_server_url
 
+    convert_to_compatible_format = params.get("convert_to_compatible_format", False)
+
     history = []
     messages: List[ModelMessage] = params["messages"]
     for message in messages:
@@ -25,14 +27,15 @@ def bard_generate_stream(
         else:
             pass
 
-    last_user_input_index = None
-    for i in range(len(history) - 1, -1, -1):
-        if history[i]["role"] == "user":
-            last_user_input_index = i
-            break
-    if last_user_input_index:
-        last_user_input = history.pop(last_user_input_index)
-        history.append(last_user_input)
+    if convert_to_compatible_format:
+        last_user_input_index = None
+        for i in range(len(history) - 1, -1, -1):
+            if history[i]["role"] == "user":
+                last_user_input_index = i
+                break
+        if last_user_input_index:
+            last_user_input = history.pop(last_user_input_index)
+            history.append(last_user_input)
 
     msgs = []
     for msg in history:

--- a/dbgpt/model/proxy/llms/chatgpt.py
+++ b/dbgpt/model/proxy/llms/chatgpt.py
@@ -128,7 +128,10 @@ def _build_request(model: ProxyModel, params):
     messages: List[ModelMessage] = params["messages"]
 
     # history = __convert_2_gpt_messages(messages)
-    history = ModelMessage.to_openai_messages(messages)
+    convert_to_compatible_format = params.get("convert_to_compatible_format", False)
+    history = ModelMessage.to_openai_messages(
+        messages, convert_to_compatible_format=convert_to_compatible_format
+    )
     payloads = {
         "temperature": params.get("temperature"),
         "max_tokens": params.get("max_new_tokens"),

--- a/dbgpt/model/proxy/llms/gemini.py
+++ b/dbgpt/model/proxy/llms/gemini.py
@@ -12,7 +12,6 @@ def gemini_generate_stream(
     """Zhipu ai, see: https://open.bigmodel.cn/dev/api#overview"""
     model_params = model.get_params()
     print(f"Model: {model}, model_params: {model_params}")
-    global history
 
     # TODO proxy model use unified config?
     proxy_api_key = model_params.proxy_api_key

--- a/dbgpt/model/proxy/llms/spark.py
+++ b/dbgpt/model/proxy/llms/spark.py
@@ -56,6 +56,9 @@ def spark_generate_stream(
             del messages[index]
             break
 
+    # TODO: Support convert_to_compatible_format config
+    convert_to_compatible_format = params.get("convert_to_compatible_format", False)
+
     history = []
     # Add history conversation
     for message in messages:

--- a/dbgpt/model/proxy/llms/tongyi.py
+++ b/dbgpt/model/proxy/llms/tongyi.py
@@ -53,8 +53,12 @@ def tongyi_generate_stream(
         proxyllm_backend = Generation.Models.qwen_turbo  # By Default qwen_turbo
 
     messages: List[ModelMessage] = params["messages"]
+    convert_to_compatible_format = params.get("convert_to_compatible_format", False)
 
-    history = __convert_2_tongyi_messages(messages)
+    if convert_to_compatible_format:
+        history = __convert_2_tongyi_messages(messages)
+    else:
+        history = ModelMessage.to_openai_messages(messages)
     gen = Generation()
     res = gen.call(
         proxyllm_backend,

--- a/dbgpt/model/proxy/llms/zhipu.py
+++ b/dbgpt/model/proxy/llms/zhipu.py
@@ -57,6 +57,10 @@ def zhipu_generate_stream(
     zhipuai.api_key = proxy_api_key
 
     messages: List[ModelMessage] = params["messages"]
+
+    # TODO: Support convert_to_compatible_format config, zhipu not support system message
+    convert_to_compatible_format = params.get("convert_to_compatible_format", False)
+
     history, systems = __convert_2_zhipu_messages(messages)
     res = zhipuai.model_api.sse_invoke(
         model=proxyllm_backend,

--- a/dbgpt/serve/conversation/operator.py
+++ b/dbgpt/serve/conversation/operator.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Any, Optional
+
+from dbgpt.core import (
+    InMemoryStorage,
+    MessageStorageItem,
+    StorageConversation,
+    StorageInterface,
+)
+from dbgpt.core.operator import PreChatHistoryLoadOperator
+
+from .serve import Serve
+
+logger = logging.getLogger(__name__)
+
+
+class ServePreChatHistoryLoadOperator(PreChatHistoryLoadOperator):
+    """Pre-chat history load operator for DB-GPT serve component
+
+    Args:
+        storage (Optional[StorageInterface[StorageConversation, Any]], optional):
+            The conversation storage, store the conversation items. Defaults to None.
+        message_storage (Optional[StorageInterface[MessageStorageItem, Any]], optional):
+            The message storage, store the messages of one conversation. Defaults to None.
+
+    If the storage or message_storage is not None, the storage or message_storage will be used first.
+    Otherwise, we will try get current serve component from system app,
+    and use the storage or message_storage of the serve component.
+    If we can't get the storage, we will use the InMemoryStorage as the storage or message_storage.
+    """
+
+    def __init__(
+        self,
+        storage: Optional[StorageInterface[StorageConversation, Any]] = None,
+        message_storage: Optional[StorageInterface[MessageStorageItem, Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(storage, message_storage, **kwargs)
+
+    @property
+    def storage(self):
+        if self._storage:
+            return self._storage
+        storage = Serve.call_on_current_serve(
+            self.system_app, lambda serve: serve.conv_storage
+        )
+        if not storage:
+            logger.warning(
+                "Can't get the conversation storage from current serve component, "
+                "use the InMemoryStorage as the conversation storage."
+            )
+            self._storage = InMemoryStorage()
+            return self._storage
+        return storage
+
+    @property
+    def message_storage(self):
+        if self._message_storage:
+            return self._message_storage
+        storage = Serve.call_on_current_serve(
+            self.system_app,
+            lambda serve: serve.message_storage,
+        )
+        if not storage:
+            logger.warning(
+                "Can't get the message storage from current serve component, "
+                "use the InMemoryStorage as the message storage."
+            )
+            self._message_storage = InMemoryStorage()
+            return self._message_storage
+        return storage

--- a/dbgpt/serve/core/serve.py
+++ b/dbgpt/serve/core/serve.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC
-from typing import List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 from sqlalchemy import URL
 
@@ -60,3 +60,44 @@ class BaseServe(BaseComponent, ABC):
             finally:
                 self._not_create_table = False
         return init_db
+
+    @classmethod
+    def get_current_serve(cls, system_app: SystemApp) -> Optional["BaseServe"]:
+        """Get the current serve component.
+
+        None if the serve component is not exist.
+
+        Args:
+            system_app (SystemApp): The system app
+
+        Returns:
+            Optional[BaseServe]: The current serve component.
+        """
+        return system_app.get_component(cls.name, cls, default_component=None)
+
+    @classmethod
+    def call_on_current_serve(
+        cls,
+        system_app: SystemApp,
+        func: Callable[["BaseServe"], Optional[Any]],
+        default_value: Optional[Any] = None,
+    ) -> Optional[Any]:
+        """Call the function on the current serve component.
+
+        Return default_value if the serve component is not exist or the function return None.
+
+        Args:
+            system_app (SystemApp): The system app
+            func (Callable[[BaseServe], Any]): The function to call
+            default_value (Optional[Any], optional): The default value. Defaults to None.
+
+        Returns:
+            Optional[Any]: The result of the function
+        """
+        serve = cls.get_current_serve(system_app)
+        if not serve:
+            return default_value
+        result = func(serve)
+        if not result:
+            result = default_value
+        return result

--- a/dbgpt/util/function_utils.py
+++ b/dbgpt/util/function_utils.py
@@ -1,0 +1,87 @@
+from typing import Any, get_type_hints, get_origin, get_args
+from functools import wraps
+import inspect
+import asyncio
+
+
+def _is_instance_of_generic_type(obj, generic_type):
+    """Check if an object is an instance of a generic type."""
+    if generic_type is Any:
+        return True  # Any type is compatible with any object
+
+    origin = get_origin(generic_type)
+    if origin is None:
+        return isinstance(obj, generic_type)  # Handle non-generic types
+
+    args = get_args(generic_type)
+    if not args:
+        return isinstance(obj, origin)
+
+    # Check if object matches the generic origin (like list, dict)
+    if not isinstance(obj, origin):
+        return False
+
+    # For each item in the object, check if it matches the corresponding type argument
+    for sub_obj, arg in zip(obj, args):
+        # Skip check if the type argument is Any
+        if arg is not Any and not isinstance(sub_obj, arg):
+            return False
+
+    return True
+
+
+def _sort_args(func, args, kwargs):
+    sig = inspect.signature(func)
+    type_hints = get_type_hints(func)
+
+    arg_types = [
+        type_hints[param_name]
+        for param_name in sig.parameters
+        if param_name != "return" and param_name != "self"
+    ]
+
+    if "self" in sig.parameters:
+        self_arg = [args[0]]
+        other_args = args[1:]
+    else:
+        self_arg = []
+        other_args = args
+
+    sorted_args = sorted(
+        other_args,
+        key=lambda x: next(
+            i for i, t in enumerate(arg_types) if _is_instance_of_generic_type(x, t)
+        ),
+    )
+    return (*self_arg, *sorted_args), kwargs
+
+
+def rearrange_args_by_type(func):
+    """Decorator to rearrange the arguments of a function by type.
+
+    Examples:
+
+        .. code-block:: python
+
+            from dbgpt.util.function_utils import rearrange_args_by_type
+
+            @rearrange_args_by_type
+            def sync_regular_function(a: int, b: str, c: float):
+                return a, b, c
+
+            assert instance.sync_class_method(1, "b", 3.0) == (1, "b", 3.0)
+            assert instance.sync_class_method("b", 3.0, 1) == (1, "b", 3.0)
+
+    """
+
+    @wraps(func)
+    def sync_wrapper(*args, **kwargs):
+        sorted_args, sorted_kwargs = _sort_args(func, args, kwargs)
+        return func(*sorted_args, **sorted_kwargs)
+
+    @wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        sorted_args, sorted_kwargs = _sort_args(func, args, kwargs)
+        return await func(*sorted_args, **sorted_kwargs)
+
+    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper

--- a/dbgpt/util/prompt_util.py
+++ b/dbgpt/util/prompt_util.py
@@ -10,11 +10,12 @@ needed), or truncating them so that they fit in a single LLM call.
 
 import logging
 from string import Formatter
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, List, Optional, Sequence, Set
 
 from dbgpt._private.pydantic import Field, PrivateAttr, BaseModel
 
 from dbgpt.util.global_helper import globals_helper
+from dbgpt.core.interface.prompt import get_template_vars
 from dbgpt._private.llm_metadata import LLMMetadata
 from dbgpt.rag.text_splitter.token_splitter import TokenTextSplitter
 
@@ -230,15 +231,3 @@ def get_empty_prompt_txt(template: str) -> str:
     all_kwargs = {**partial_kargs, **empty_kwargs}
     prompt = template.format(**all_kwargs)
     return prompt
-
-
-def get_template_vars(template_str: str) -> List[str]:
-    """Get template variables from a template string."""
-    variables = []
-    formatter = Formatter()
-
-    for _, variable_name, _, _ in formatter.parse(template_str):
-        if variable_name:
-            variables.append(variable_name)
-
-    return variables

--- a/dbgpt/util/tests/test_function_utils.py
+++ b/dbgpt/util/tests/test_function_utils.py
@@ -1,0 +1,120 @@
+from typing import List, Dict, Any
+
+import pytest
+from dbgpt.util.function_utils import rearrange_args_by_type
+
+
+class ChatPromptTemplate:
+    pass
+
+
+class BaseMessage:
+    pass
+
+
+class ModelMessage:
+    pass
+
+
+class DummyClass:
+    @rearrange_args_by_type
+    async def class_method(self, a: int, b: str, c: float):
+        return a, b, c
+
+    @rearrange_args_by_type
+    async def merge_history(
+        self,
+        prompt: ChatPromptTemplate,
+        history: List[BaseMessage],
+        prompt_dict: Dict[str, Any],
+    ) -> List[ModelMessage]:
+        return [type(prompt), type(history), type(prompt_dict)]
+
+    @rearrange_args_by_type
+    def sync_class_method(self, a: int, b: str, c: float):
+        return a, b, c
+
+
+@rearrange_args_by_type
+def sync_regular_function(a: int, b: str, c: float):
+    return a, b, c
+
+
+@rearrange_args_by_type
+async def regular_function(a: int, b: str, c: float):
+    return a, b, c
+
+
+@pytest.mark.asyncio
+async def test_class_method_correct_order():
+    instance = DummyClass()
+    result = await instance.class_method(1, "b", 3.0)
+    assert result == (1, "b", 3.0), "Class method failed with correct order"
+
+
+@pytest.mark.asyncio
+async def test_class_method_incorrect_order():
+    instance = DummyClass()
+    result = await instance.class_method("b", 3.0, 1)
+    assert result == (1, "b", 3.0), "Class method failed with incorrect order"
+
+
+@pytest.mark.asyncio
+async def test_regular_function_correct_order():
+    result = await regular_function(1, "b", 3.0)
+    assert result == (1, "b", 3.0), "Regular function failed with correct order"
+
+
+@pytest.mark.asyncio
+async def test_regular_function_incorrect_order():
+    result = await regular_function("b", 3.0, 1)
+    assert result == (1, "b", 3.0), "Regular function failed with incorrect order"
+
+
+@pytest.mark.asyncio
+async def test_merge_history_correct_order():
+    instance = DummyClass()
+    result = await instance.merge_history(
+        ChatPromptTemplate(), [BaseMessage()], {"key": "value"}
+    )
+    assert result == [ChatPromptTemplate, list, dict], "Failed with correct order"
+
+
+@pytest.mark.asyncio
+async def test_merge_history_incorrect_order_1():
+    instance = DummyClass()
+    result = await instance.merge_history(
+        [BaseMessage()], ChatPromptTemplate(), {"key": "value"}
+    )
+    assert result == [ChatPromptTemplate, list, dict], "Failed with incorrect order 1"
+
+
+@pytest.mark.asyncio
+async def test_merge_history_incorrect_order_2():
+    instance = DummyClass()
+    result = await instance.merge_history(
+        {"key": "value"}, [BaseMessage()], ChatPromptTemplate()
+    )
+    assert result == [ChatPromptTemplate, list, dict], "Failed with incorrect order 2"
+
+
+def test_sync_class_method_correct_order():
+    instance = DummyClass()
+    result = instance.sync_class_method(1, "b", 3.0)
+    assert result == (1, "b", 3.0), "Sync class method failed with correct order"
+
+
+def test_sync_class_method_incorrect_order():
+    instance = DummyClass()
+    result = instance.sync_class_method("b", 3.0, 1)
+    assert result == (1, "b", 3.0), "Sync class method failed with incorrect order"
+
+
+def test_sync_regular_function_correct_order():
+    result = sync_regular_function(1, "b", 3.0)
+    assert result == (1, "b", 3.0), "Sync regular function failed with correct order"
+
+
+def test_sync_regular_function_incorrect_order():
+    result = sync_regular_function("b", 3.0, 1)
+    assert result == (1, "b", 3.0), "Sync regular function failed with incorrect order"

--- a/examples/awel/simple_dag_example.py
+++ b/examples/awel/simple_dag_example.py
@@ -31,3 +31,11 @@ with DAG("simple_dag_example") as dag:
     trigger = HttpTrigger("/examples/hello", request_body=TriggerReqBody)
     map_node = RequestHandleOperator()
     trigger >> map_node
+
+if __name__ == "__main__":
+    if dag.leaf_nodes[0].dev_mode:
+        from dbgpt.core.awel import setup_dev_environment
+
+        setup_dev_environment([dag])
+    else:
+        pass

--- a/examples/sdk/simple_sdk_llm_example.py
+++ b/examples/sdk/simple_sdk_llm_example.py
@@ -1,16 +1,20 @@
 import asyncio
 
-from dbgpt.core import BaseOutputParser, PromptTemplate
+from dbgpt.core import BaseOutputParser
 from dbgpt.core.awel import DAG
-from dbgpt.core.operator import LLMOperator, RequestBuildOperator
+from dbgpt.core.operator import (
+    BaseLLMOperator,
+    PromptBuilderOperator,
+    RequestBuilderOperator,
+)
 from dbgpt.model import OpenAILLMClient
 
 with DAG("simple_sdk_llm_example_dag") as dag:
-    prompt_task = PromptTemplate.from_template(
+    prompt_task = PromptBuilderOperator(
         "Write a SQL of {dialect} to query all data of {table_name}."
     )
-    model_pre_handle_task = RequestBuildOperator(model="gpt-3.5-turbo")
-    llm_task = LLMOperator(OpenAILLMClient())
+    model_pre_handle_task = RequestBuilderOperator(model="gpt-3.5-turbo")
+    llm_task = BaseLLMOperator(OpenAILLMClient())
     out_parse_task = BaseOutputParser()
     prompt_task >> model_pre_handle_task >> llm_task >> out_parse_task
 

--- a/examples/sdk/simple_sdk_llm_sql_example.py
+++ b/examples/sdk/simple_sdk_llm_sql_example.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from typing import Dict, List
 
-from dbgpt.core import PromptTemplate, SQLOutputParser
+from dbgpt.core import SQLOutputParser
 from dbgpt.core.awel import (
     DAG,
     InputOperator,
@@ -10,7 +10,11 @@ from dbgpt.core.awel import (
     MapOperator,
     SimpleCallDataInputSource,
 )
-from dbgpt.core.operator import LLMOperator, RequestBuildOperator
+from dbgpt.core.operator import (
+    BaseLLMOperator,
+    PromptBuilderOperator,
+    RequestBuilderOperator,
+)
 from dbgpt.datasource.operator.datasource_operator import DatasourceOperator
 from dbgpt.datasource.rdbms.conn_sqlite import SQLiteTempConnect
 from dbgpt.model import OpenAILLMClient
@@ -116,9 +120,9 @@ with DAG("simple_sdk_llm_sql_example") as dag:
     retriever_task = DatasourceRetrieverOperator(connection=db_connection)
     # Merge the input data and the table structure information.
     prompt_input_task = JoinOperator(combine_function=_join_func)
-    prompt_task = PromptTemplate.from_template(_sql_prompt())
-    model_pre_handle_task = RequestBuildOperator(model="gpt-3.5-turbo")
-    llm_task = LLMOperator(OpenAILLMClient())
+    prompt_task = PromptBuilderOperator(_sql_prompt())
+    model_pre_handle_task = RequestBuilderOperator(model="gpt-3.5-turbo")
+    llm_task = BaseLLMOperator(OpenAILLMClient())
     out_parse_task = SQLOutputParser()
     sql_parse_task = MapOperator(map_function=lambda x: x["sql"])
     db_query_task = DatasourceOperator(connection=db_connection)

--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,8 @@ def core_requires():
         "aiofiles",
         # for agent
         "GitPython",
+        # For AWEL dag visualization, graphviz is a small package, also we can move it to default.
+        "graphviz",
     ]
 
 


### PR DESCRIPTION
# Description

1.  New `MessageConverter` to support unified model message adaptation.
2. Model layer multi-version message, the previous one was `v1`, the new version in the sdk defaults to `v2`
    - `v1` is previous usage. 
    - `v2` does not automatically convert messages, you need to use `MessageConverter`
3.  New `ChatPromptTemplate`
4. More built-in AWEL operators.

# How Has This Been Tested?

1. `make test`
2. Run examples in `examples/sdk` and `examples/awel`

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
