### PR TITLE
[hotfix] Fix examples/awel default loading model text2vec-large-chinese issue

### DIFF
--- a/examples/awel/simple_dbschema_retriever_example.py
+++ b/examples/awel/simple_dbschema_retriever_example.py
@@ -40,6 +40,7 @@ from dbgpt.storage.vector_store.connector import VectorStoreConnector
 
 def _create_vector_connector():
     """Create vector connector."""
+    model_name = os.getenv("EMBEDDING_MODEL", "text2vec")
     return VectorStoreConnector.from_default(
         "Chroma",
         vector_store_config=ChromaVectorConfig(
@@ -47,7 +48,7 @@ def _create_vector_connector():
             persist_path=os.path.join(PILOT_PATH, "data"),
         ),
         embedding_fn=DefaultEmbeddingFactory(
-            default_model_name=os.path.join(MODEL_PATH, "text2vec-large-chinese"),
+            default_model_name=os.path.join(MODEL_PATH, model_name),
         ).create(),
     )
 

--- a/examples/awel/simple_rag_embedding_example.py
+++ b/examples/awel/simple_rag_embedding_example.py
@@ -28,6 +28,7 @@ from dbgpt.storage.vector_store.connector import VectorStoreConnector
 
 def _create_vector_connector() -> VectorStoreConnector:
     """Create vector connector."""
+    model_name = os.getenv("EMBEDDING_MODEL", "text2vec")
     return VectorStoreConnector.from_default(
         "Chroma",
         vector_store_config=ChromaVectorConfig(
@@ -35,7 +36,7 @@ def _create_vector_connector() -> VectorStoreConnector:
             persist_path=os.path.join(PILOT_PATH, "data"),
         ),
         embedding_fn=DefaultEmbeddingFactory(
-            default_model_name=os.path.join(MODEL_PATH, "text2vec-large-chinese"),
+            default_model_name=os.path.join(MODEL_PATH, model_name),
         ).create(),
     )
 

--- a/examples/awel/simple_rag_retriever_example.py
+++ b/examples/awel/simple_rag_retriever_example.py
@@ -75,6 +75,7 @@ def _context_join_fn(context_dict: Dict, chunks: List[Chunk]) -> Dict:
 
 def _create_vector_connector():
     """Create vector connector."""
+    model_name = os.getenv("EMBEDDING_MODEL", "text2vec")
     return VectorStoreConnector.from_default(
         "Chroma",
         vector_store_config=ChromaVectorConfig(
@@ -82,7 +83,7 @@ def _create_vector_connector():
             persist_path=os.path.join(PILOT_PATH, "data"),
         ),
         embedding_fn=DefaultEmbeddingFactory(
-            default_model_name=os.path.join(MODEL_PATH, "text2vec-large-chinese"),
+            default_model_name=os.path.join(MODEL_PATH, model_name),
         ).create(),
     )
 


### PR DESCRIPTION

# Description

When I set the parameter EMBEDDING_MODEL=bge-large-zh, an error occurs when starting the service
2024-01-19 17:51:55 172-16-10-163 dbgpt.core.awel.dag.loader[5422] ERROR Failed to import: /mnt/data/xiuzhu/DB-GPT/examples/awel/simple_rag_retriever_example.py, error message: Traceback (most recent call last):
File "/mnt/data/xiuzhu/DB-GPT/dbgpt/core/awel/dag/loader.py", line 86, in parse
loader.exec_module(new_module)
File "", line 883, in exec_module
File "", line 241, in _call_with_frames_removed
File "/mnt/data/xiuzhu/DB-GPT/examples/awel/simple_rag_retriever_example.py", line 91, in
vector_connector = _create_vector_connector()
File "/mnt/data/xiuzhu/DB-GPT/examples/awel/simple_rag_retriever_example.py", line 86, in _create_vector_connector
).create(),
File "/mnt/data/xiuzhu/DB-GPT/dbgpt/rag/embedding/embedding_factory.py", line 48, in create
return HuggingFaceEmbeddings(**new_kwargs)
File "/mnt/data/xiuzhu/DB-GPT/dbgpt/rag/embedding/embeddings.py", line 91, in init
self.client = sentence_transformers.SentenceTransformer(
File "/home/dtstack/miniconda3/envs/dbgpt_0.4.6/lib/python3.10/site-packages/sentence_transformers/SentenceTransformer.py", line 77, in init
raise ValueError("Path {} not found".format(model_name_or_path))
ValueError: Path /mnt/data/xiuzhu/models/text2vec-large-chinese not found

Close #1094

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
