### PR TITLE
fix(core): Fix HTTP Trigger parse parameter bug

### DIFF
--- a/dbgpt/core/awel/trigger/http_trigger.py
+++ b/dbgpt/core/awel/trigger/http_trigger.py
@@ -541,15 +541,19 @@ class HttpTrigger(Trigger):
                     req_body_cls, BaseModel
                 ):
                     fields = req_body_cls.__fields__  # type: ignore
-                    parameters = [
-                        Parameter(
-                            name=field_name,
-                            kind=Parameter.KEYWORD_ONLY,
-                            default=Parameter.empty,
-                            annotation=field.outer_type_,
+                    parameters = []
+                    for field_name, field in fields.items():
+                        default_value = (
+                            Parameter.empty if field.required else field.default
                         )
-                        for field_name, field in fields.items()
-                    ]
+                        parameters.append(
+                            Parameter(
+                                name=field_name,
+                                kind=Parameter.KEYWORD_ONLY,
+                                default=default_value,
+                                annotation=field.outer_type_,
+                            )
+                        )
                 elif req_body_cls == Dict[str, Any] or req_body_cls == dict:
                     raise AWELHttpError(
                         f"Query methods {self._methods} not support dict type"


### PR DESCRIPTION
# Description

Closes #1218 

# How Has This Been Tested?

1. `python examples/awel/simple_dag_example.py`
2. `curl -X GET http://127.0.0.1:5555/api/v1/awel/trigger/examples/hello\?name\=zhangsan`

# Snapshots:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
