### PR TITLE
feat(core): Dynamically loading dbgpts

### DIFF
--- a/dbgpt/app/component_configs.py
+++ b/dbgpt/app/component_configs.py
@@ -21,6 +21,7 @@ def initialize_components(
 ):
     # Lazy import to avoid high time cost
     from dbgpt.app.initialization.embedding_component import _initialize_embedding_model
+    from dbgpt.app.initialization.scheduler import DefaultScheduler
     from dbgpt.app.initialization.serve_initialization import register_serve_apps
     from dbgpt.model.cluster.controller.controller import controller
 
@@ -28,6 +29,7 @@ def initialize_components(
     system_app.register(
         DefaultExecutorFactory, max_workers=param.default_thread_pool_size
     )
+    system_app.register(DefaultScheduler)
     system_app.register_instance(controller)
 
     from dbgpt.serve.agent.hub.controller import module_plugin

--- a/dbgpt/app/initialization/scheduler.py
+++ b/dbgpt/app/initialization/scheduler.py
@@ -1,0 +1,43 @@
+import logging
+import threading
+import time
+
+import schedule
+
+from dbgpt.component import BaseComponent, SystemApp
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultScheduler(BaseComponent):
+    """The default scheduler"""
+
+    name = "dbgpt_default_scheduler"
+
+    def __init__(
+        self,
+        system_app: SystemApp,
+        scheduler_delay_ms: int = 5000,
+        scheduler_interval_ms: int = 1000,
+    ):
+        super().__init__(system_app)
+        self.system_app = system_app
+        self._scheduler_interval_ms = scheduler_interval_ms
+        self._scheduler_delay_ms = scheduler_delay_ms
+
+    def init_app(self, system_app: SystemApp):
+        self.system_app = system_app
+
+    def after_start(self):
+        thread = threading.Thread(target=self._scheduler)
+        thread.start()
+
+    def _scheduler(self):
+        time.sleep(self._scheduler_delay_ms / 1000)
+        while True:
+            try:
+                schedule.run_pending()
+            except Exception as e:
+                logger.debug(f"Scheduler error: {e}")
+            finally:
+                time.sleep(self._scheduler_interval_ms / 1000)

--- a/dbgpt/cli/cli_scripts.py
+++ b/dbgpt/cli/cli_scripts.py
@@ -163,7 +163,7 @@ try:
     from dbgpt.util.dbgpts.cli import add_repo
     from dbgpt.util.dbgpts.cli import install as app_install
     from dbgpt.util.dbgpts.cli import list_all_apps as app_list
-    from dbgpt.util.dbgpts.cli import list_repos, remove_repo
+    from dbgpt.util.dbgpts.cli import list_repos, new_dbgpts, remove_repo
     from dbgpt.util.dbgpts.cli import uninstall as app_uninstall
     from dbgpt.util.dbgpts.cli import update_repo
 
@@ -174,6 +174,7 @@ try:
     add_command_alias(app_install, name="install", parent_group=app)
     add_command_alias(app_uninstall, name="uninstall", parent_group=app)
     add_command_alias(app_list, name="list-remote", parent_group=app)
+    add_command_alias(new_dbgpts, name="app", parent_group=new)
 
 except ImportError as e:
     logging.warning(f"Integrating dbgpt dbgpts command line tool failed: {e}")

--- a/dbgpt/core/awel/dag/loader.py
+++ b/dbgpt/core/awel/dag/loader.py
@@ -63,19 +63,23 @@ def _process_file(filepath) -> List[DAG]:
     return results
 
 
-def _load_modules_from_file(filepath: str):
+def _load_modules_from_file(
+    filepath: str, mod_name: str | None = None, show_log: bool = True
+):
     import importlib
     import importlib.machinery
     import importlib.util
 
-    logger.info(f"Importing {filepath}")
+    if show_log:
+        logger.info(f"Importing {filepath}")
 
     org_mod_name, _ = os.path.splitext(os.path.split(filepath)[-1])
     path_hash = hashlib.sha1(filepath.encode("utf-8")).hexdigest()
-    mod_name = f"unusual_prefix_{path_hash}_{org_mod_name}"
+    if mod_name is None:
+        mod_name = f"unusual_prefix_{path_hash}_{org_mod_name}"
 
-    if mod_name in sys.modules:
-        del sys.modules[mod_name]
+        if mod_name in sys.modules:
+            del sys.modules[mod_name]
 
     def parse(mod_name, filepath):
         try:

--- a/dbgpt/core/awel/trigger/http_trigger.py
+++ b/dbgpt/core/awel/trigger/http_trigger.py
@@ -1046,7 +1046,7 @@ class RequestedParsedOperator(MapOperator[CommonLLMHttpRequestBody, str]):
                 "key",
                 str,
                 optional=True,
-                default="",
+                default="messages",
                 description="The key of the dict, link 'user_input'",
             )
         ],

