### PR TITLE
feat: AWEL flow supports dynamic parameters

### DIFF
--- a/dbgpt/app/scene/chat_knowledge/v1/chat.py
+++ b/dbgpt/app/scene/chat_knowledge/v1/chat.py
@@ -208,7 +208,9 @@ class ChatKnowledge(BaseChat):
                     }
                 )
         references_list = list(references_dict.values())
-        references_ele.set("references", json.dumps(references_list))
+        references_ele.set(
+            "references", json.dumps(references_list, ensure_ascii=False)
+        )
         html = ET.tostring(references_ele, encoding="utf-8")
         reference = html.decode("utf-8")
         return reference.replace("\\n", "")

--- a/dbgpt/core/awel/flow/__init__.py
+++ b/dbgpt/core/awel/flow/__init__.py
@@ -3,11 +3,15 @@
 This module contains the classes and functions to build AWEL DAGs from serialized data.
 """
 
+from ..util.parameter_util import (  # noqa: F401
+    BaseDynamicOptions,
+    FunctionDynamicOptions,
+    OptionValue,
+)
 from .base import (  # noqa: F401
     IOField,
     OperatorCategory,
     OperatorType,
-    OptionValue,
     Parameter,
     ResourceCategory,
     ResourceMetadata,
@@ -29,4 +33,6 @@ __ALL__ = [
     "ResourceType",
     "OperatorType",
     "IOField",
+    "BaseDynamicOptions",
+    "FunctionDynamicOptions",
 ]

--- a/dbgpt/core/awel/util/parameter_util.py
+++ b/dbgpt/core/awel/util/parameter_util.py
@@ -1,0 +1,70 @@
+"""The parameter utility."""
+
+import inspect
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List
+
+from dbgpt._private.pydantic import BaseModel, Field, root_validator
+from dbgpt.core.interface.serialization import Serializable
+
+_DEFAULT_DYNAMIC_REGISTRY = {}
+
+
+class OptionValue(Serializable, BaseModel):
+    """The option value of the parameter."""
+
+    label: str = Field(..., description="The label of the option")
+    name: str = Field(..., description="The name of the option")
+    value: Any = Field(..., description="The value of the option")
+
+    def to_dict(self) -> Dict:
+        """Convert current metadata to json dict."""
+        return self.dict()
+
+
+class BaseDynamicOptions(Serializable, BaseModel, ABC):
+    """The base dynamic options."""
+
+    @abstractmethod
+    def option_values(self) -> List[OptionValue]:
+        """Return the option values of the parameter."""
+
+
+class FunctionDynamicOptions(BaseDynamicOptions):
+    """The function dynamic options."""
+
+    func: Callable[[], List[OptionValue]] = Field(
+        ..., description="The function to generate the dynamic options"
+    )
+    func_id: str = Field(
+        ..., description="The unique id of the function to generate the dynamic options"
+    )
+
+    def option_values(self) -> List[OptionValue]:
+        """Return the option values of the parameter."""
+        return self.func()
+
+    @root_validator(pre=True)
+    def pre_fill(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Pre fill the function id."""
+        func = values.get("func")
+        if func is None:
+            raise ValueError(
+                "The function to generate the dynamic options is required."
+            )
+        func_id = _generate_unique_id(func)
+        values["func_id"] = func_id
+        _DEFAULT_DYNAMIC_REGISTRY[func_id] = func
+        return values
+
+    def to_dict(self) -> Dict:
+        """Convert current metadata to json dict."""
+        return {"func_id": self.func_id}
+
+
+def _generate_unique_id(func: Callable) -> str:
+    if func.__name__ == "<lambda>":
+        func_id = f"lambda_{inspect.getfile(func)}_{inspect.getsourcelines(func)}"
+    else:
+        func_id = f"{func.__module__}.{func.__name__}"
+    return func_id

