### PR TITLE
fix:default setting prompt with history messages

### DIFF
--- a/dbgpt/core/interface/operators/message_operator.py
+++ b/dbgpt/core/interface/operators/message_operator.py
@@ -416,6 +416,18 @@ class BufferedConversationMapperOperator(ConversationMapperOperator):
             ...     ],
             ... ]
 
+            # Test end rounds is zero
+            >>> operator = BufferedConversationMapperOperator(
+            ...     keep_start_rounds=1, keep_end_rounds=0
+            ... )
+            >>> assert operator._filter_round_messages(messages) == [
+            ...     [
+            ...         HumanMessage(content="Hi", round_index=1),
+            ...         AIMessage(content="Hello!", round_index=1),
+            ...     ]
+            ... ]
+
+
         Args:
             messages_by_round (List[List[BaseMessage]]):
                 The messages grouped by round.

--- a/dbgpt/core/interface/operators/message_operator.py
+++ b/dbgpt/core/interface/operators/message_operator.py
@@ -425,7 +425,12 @@ class BufferedConversationMapperOperator(ConversationMapperOperator):
 
         """
         total_rounds = len(messages_by_round)
-        if self._keep_start_rounds is not None and self._keep_end_rounds is not None:
+        if (
+            self._keep_start_rounds is not None
+            and self._keep_end_rounds is not None
+            and self._keep_start_rounds > 0
+            and self._keep_end_rounds > 0
+        ):
             if self._keep_start_rounds + self._keep_end_rounds > total_rounds:
                 # Avoid overlapping when the sum of start and end rounds exceeds total
                 # rounds

--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -133,8 +133,9 @@ class MilvusStore(VectorStoreBase):
         connections.connect(
             host=self.uri or "127.0.0.1",
             port=self.port or "19530",
-            alias="default"
-            # secure=self.secure,
+            username=self.username,
+            password=self.password,
+            alias="default",
         )
 
     def init_schema_and_load(self, vector_name, documents) -> List[str]:


### PR DESCRIPTION
Close #1116

# Description

- BufferedConversationMapperOperator
![image](https://github.com/eosphoros-ai/DB-GPT/assets/13723926/ff2f31c4-997b-4caf-a169-e8fc16257772)
- Milvus add username and password


# How Has This Been Tested?
when chat knowledge,
default setting prompt should with no history messages

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
