### PR TITLE
fix(rag): Fix CrossEncoderRanker bug of EmbeddingRetriever

### DIFF
--- a/dbgpt/rag/retriever/rerank.py
+++ b/dbgpt/rag/retriever/rerank.py
@@ -219,7 +219,7 @@ class CrossEncoderRanker(Ranker):
         rank_scores = self._model.predict(sentences=query_content_pairs)
 
         for candidate, score in zip(candidates_with_scores, rank_scores):
-            candidate.score = score
+            candidate.score = float(score)
 
         new_candidates_with_scores = sorted(
             candidates_with_scores, key=lambda x: x.score, reverse=True


### PR DESCRIPTION
When using EmbeddingRetriever with reranking specified as CrossEncoderRanker, a TypeError ('Object of type float32 is not JSON serializable') occurs when attempting to serialize references of the answer.
![image](https://github.com/eosphoros-ai/DB-GPT/assets/53419016/73c227ce-5aa7-4d06-a3dc-a95fb8bbffdf)
![image](https://github.com/eosphoros-ai/DB-GPT/assets/53419016/158f45cf-1ff7-401c-ab15-8fc1b26df0e9)
