### PR TITLE
Fixed the problem of loading only one plugin when there are multiple …

### DIFF
--- a/dbgpt/agent/agents/expand/plugin_assistant_agent.py
+++ b/dbgpt/agent/agents/expand/plugin_assistant_agent.py
@@ -49,10 +49,12 @@ class PluginAssistantAgent(ConversableAgent):
         plugin_loader_client: ResourcePluginClient = (
             self.resource_loader.get_resesource_api(ResourceType.Plugin)
         )
+        item_list = []
         for item in self.resources:
             if item.type == ResourceType.Plugin:
-                self.plugin_generator = await plugin_loader_client.a_load_plugin(
-                    item.value, self.plugin_generator
+                item_list.append(item.value)
+        self.plugin_generator = await plugin_loader_client.a_load_plugin(
+                    item_list, self.plugin_generator
                 )
 
     def prepare_act_param(self) -> Optional[Dict]:


### PR DESCRIPTION
…plugins

# Description

 plugin_generator is overrided when ToolExpert loading multiple plugins, and only one plugin is available during execution.

# How Has This Been Tested?

I added three custom plugins, but only one is executable

# Snapshots:
![微信截图_20240313094516](https://github.com/eosphoros-ai/DB-GPT/assets/49380783/258a73d1-86f9-49c4-bbf2-4fd2d28f6596)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
