### PR TITLE
Update milvus_store.py

### DIFF
--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -165,7 +165,7 @@ class MilvusStore(VectorStoreBase):
             connections.connect(
                 host=self.uri or "127.0.0.1",
                 port=self.port or "19530",
-                alias="default"
+                alias="default",
                 # secure=self.secure,
             )
         texts = [d.content for d in documents]

--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -419,7 +419,7 @@ class MilvusStore(VectorStoreBase):
 
         """milvus delete collection name"""
         logger.info(f"milvus vector_name:{vector_name} begin delete...")
-        utility.drop_collection(vector_name)
+        utility.drop_collection(self.collection_name)
         return True
 
     def delete_by_ids(self, ids):


### PR DESCRIPTION
Fix the issue where the first character of a collection name must be an underscore or letter: invalid parameter cannot be deleted if the name of the knowledge base is in Chinese after connecting to Milvus v 2.3.7 as a vector database.
https://github.com/eosphoros-ai/DB-GPT/issues/1150#issue-2119939668
Close #1150
# Description

Fix the issue where the first character of a collection name must be an underscore or letter: invalid parameter cannot be deleted if the name of the knowledge base is in Chinese after connecting to Milvus v 2.3.7 as a vector database.

# How Has This Been Tested?

Chinese Name Knowledge Base Test:
1. After modifying the code, connect Milvus v 2.3.7 as the vector database and start the project.
2. Create a Chinese knowledge base on the web interface, and after the prompt is successful, check if the new Collection is successfully created in the Milvus database
3. Delete the newly created Chinese name knowledge base on the web interface. After a prompt indicating successful deletion, the knowledge base on the web interface disappears, the service log shows no errors, and the corresponding Collection in the Milvus database is successfully deleted
English Name Knowledge Base Test:
1. After modifying the code, connect Milvus v 2.3.7 as the vector database and start the project.
2. Create an English knowledge base on the web interface, and after the prompt is successful, check whether the new Collection was successfully created in the Milvus database
3. Delete the newly created English named knowledge base on the web interface. After a prompt indicating successful deletion, the knowledge base on the web interface disappears, the service log shows no errors, and the corresponding Collection in the Milvus database is successfully deleted

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
