### PR TITLE
fix: Resolve the issue of incorrect parameter echo for resources under app editing

### DIFF
--- a/web/components/app/resource-card.tsx
+++ b/web/components/app/resource-card.tsx
@@ -61,7 +61,7 @@ export default function ResourceCard(props: IProps) {
   }, [resourceType]);
 
   useEffect(() => {
-    // fix bug ：解决应用管理页面，资源参数保存后的回显不对的问题
+    // fix bug ：Resolve the issue of incorrect parameter echo for resources under app editing
     updateResource(editResource.value || resourceValueOptions[0]?.label, 'value');
     setResource({ ...resource, value: editResource.value || resourceValueOptions[0]?.label });
   }, [resourceValueOptions]);

--- a/web/components/app/resource-card.tsx
+++ b/web/components/app/resource-card.tsx
@@ -61,8 +61,9 @@ export default function ResourceCard(props: IProps) {
   }, [resourceType]);
 
   useEffect(() => {
-    updateResource(resourceValueOptions[0]?.label || editResource.value, 'value');
-    setResource({ ...resource, value: resourceValueOptions[0]?.label || editResource.value });
+    // fix bug ：解决应用管理页面，资源参数保存后的回显不对的问题
+    updateResource(editResource.value || resourceValueOptions[0]?.label, 'value');
+    setResource({ ...resource, value: editResource.value || resourceValueOptions[0]?.label });
   }, [resourceValueOptions]);
 
   return (


### PR DESCRIPTION
…r app editing

# Description

Resolve the issue of incorrect parameter echo for resources under app editing；
When editing the resource parameters of an app, randomly select a resource type and set the resource parameters, then click save; Click edit again to open, the resource parameters echoed are not saved resource parameters

# How Has This Been Tested?

1. open an app, then add one resource and set resource parameters.
2. Open the app again and view the resource parameters that were set and saved in the previous step. Instead, select the first value from the drop-down list as a display.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
