### PR TITLE
fix(rag): Fix rerank bug of EmbeddingRetriever

### DIFF
--- a/dbgpt/rag/retriever/embedding.py
+++ b/dbgpt/rag/retriever/embedding.py
@@ -120,7 +120,7 @@ class EmbeddingRetriever(BaseRetriever):
         new_candidates_with_score = cast(
             List[Chunk], reduce(lambda x, y: x + y, candidates_with_score)
         )
-        new_candidates_with_score = self._rerank.rank(new_candidates_with_score)
+        new_candidates_with_score = self._rerank.rank(new_candidates_with_score, query)
         return new_candidates_with_score
 
     async def _aretrieve(
@@ -207,7 +207,9 @@ class EmbeddingRetriever(BaseRetriever):
                 "rerank_cls": self._rerank.__class__.__name__,
             },
         ):
-            new_candidates_with_score = self._rerank.rank(new_candidates_with_score)
+            new_candidates_with_score = self._rerank.rank(
+                new_candidates_with_score, query
+            )
             return new_candidates_with_score
 
     async def _similarity_search(


### PR DESCRIPTION
# Description

The EmbeddingRetriever's _aretrieve_with_score and _aretrieve methods do not pass the query parameter to the rank function when calling the ranker to re-rank the retrieval results.

# How Has This Been Tested?

1. initialize a EmbeddingRetiever with the CrossEncoderRanker

`retriever = EmbeddingRetriever( vector_store_connector=vector_store_connector, top_k=100, rerank=CrossEncoderRanker(topk=3), )`

2. call aretrieve_with_scores

`retriever.aretrieve_with_scores("what is awel talk about", 0.3)`
3. debug at "[/DB-GPT/dbgpt/rag/retriever/rerank.py](https://github.com/eosphoros-ai/DB-GPT/issues/url)", line 211
4. check whether the value of parameter query is None, if not, bug is fixed.

Closes #1498

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