--- a/dbgpt/model/base.py
+++ b/dbgpt/model/base.py
@@ -59,7 +59,7 @@ class WorkerApplyOutput:
             return WorkerApplyOutput("Not outputs")
         combined_success = all(out.success for out in outs)
         max_timecost = max(out.timecost for out in outs)
-        combined_message = ", ".join(out.message for out in outs)
+        combined_message = "\n;".join(out.message for out in outs)
         return WorkerApplyOutput(combined_message, combined_success, max_timecost)
 
 

--- a/dbgpt/serve/flow/config.py
+++ b/dbgpt/serve/flow/config.py
@@ -20,3 +20,6 @@ class ServeConfig(BaseServeConfig):
     api_keys: Optional[str] = field(
         default=None, metadata={"help": "API keys for the endpoint, if None, allow all"}
     )
+    load_dbgpts_interval: int = field(
+        default=5, metadata={"help": "Interval to load dbgpts from installed packages"}
+    )

--- a/dbgpt/util/dbgpts/base.py
+++ b/dbgpt/util/dbgpts/base.py
@@ -23,6 +23,13 @@ DEFAULT_PACKAGE_TYPES = ["agent", "app", "operator", "flow"]
 INSTALL_METADATA_FILE = "install_metadata.toml"
 DBGPTS_METADATA_FILE = "dbgpts.toml"
 
+TYPE_TO_PACKAGE = {
+    "agent": "agents",
+    "app": "apps",
+    "operator": "operators",
+    "flow": "workflow",
+}
+
 
 def _get_env_sig() -> str:
     """Get a unique signature for the current Python environment."""

--- a/dbgpt/util/dbgpts/cli.py
+++ b/dbgpt/util/dbgpts/cli.py
@@ -1,6 +1,30 @@
 import functools
+import subprocess
+import sys
+from pathlib import Path
 
 import click
