### PR TITLE
feat: Support retry for 'Chat Data'

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -248,3 +248,12 @@ DBGPT_LOG_LEVEL=INFO
 #*******************************************************************#
 # API_KEYS - The list of API keys that are allowed to access the API. Each of the below are an option, separated by commas.
 # API_KEYS=dbgpt
+
+
+#*******************************************************************#
+#**                     Application Config                        **#
+#*******************************************************************#
+# Non-streaming scene retries
+DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE=1
+# Non-streaming scene parallelism
+DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE=1

--- a/.env.template
+++ b/.env.template
@@ -253,7 +253,7 @@ DBGPT_LOG_LEVEL=INFO
 #*******************************************************************#
 #**                     Application Config                        **#
 #*******************************************************************#
-# Non-streaming scene retries
-DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE=1
-# Non-streaming scene parallelism
-DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE=1
+## Non-streaming scene retries
+# DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE=1
+## Non-streaming scene parallelism
+# DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE=1

--- a/dbgpt/_private/config.py
+++ b/dbgpt/_private/config.py
@@ -300,6 +300,15 @@ class Config(metaclass=Singleton):
         # global dbgpt api key
         self.API_KEYS = os.getenv("API_KEYS", None)
 
+        # Non-streaming scene retries
+        self.DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE = int(
+            os.getenv("DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE", 1)
+        )
+        # Non-streaming scene parallelism
+        self.DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE = int(
+            os.getenv("DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE", 1)
+        )
+
     @property
     def local_db_manager(self) -> "ConnectorManager":
         from dbgpt.datasource.manages import ConnectorManager

--- a/dbgpt/app/scene/chat_db/auto_execute/out_parser.py
+++ b/dbgpt/app/scene/chat_db/auto_execute/out_parser.py
@@ -9,6 +9,8 @@ from dbgpt._private.config import Config
 from dbgpt.core.interface.output_parser import BaseOutputParser
 from dbgpt.util.json_utils import serialize
 
+from ...exceptions import AppActionException
+
 CFG = Config()
 
 
@@ -66,9 +68,10 @@ class DbChatOutputParser(BaseOutputParser):
         param = {}
         api_call_element = ET.Element("chart-view")
         err_msg = None
+        success = False
         try:
             if not prompt_response.sql or len(prompt_response.sql) <= 0:
-                return f"""{speak}"""
+                raise AppActionException("Can not find sql in response", speak)
 
             df = data(prompt_response.sql)
             param["type"] = prompt_response.display
@@ -77,20 +80,26 @@ class DbChatOutputParser(BaseOutputParser):
                 df.to_json(orient="records", date_format="iso", date_unit="s")
             )
             view_json_str = json.dumps(param, default=serialize, ensure_ascii=False)
+            success = True
         except Exception as e:
             logger.error("parse_view_response error!" + str(e))
-            err_param = {}
-            err_param["sql"] = f"{prompt_response.sql}"
-            err_param["type"] = "response_table"
+            err_param = {
+                "sql": f"{prompt_response.sql}",
+                "type": "response_table",
+                "data": [],
+            }
             # err_param["err_msg"] = str(e)
-            err_param["data"] = []
             err_msg = str(e)
             view_json_str = json.dumps(err_param, default=serialize, ensure_ascii=False)
 
         # api_call_element.text = view_json_str
         api_call_element.set("content", view_json_str)
         result = ET.tostring(api_call_element, encoding="utf-8")
-        if err_msg:
-            return f"""{speak} \\n <span style=\"color:red\">ERROR!</span>{err_msg} \n {result.decode("utf-8")}"""
+        if not success:
+            view_content = (
+                f'{speak} \\n <span style="color:red">ERROR!</span>'
+                f"{err_msg} \n {result.decode('utf-8')}"
+            )
+            raise AppActionException("Generate view content failed", view_content)
         else:
             return speak + "\n" + result.decode("utf-8")

--- a/dbgpt/app/scene/exceptions.py
+++ b/dbgpt/app/scene/exceptions.py
@@ -1,0 +1,22 @@
+"""Exceptions for Application."""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BaseAppException(Exception):
+    """Base Exception for App"""
+
+    def __init__(self, message: str, view: str):
+        """Base Exception for App"""
+        super().__init__(message)
+        self.message = message
+        self.view = view
+
+
+class AppActionException(BaseAppException):
+    """Exception for App Action."""
+
+    def __init__(self, message: str, view: str):
+        """Exception for App Action"""
+        super().__init__(message, view)

--- a/dbgpt/util/retry.py
+++ b/dbgpt/util/retry.py
@@ -1,0 +1,51 @@
+import asyncio
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+def async_retry(
+    retries: int = 1, parallel_executions: int = 1, catch_exceptions=(Exception,)
+):
+    """Async retry decorator.
+
+    Examples:
+        .. code-block:: python
+
+            @async_retry(retries=3, parallel_executions=2)
+            async def my_func():
+                # Some code that may raise exceptions
+                pass
+
+    Args:
+        retries (int): Number of retries.
+        parallel_executions (int): Number of parallel executions.
+        catch_exceptions (tuple): Tuple of exceptions to catch.
+    """
+
+    def decorator(func):
+        async def wrapper(*args, **kwargs):
+            last_exception = None
+            for attempt in range(retries):
+                tasks = [func(*args, **kwargs) for _ in range(parallel_executions)]
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                for result in results:
+                    if not isinstance(result, Exception):
+                        return result
+                    if isinstance(result, catch_exceptions):
+                        last_exception = result
+                        logger.error(
+                            f"Attempt {attempt + 1} of {retries} failed with error: "
+                            f"{type(result).__name__}, {str(result)}"
+                        )
+                        logger.debug(traceback.format_exc())
+
+                logger.info(f"Retrying... (Attempt {attempt + 1} of {retries})")
+
+            raise last_exception  # After all retries, raise the last caught exception
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
# Description

In some scenarios, we need to call the LLM in parallel, select the successful result, or retry in case of failure.

# How Has This Been Tested?


1. Modify `.env`

```bash
# Non-streaming scene retries
DBGPT_APP_SCENE_NON_STREAMING_RETRIES_BASE=2
# Non-streaming scene parallelism
DBGPT_APP_SCENE_NON_STREAMING_PARALLELISM_BASE=2
```
2. Restart DB-GPT
3. Use "Chat Data" to perform some error-prone problems, and you will find that the success rate increases.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
