### PR TITLE
fix: when delete knowledge, error: space list error embedding is required for MilvusStore

### DIFF
--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -175,9 +175,6 @@ class MilvusStore(VectorStoreBase):
             hex_str = bytes_str.hex()
             self.collection_name = hex_str
 
-        if not vector_store_config.embedding_fn:
-            raise ValueError("embedding is required for MilvusStore")
-
         self.embedding: Embeddings = vector_store_config.embedding_fn
         self.fields: List = []
         self.alias = milvus_vector_config.get("alias") or "default"


### PR DESCRIPTION

# Description

set VECTOR_STORE_TYPE=Milvus
When delete knowledge, error: space list error embedding is required for MilvusStore. 


![image](https://github.com/eosphoros-ai/DB-GPT/assets/30332358/67abc01d-9ac0-46c9-b6c3-9c6443b86622)


# How Has This Been Tested?

1. set VECTOR_STORE_TYPE=Milvus
2. delete knowledge

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
