### PR TITLE
fix(awel): Fix awel check empty data bug

### DIFF
--- a/dbgpt/core/awel/task/base.py
+++ b/dbgpt/core/awel/task/base.py
@@ -33,6 +33,19 @@ class _EMPTY_DATA_TYPE:
     def __str__(self):
         return f"EmptyData({self.name})"
 
+    def is_same(self, obj: Any) -> bool:
+        """Check if the object is the same as the current object.
+
+        Args:
+            obj (Any): The object to compare with.
+
+        Returns:
+            bool: True if the object is the same as the current object, False otherwise.
+        """
+        if not isinstance(obj, _EMPTY_DATA_TYPE):
+            return False
+        return self == obj
+
 
 EMPTY_DATA = _EMPTY_DATA_TYPE("EMPTY_DATA")
 SKIP_DATA = _EMPTY_DATA_TYPE("SKIP_DATA")

--- a/dbgpt/core/awel/task/task_impl.py
+++ b/dbgpt/core/awel/task/task_impl.py
@@ -76,7 +76,7 @@ class SimpleTaskOutput(TaskOutput[T], Generic[T]):
     @property
     def output(self) -> T:
         """Return the output data."""
-        if self._data == EMPTY_DATA:
+        if EMPTY_DATA.is_same(self._data):
             raise ValueError("No output data for current task output")
         return cast(T, self._data)
 
@@ -188,7 +188,7 @@ class SimpleStreamTaskOutput(TaskOutput[T], Generic[T]):
         Raises:
             ValueError: If the output data is empty.
         """
-        if self._data == EMPTY_DATA:
+        if EMPTY_DATA.is_same(self._data):
             raise ValueError("No output data for current task output")
         return cast(AsyncIterator[T], self._data)
 


### PR DESCRIPTION
# Description

Closes #1310

# How Has This Been Tested?

`python examples/sdk/simple_sdk_llm_sql_example.py `


# Snapshots:

![image](https://github.com/eosphoros-ai/DB-GPT/assets/22972572/f8dadaa0-c41c-41ce-8c1a-c6c34cacc8ad)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
