### PR TITLE
fix(rag): Fix CrossEncoderRanker bug of EmbeddingRetriever

### DIFF
--- a/dbgpt/rag/retriever/rerank.py
+++ b/dbgpt/rag/retriever/rerank.py
@@ -219,7 +219,7 @@ class CrossEncoderRanker(Ranker):
         rank_scores = self._model.predict(sentences=query_content_pairs)
 
         for candidate, score in zip(candidates_with_scores, rank_scores):
-            candidate.score = score
+            candidate.score = float(score)
 
         new_candidates_with_scores = sorted(
             candidates_with_scores, key=lambda x: x.score, reverse=True

--- a/dbgpt/storage/vector_store/chroma_store.py
+++ b/dbgpt/storage/vector_store/chroma_store.py
@@ -82,7 +82,7 @@ class ChromaStore(VectorStoreBase):
             # client_settings=chroma_settings,
             client=client,
             collection_metadata=collection_metadata,
-        )
+        )   # type: ignore
 
     def similar_search(
         self, text, topk, filters: Optional[MetadataFilters] = None

--- a/dbgpt/storage/vector_store/pgvector_store.py
+++ b/dbgpt/storage/vector_store/pgvector_store.py
@@ -93,7 +93,8 @@ class PGVectorStore(VectorStoreBase):
             List[str]: chunk ids.
         """
         lc_documents = [Chunk.chunk2langchain(chunk) for chunk in chunks]
-        return self.vector_store_client.from_documents(lc_documents)
+        self.vector_store_client.from_documents(lc_documents)
+        return [str(chunk.chunk_id) for chunk in lc_documents]
 
     def delete_vector_name(self, vector_name: str):
         """Delete vector by name.
@@ -109,4 +110,5 @@ class PGVectorStore(VectorStoreBase):
         Args:
             ids(str): vector ids, separated by comma.
         """
-        return self.vector_store_client.delete(ids)
+        delete_ids = ids.split(",")
+        return self.vector_store_client.delete(delete_ids)


### PR DESCRIPTION
When using EmbeddingRetriever with reranking specified as CrossEncoderRanker, a TypeError ('Object of type float32 is not JSON serializable') occurs when attempting to serialize references of the answer.
![image](https://github.com/eosphoros-ai/DB-GPT/assets/53419016/73c227ce-5aa7-4d06-a3dc-a95fb8bbffdf)
![image](https://github.com/eosphoros-ai/DB-GPT/assets/53419016/158f45cf-1ff7-401c-ab15-8fc1b26df0e9)