### PR TITLE
fix: Upgrade spacy model

### DIFF
--- a/dbgpt/storage/vector_store/chroma_store.py
+++ b/dbgpt/storage/vector_store/chroma_store.py
@@ -82,7 +82,7 @@ class ChromaStore(VectorStoreBase):
             # client_settings=chroma_settings,
             client=client,
             collection_metadata=collection_metadata,
-        )   # type: ignore
+        )  # type: ignore
 
     def similar_search(
         self, text, topk, filters: Optional[MetadataFilters] = None

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -36,9 +36,9 @@ RUN pip3 install --upgrade pip -i $PIP_INDEX_URL \
 
 RUN (if [ "${LANGUAGE}" = "zh" ]; \
         # language is zh, download zh_core_web_sm from github
-        then wget https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.5.0/zh_core_web_sm-3.5.0-py3-none-any.whl -O /tmp/zh_core_web_sm-3.5.0-py3-none-any.whl \
-        && pip3 install /tmp/zh_core_web_sm-3.5.0-py3-none-any.whl -i $PIP_INDEX_URL \
-        && rm /tmp/zh_core_web_sm-3.5.0-py3-none-any.whl; \
+        then wget https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.7.0/zh_core_web_sm-3.7.0-py3-none-any.whl -O /tmp/zh_core_web_sm-3.7.0-py3-none-any.whl \
+        && pip3 install /tmp/zh_core_web_sm-3.7.0-py3-none-any.whl -i $PIP_INDEX_URL \
+        && rm /tmp/zh_core_web_sm-3.7.0-py3-none-any.whl; \
         # not zh, download directly
         else python3 -m spacy download zh_core_web_sm; \
     fi;) \


### PR DESCRIPTION
# Description

Old zh_core_web_sm model will install pydantic 1.x, we should upgrade i to new version.

# How Has This Been Tested?

Modify `.env`:
```
# Makesure use SpacyTextSplitter with model "zh_core_web_sm"
LANGUAGE=zh
```
Load documents into knowledge space,  then test it's  functionality.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
