### PR TITLE
Fix the issue where the knowledge base cannot be edited when using ve…

### DIFF
--- a/dbgpt/serve/rag/api/schemas.py
+++ b/dbgpt/serve/rag/api/schemas.py
@@ -15,7 +15,7 @@ class SpaceServeRequest(BaseModel):
     id: Optional[int] = Field(None, description="The space id")
     name: str = Field(None, description="The space name")
     """vector_type: vector type"""
-    vector_type: str = Field("Chroma", description="The vector type")
+    vector_type: str = Field(None, description="The vector type")
     """desc: description"""
     desc: Optional[str] = Field(None, description="The description")
     """owner: owner"""


### PR DESCRIPTION
…ctor type other than chrome

# Description

When the vector database is not in Chroma, errors may occur when editing Arguments in the knowledge base.
The error exception is Invalid request

The reason traced back to the cause is a problem with the code logic

```
Request=SpaceServeRequest (id=space. id)
Update_request=self. to_request (space)
Query=self_ Create_query_object (session, request)
Entry=query. first()
If entry is None:
Raise Exception ("Invalid request")
```
What is expected here is to query records based on their IDs,
But the actual query conditions are ID and vectortype
Because vector type provides a default value of Chroma
Causing query failure.





# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
