### PR TITLE
fix: pg py dependency problem fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -562,7 +562,6 @@ def all_datasource_requires():
     setup_spec.extras["datasource"] = [
         # "sqlparse==0.4.4",
         "pymysql",
-        "psycopg2",
         # for doris
         # mysqlclient 2.2.x have pkg-config issue on 3.10+
         "mysqlclient==2.1.0",
@@ -570,6 +569,9 @@ def all_datasource_requires():
     setup_spec.extras["datasource_all"] = setup_spec.extras["datasource"] + [
         "pyspark",
         "pymssql",
+        # install psycopg2-binary when you are in a virtual environment
+        # pip install psycopg2-binary
+        "psycopg2",
         "pydoris>=1.0.2,<2.0.0",
         "clickhouse-connect",
         "pyhive",


### PR DESCRIPTION
# Description

Install py-pg use `psycopg2-binary` instead of  `psycopg2`

# How Has This Been Tested?

```
pip install psycopg2-binary
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