--- a/dbgpt/serve/agent/team/layout/agent_operator_resource.py
+++ b/dbgpt/serve/agent/team/layout/agent_operator_resource.py
@@ -4,21 +4,16 @@ from pydantic import BaseModel, Field
 
 from dbgpt._private.pydantic import root_validator
 from dbgpt.agent.agents.agents_manage import agent_manage
-from dbgpt.agent.agents.base_agent_new import ConversableAgent
 from dbgpt.agent.agents.llm.llm import LLMConfig, LLMStrategyType
 from dbgpt.agent.resource.resource_api import AgentResource, ResourceType
 from dbgpt.core import LLMClient
 from dbgpt.core.awel.flow import (
-    IOField,
-    OperatorCategory,
-    OperatorType,
+    FunctionDynamicOptions,
     OptionValue,
     Parameter,
     ResourceCategory,
-    ViewMetadata,
     register_resource,
 )
-from dbgpt.core.interface.operators.prompt_operator import CommonChatPromptTemplate
 
 
 @register_resource(
@@ -115,6 +110,13 @@ class AwelAgentConfig(LLMConfig):
         return values
 
 
+def _agent_resource_option_values() -> List[OptionValue]:
+    return [
+        OptionValue(label=item["name"], name=item["name"], value=item["name"])
+        for item in agent_manage.list_agents()
+    ]
+
+
 @register_resource(
     label="Awel Layout Agent",
     name="agent_operator_agent",
@@ -126,10 +128,7 @@ class AwelAgentConfig(LLMConfig):
             name="agent_profile",
             type=str,
             description="Which agent want use.",
-            options=[
-                OptionValue(label=item["name"], name=item["name"], value=item["name"])
-                for item in agent_manage.list_agents()
-            ],
+            options=FunctionDynamicOptions(func=_agent_resource_option_values),
         ),
         Parameter.build_from(
             label="Role Name",

--- a/dbgpt/serve/rag/operators/knowledge_space.py
+++ b/dbgpt/serve/rag/operators/knowledge_space.py
@@ -13,6 +13,7 @@ from dbgpt.core import (
 )
 from dbgpt.core.awel import JoinOperator, MapOperator
 from dbgpt.core.awel.flow import (
+    FunctionDynamicOptions,
     IOField,
     OperatorCategory,
     OperatorType,
@@ -27,6 +28,15 @@ from dbgpt.rag.retriever.embedding import EmbeddingRetriever
 from dbgpt.storage.vector_store.base import VectorStoreConfig
 from dbgpt.storage.vector_store.connector import VectorStoreConnector
 from dbgpt.util.function_utils import rearrange_args_by_type
+
+
+def _load_space_name() -> List[OptionValue]:
+    return [
+        OptionValue(label=space.name, name=space.name, value=space.name)
+        for space in knowledge_space_service.get_knowledge_space(
+            KnowledgeSpaceRequest()
+        )
+    ]
 
 
 class SpaceRetrieverOperator(MapOperator[IN, OUT]):
@@ -51,12 +61,7 @@ class SpaceRetrieverOperator(MapOperator[IN, OUT]):
                 "Space Name",
                 "space_name",
                 str,
-                options=[
-                    OptionValue(label=space.name, name=space.name, value=space.name)
-                    for space in knowledge_space_service.get_knowledge_space(
-                        KnowledgeSpaceRequest()
-                    )
-                ],
+                options=FunctionDynamicOptions(func=_load_space_name),
                 optional=False,
                 default=None,
                 description="space name.",


### PR DESCRIPTION
# Description

AWEL flow dynamically read optional parameter list, now supports:
- `SpaceRetrieverOperator`
- `AwelAgent`

# How Has This Been Tested?

Test it with `SpaceRetrieverOperator`.

1. Start DB-GPT
2. New AWEL flow, select `SpaceRetrieverOperator`, you can see a list of "Space Name"
3. Create a new knowledge space.
4. Reload your web page.
5. New AWEL flow, select `SpaceRetrieverOperator`, you can see a list of "Space Name" includs your new space name.


# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
