### PR TITLE
fix: Fix oceanbase vector_name_exists bug

### DIFF
--- a/dbgpt/rag/evaluation/retriever.py
+++ b/dbgpt/rag/evaluation/retriever.py
@@ -79,9 +79,8 @@ class RetrieverMRRMetric(RetrieverEvaluationMetric):
 
     def sync_compute(
         self,
-        prediction: Optional[List[str]] = None,
-        contexts: Optional[List[str]] = None,
-        **kwargs: Any,
+        prediction: List[str],
+        contexts: Optional[Sequence[str]] = None,
     ) -> BaseEvaluationResult:
         """Compute MRR metric.
 
@@ -118,9 +117,8 @@ class RetrieverHitRateMetric(RetrieverEvaluationMetric):
 
     def sync_compute(
         self,
-        prediction: Optional[List[str]] = None,
-        contexts: Optional[List[str]] = None,
-        **kwargs: Any,
+        prediction: List[str],
+        contexts: Optional[Sequence[str]] = None,
     ) -> BaseEvaluationResult:
         """Compute HitRate metric.
 


### PR DESCRIPTION
# Description

When using OceanBase as the Vector Store for `ChatData`, the db_profile table is not created because the vector_name_exists API returns True.

# How Has This Been Tested?

- Test the `ChatData` function using OceanBase + DB-GPT

# Snapshots:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