+
+from .base import DEFAULT_PACKAGE_TYPES
+
+
+def check_poetry_installed():
+    try:
+        # Check if poetry is installed
+        subprocess.run(
+            ["poetry", "--version"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Poetry is not installed. Please install Poetry to proceed.")
+        print(
+            "Visit https://python-poetry.org/docs/#installation for installation "
+            "instructions."
+        )
+        # Exit with error
+        sys.exit(1)
 
 
 def add_tap_options(func):
@@ -26,6 +50,7 @@ def install(repo: str | None, name: str):
     """Install your dbgpts(operators,agents,workflows or apps)"""
     from .repo import install
 
+    check_poetry_installed()
     install(name, repo)
 
 
@@ -108,3 +133,84 @@ def update_repo(repo: str | None):
         else:
             print(f"Updating repo '{p}'...")
             update_repo(p)
+
+
+@click.command(name="app")
+@click.option(
+    "-n",
+    "--name",
+    type=str,
+    required=True,
+    help="The name you want to give to the dbgpt",
+)
+@click.option(
+    "-l",
+    "--label",
+    type=str,
+    default=None,
+    required=False,
+    help="The label of the dbgpt",
+)
+@click.option(
+    "-d",
+    "--description",
+    type=str,
+    default=None,
+    required=False,
+    help="The description of the dbgpt",
+)
+@click.option(
+    "-t",
+    "--type",
+    type=click.Choice(DEFAULT_PACKAGE_TYPES),
+    default="flow",
+    required=False,
+    help="The type of the dbgpt",
+)
+@click.option(
+    "--definition_type",
+    type=click.Choice(["json", "python"]),
+    default="json",
+    required=False,
+    help="The definition type of the dbgpt",
+)
+@click.option(
+    "-C",
+    "--directory",
+    type=str,
+    default=None,
+    required=False,
+    help="The working directory of the dbgpt(defaults to the current directory).",
+)
+def new_dbgpts(
+    name: str,
+    label: str | None,
+    description: str | None,
+    type: str,
+    definition_type: str,
+    directory: str | None,
+):
+    """New a dbgpts module structure"""
+    if not label:
+        # Set label to the name
+        default_label = name.replace("-", " ").replace("_", " ").title()
+        label = click.prompt(
+            "Please input the label of the dbgpt", default=default_label
+        )
+    if not description:
+        # Read with click
+        description = click.prompt(
+            "Please input the description of the dbgpt", default=""
+        )
+    if not directory:
+        # Set directory to the current directory(abs path)
+        directory = click.prompt(
+            "Please input the working directory of the dbgpt",
+            default=str(Path.cwd()),
+            type=click.Path(exists=True, file_okay=False, dir_okay=True),
+        )
+
+    check_poetry_installed()
+    from .template import create_template
+
+    create_template(name, label, description, type, definition_type, directory)

--- a/dbgpt/util/dbgpts/repo.py
+++ b/dbgpt/util/dbgpts/repo.py
@@ -214,13 +214,18 @@ def _copy_and_install(repo: str, name: str, package_path: Path):
             err=True,
         )
         return
-    shutil.copytree(package_path, install_path)
-    logger.info(f"Installing dbgpts '{name}' from {repo}...")
-    os.chdir(install_path)
-    subprocess.run(["poetry", "install"], check=True)
-    _write_install_metadata(name, repo, install_path)
-    click.echo(f"Installed dbgpts at {_print_path(install_path)}.")
-    click.echo(f"dbgpts '{name}' installed successfully.")
+    try:
+        shutil.copytree(package_path, install_path)
+        logger.info(f"Installing dbgpts '{name}' from {repo}...")
+        os.chdir(install_path)
+        subprocess.run(["poetry", "install"], check=True)
+        _write_install_metadata(name, repo, install_path)
+        click.echo(f"Installed dbgpts at {_print_path(install_path)}.")
+        click.echo(f"dbgpts '{name}' installed successfully.")
+    except Exception as e:
+        if install_path.exists():
+            shutil.rmtree(install_path)
+        raise e
 
 
 def _write_install_metadata(name: str, repo: str, install_path: Path):

--- a/dbgpt/util/dbgpts/template.py
+++ b/dbgpt/util/dbgpts/template.py
@@ -1,0 +1,209 @@
+import os
+import subprocess
+from pathlib import Path
+
+import click
+
+from .base import DBGPTS_METADATA_FILE, TYPE_TO_PACKAGE
+
+
+def create_template(
+    name: str,
+    name_label: str,
+    description: str,
+    dbgpts_type: str,
+    definition_type: str,
+    working_directory: str,
+):
+    """Create a new flow dbgpt"""
+    if dbgpts_type != "flow":
+        definition_type = "python"
+    mod_name = name.replace("-", "_")
+    base_metadata = {
+        "label": name_label,
+        "name": mod_name,
+        "version": "0.1.0",
+        "description": description,
+        "authors": [],
+        "definition_type": definition_type,
+    }
+    working_directory = os.path.join(working_directory, TYPE_TO_PACKAGE[dbgpts_type])
+    package_dir = Path(working_directory) / name
+    if os.path.exists(package_dir):
+        raise click.ClickException(f"Package '{str(package_dir)}' already exists")
+
+    if dbgpts_type == "flow":
+        _create_flow_template(
+            name,
+            mod_name,
+            dbgpts_type,
+            base_metadata,
+            definition_type,
+            working_directory,
+        )
+    elif dbgpts_type == "operator":
+        _create_operator_template(
+            name,
+            mod_name,
+            dbgpts_type,
+            base_metadata,
+            definition_type,
+            working_directory,
+        )
+    else:
+        raise ValueError(f"Invalid dbgpts type: {dbgpts_type}")
+
+
+def _create_flow_template(
+    name: str,
+    mod_name: str,
+    dbgpts_type: str,
+    base_metadata: dict,
+    definition_type: str,
+    working_directory: str,
+):
+    """Create a new flow dbgpt"""
+
+    json_dict = {
+        "flow": base_metadata,
+        "python_config": {},
+        "json_config": {},
+    }
+    if definition_type == "json":
+        json_dict["json_config"] = {"file_path": "definition/flow_definition.json"}
+
+    _create_poetry_project(working_directory, name)
+    _write_dbgpts_toml(working_directory, name, json_dict)
+    _write_manifest_file(working_directory, name, mod_name)
+
+    if definition_type == "json":
+        _write_flow_define_json_file(working_directory, name, mod_name)
+    else:
+        raise click.ClickException(
+            f"Unsupported definition type: {definition_type} for dbgpts type: {dbgpts_type}"
+        )
+
+
+def _create_operator_template(
+    name: str,
+    mod_name: str,
+    dbgpts_type: str,
+    base_metadata: dict,
+    definition_type: str,
+    working_directory: str,
+):
+    """Create a new operator dbgpt"""
+
+    json_dict = {
+        "operator": base_metadata,
+        "python_config": {},
+        "json_config": {},
+    }
+    if definition_type != "python":
+        raise click.ClickException(
+            f"Unsupported definition type: {definition_type} for dbgpts type: "
+            f"{dbgpts_type}"
+        )
+
+    _create_poetry_project(working_directory, name)
+    _write_dbgpts_toml(working_directory, name, json_dict)
+    _write_operator_init_file(working_directory, name, mod_name)
+    _write_manifest_file(working_directory, name, mod_name)
+
+
+def _create_poetry_project(working_directory: str, name: str):
+    """Create a new poetry project"""
+
+    os.chdir(working_directory)
+    subprocess.run(["poetry", "new", name, "-n"], check=True)
+
+
+def _write_dbgpts_toml(working_directory: str, name: str, json_data: dict):
+    """Write the dbgpts.toml file"""
+
+    import tomlkit
+
+    with open(Path(working_directory) / name / DBGPTS_METADATA_FILE, "w") as f:
+        tomlkit.dump(json_data, f)
+
+
+def _write_manifest_file(working_directory: str, name: str, mod_name: str):
+    """Write the manifest file"""
+
+    manifest = f"""include dbgpts.toml
+include {mod_name}/definition/*.json
+"""
+    with open(Path(working_directory) / name / "MANIFEST.in", "w") as f:
+        f.write(manifest)
+
+
+def _write_flow_define_json_file(working_directory: str, name: str, mod_name: str):
+    """Write the flow define json file"""
+
+    def_file = (
+        Path(working_directory)
+        / name
+        / mod_name
+        / "definition"
+        / "flow_definition.json"
+    )
+    if not def_file.parent.exists():
+        def_file.parent.mkdir(parents=True)
+    with open(def_file, "w") as f:
+        f.write("")
+        print("Please write your flow json to the file: ", def_file)
+
+
+def _write_operator_init_file(working_directory: str, name: str, mod_name: str):
+    """Write the operator __init__.py file"""
+
+    init_file = Path(working_directory) / name / mod_name / "__init__.py"
+    content = """
+from dbgpt.core.awel import MapOperator
+from dbgpt.core.awel.flow import ViewMetadata, OperatorCategory, IOField, Parameter
+
+
+class HelloWorldOperator(MapOperator[str, str]):
+    # The metadata for AWEL flow
+    metadata = ViewMetadata(
+        label="Hello World Operator",
+        name="hello_world_operator",
+        category=OperatorCategory.COMMON,
+        description="A example operator to say hello to someone.",
+        parameters=[
+            Parameter.build_from(
+                "Name",
+                "name",
+                str,
+                optional=True,
+                default="World",
+                description="The name to say hello",
+            )
+        ],
+        inputs=[
+            IOField.build_from(
+                "Input value",
+                "value",
+                str,
+                description="The input value to say hello",
+            )
+        ],
+        outputs=[
+            IOField.build_from(
+                "Output value",
+                "value",
+                str,
+                description="The output value after saying hello",
+            )
+        ]
+    )
+
+    def __init__(self, name: str = "World", **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+
+    async def map(self, value: str) -> str:
+        return f"Hello, {self.name}! {value}"
+"""
+    with open(init_file, "w") as f:
+        f.write(f'"""{name} operator package"""\n{content}')

--- a/setup.py
+++ b/setup.py
@@ -400,6 +400,8 @@ def core_requires():
         "sqlparse==0.4.4",
         "duckdb==0.8.1",
         "duckdb-engine",
+        # lightweight python library for scheduling jobs
+        "schedule",
     ]
     # TODO: remove fschat from simple_framework
     if BUILD_FROM_SOURCE:


### PR DESCRIPTION
# Description

- Support dynamic loading of dbgpts
- Support install `operator` from dbgpts
- New command to create a template of dbgpts: `dbgpt new app --help`

# How Has This Been Tested?

Test dynamic loading.

1. Start your DB-GPT
2.Install an new AWEL flow, eg. `dbgpt app install awel-flow-rag-chat-example`
3. Wait 10 seconds, then reload refresh  web page and you will see the new flow.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
