### PR TITLE
fix: Fixed multi-turn dialogue bug

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -96,6 +96,13 @@ KNOWLEDGE_SEARCH_REWRITE=False
 # proxy_openai_proxy_api_key={your-openai-sk}
 # proxy_openai_proxy_backend=text-embedding-ada-002
 
+## Common HTTP embedding model
+# EMBEDDING_MODEL=proxy_http_openapi
+# proxy_http_openapi_proxy_server_url=http://localhost:8100/api/v1/embeddings
+# proxy_http_openapi_proxy_api_key=1dce29a6d66b4e2dbfec67044edbb924
+# proxy_http_openapi_proxy_backend=text2vec
+
+
 
 #*******************************************************************#
 #**                  DB-GPT METADATA DATABASE SETTINGS            **#

--- a/dbgpt/configs/model_config.py
+++ b/dbgpt/configs/model_config.py
@@ -172,6 +172,8 @@ EMBEDDING_MODEL_CONFIG = {
     "sentence-transforms": os.path.join(MODEL_PATH, "all-MiniLM-L6-v2"),
     "proxy_openai": "proxy_openai",
     "proxy_azure": "proxy_azure",
+    # Common HTTP embedding model
+    "proxy_http_openapi": "proxy_http_openapi",
 }
 
 

--- a/dbgpt/core/interface/operators/tests/test_message_operator.py
+++ b/dbgpt/core/interface/operators/tests/test_message_operator.py
@@ -1,0 +1,155 @@
+from typing import List
+
+import pytest
+
+from dbgpt.core.interface.message import AIMessage, BaseMessage, HumanMessage
+from dbgpt.core.operators import BufferedConversationMapperOperator
+
+
+@pytest.fixture
+def messages() -> List[BaseMessage]:
+    return [
+        HumanMessage(content="Hi", round_index=1),
+        AIMessage(content="Hello!", round_index=1),
+        HumanMessage(content="How are you?", round_index=2),
+        AIMessage(content="I'm good, thanks!", round_index=2),
+        HumanMessage(content="What's new today?", round_index=3),
+        AIMessage(content="Lots of things!", round_index=3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_buffered_conversation_keep_start_rounds(messages: List[BaseMessage]):
+    # Test keep_start_rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=2,
+        keep_end_rounds=None,
+    )
+    assert await operator.map_messages(messages) == [
+        HumanMessage(content="Hi", round_index=1),
+        AIMessage(content="Hello!", round_index=1),
+        HumanMessage(content="How are you?", round_index=2),
+        AIMessage(content="I'm good, thanks!", round_index=2),
+    ]
+    # Test keep start 0 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=0,
+        keep_end_rounds=None,
+    )
+    assert await operator.map_messages(messages) == []
+
+    # Test keep start 100 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=100,
+        keep_end_rounds=None,
+    )
+    assert await operator.map_messages(messages) == messages
+
+    # Test keep start -1 rounds
+    with pytest.raises(ValueError):
+        operator = BufferedConversationMapperOperator(
+            keep_start_rounds=-1,
+            keep_end_rounds=None,
+        )
+        await operator.map_messages(messages)
+
+
+@pytest.mark.asyncio
+async def test_buffered_conversation_keep_end_rounds(messages: List[BaseMessage]):
+    # Test keep_end_rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=None,
+        keep_end_rounds=2,
+    )
+    assert await operator.map_messages(messages) == [
+        HumanMessage(content="How are you?", round_index=2),
+        AIMessage(content="I'm good, thanks!", round_index=2),
+        HumanMessage(content="What's new today?", round_index=3),
+        AIMessage(content="Lots of things!", round_index=3),
+    ]
+    # Test keep end 0 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=0,
+        keep_end_rounds=0,
+    )
+    assert await operator.map_messages(messages) == []
+
+    # Test keep end 100 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=None,
+        keep_end_rounds=100,
+    )
+    assert await operator.map_messages(messages) == messages
+
+    # Test keep end -1 rounds
+    with pytest.raises(ValueError):
+        operator = BufferedConversationMapperOperator(
+            keep_start_rounds=None,
+            keep_end_rounds=-1,
+        )
+        await operator.map_messages(messages)
+
+
+@pytest.mark.asyncio
+async def test_buffered_conversation_keep_start_end_rounds(messages: List[BaseMessage]):
+    # Test keep_start_rounds and keep_end_rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=1,
+        keep_end_rounds=1,
+    )
+    assert await operator.map_messages(messages) == [
+        HumanMessage(content="Hi", round_index=1),
+        AIMessage(content="Hello!", round_index=1),
+        HumanMessage(content="What's new today?", round_index=3),
+        AIMessage(content="Lots of things!", round_index=3),
+    ]
+    # Test keep start 0 rounds and keep end 0 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=0,
+        keep_end_rounds=0,
+    )
+    assert await operator.map_messages(messages) == []
+
+    # Test keep start 0 rounds and keep end 1 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=0,
+        keep_end_rounds=1,
+    )
+    assert await operator.map_messages(messages) == [
+        HumanMessage(content="What's new today?", round_index=3),
+        AIMessage(content="Lots of things!", round_index=3),
+    ]
+
+    # Test keep start 2 rounds and keep end 0 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=2,
+        keep_end_rounds=0,
+    )
+    assert await operator.map_messages(messages) == [
+        HumanMessage(content="Hi", round_index=1),
+        AIMessage(content="Hello!", round_index=1),
+        HumanMessage(content="How are you?", round_index=2),
+        AIMessage(content="I'm good, thanks!", round_index=2),
+    ]
+
+    # Test keep start 100 rounds and keep end 100 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=100,
+        keep_end_rounds=100,
+    )
+    assert await operator.map_messages(messages) == messages
+
+    # Test keep start 2 round and keep end 2 rounds
+    operator = BufferedConversationMapperOperator(
+        keep_start_rounds=2,
+        keep_end_rounds=2,
+    )
+    assert await operator.map_messages(messages) == messages
+
+    # Test keep start -1 rounds and keep end -1 rounds
+    with pytest.raises(ValueError):
+        operator = BufferedConversationMapperOperator(
+            keep_start_rounds=-1,
+            keep_end_rounds=-1,
+        )
+        await operator.map_messages(messages)

--- a/dbgpt/model/parameter.py
+++ b/dbgpt/model/parameter.py
@@ -552,7 +552,7 @@ class ProxyEmbeddingParameters(BaseEmbeddingModelParameters):
 
 
 _EMBEDDING_PARAMETER_CLASS_TO_NAME_CONFIG = {
-    ProxyEmbeddingParameters: "proxy_openai,proxy_azure"
+    ProxyEmbeddingParameters: "proxy_openai,proxy_azure,proxy_http_openapi",
 }
 
 EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG = {}


### PR DESCRIPTION
# Description

- Fix the problem that multi-turn dialogues do not work properly in `chat_normal`
- Add unit test for `BufferedConversationMapperOperator`
-  Webserver support [`OpenAPIEmbeddings`](https://github.com/eosphoros-ai/DB-GPT/pull/1256):
```
EMBEDDING_MODEL=proxy_http_openapi
proxy_http_openapi_proxy_server_url=http://localhost:8100/api/v1/embeddings
proxy_http_openapi_proxy_api_key={your api key}
proxy_http_openapi_proxy_backend=text2vec
```

# How Has This Been Tested?

```bash
make test
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
