### PR TITLE
feat(model): Support deploy rerank model

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -97,6 +97,23 @@ KNOWLEDGE_SEARCH_REWRITE=False
 # proxy_http_openapi_proxy_api_key=1dce29a6d66b4e2dbfec67044edbb924
 # proxy_http_openapi_proxy_backend=text2vec
 
+#*******************************************************************#
+#**                         RERANK SETTINGS                       **#
+#*******************************************************************#
+## Rerank model
+# RERANK_MODEL=bge-reranker-base
+## If you not set RERANK_MODEL_PATH, DB-GPT will read the model path from EMBEDDING_MODEL_CONFIG based on the RERANK_MODEL.
+# RERANK_MODEL_PATH=
+## The number of rerank results to return
+# RERANK_TOP_K=3
+
+## Common HTTP rerank model
+# RERANK_MODEL=rerank_proxy_http_openapi
+# rerank_proxy_http_openapi_proxy_server_url=http://127.0.0.1:8100/api/v1/beta/relevance
+# rerank_proxy_http_openapi_proxy_api_key={your-api-key}
+# rerank_proxy_http_openapi_proxy_backend=bge-reranker-base
+
+
 
 
 #*******************************************************************#

--- a/dbgpt/_private/config.py
+++ b/dbgpt/_private/config.py
@@ -247,6 +247,10 @@ class Config(metaclass=Singleton):
 
         ### EMBEDDING Configuration
         self.EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text2vec")
+        # Rerank model configuration
+        self.RERANK_MODEL = os.getenv("RERANK_MODEL")
+        self.RERANK_MODEL_PATH = os.getenv("RERANK_MODEL_PATH")
+        self.RERANK_TOP_K = int(os.getenv("RERANK_TOP_K", 3))
         self.KNOWLEDGE_CHUNK_SIZE = int(os.getenv("KNOWLEDGE_CHUNK_SIZE", 100))
         self.KNOWLEDGE_CHUNK_OVERLAP = int(os.getenv("KNOWLEDGE_CHUNK_OVERLAP", 50))
         self.KNOWLEDGE_SEARCH_TOP_SIZE = int(os.getenv("KNOWLEDGE_SEARCH_TOP_SIZE", 5))

--- a/dbgpt/agent/expand/resources/host_tool.py
+++ b/dbgpt/agent/expand/resources/host_tool.py
@@ -1,0 +1,45 @@
+"""Host tool resource module."""
+
+from ...resource.tool.base import tool
+
+
+@tool(description="Get current host CPU status.")
+def get_current_host_cpu_status() -> str:
+    """Get current host CPU status."""
+    import platform
+
+    import psutil
+
+    cpu_architecture = platform.machine()
+    cpu_count_physical = psutil.cpu_count(logical=False)
+    cpu_count_logical = psutil.cpu_count(logical=True)
+    cpu_usage = psutil.cpu_percent(interval=1)
+    return (
+        f"CPU Architecture: {cpu_architecture}\n"
+        f"Physical CPU Cores: {cpu_count_physical}\n"
+        f"Logical CPU Cores: {cpu_count_logical}\n"
+        f"CPU Usage: {cpu_usage}%"
+    )
+
+
+@tool(description="Get current host memory status.")
+def get_current_host_memory_status() -> str:
+    """Get current host memory status."""
+    import psutil
+
+    memory = psutil.virtual_memory()
+    return (
+        f"Total:  {memory.total / (1024**3):.2f} GB\n"
+        f"Available: {memory.available / (1024**3):.2f} GB\n"
+        f"Used:  {memory.used / (1024**3):.2f} GB\n"
+        f"Percent: {memory.percent}%"
+    )
+
+
+@tool(description="Get current host system load.")
+def get_current_host_system_load() -> str:
+    """Get current host system load."""
+    import os
+
+    load1, load5, load15 = os.getloadavg()
+    return f"System load average: {load1:.2f}, {load5:.2f}, {load15:.2f}"

--- a/dbgpt/app/base.py
+++ b/dbgpt/app/base.py
@@ -227,6 +227,14 @@ class WebServerParameters(BaseParameters):
             "text2vec --model_name xxx --model_path xxx`"
         },
     )
+    remote_rerank: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "Whether to enable remote rerank models. If it is True, you need"
+            " to start a rerank model through `dbgpt start worker --worker_type "
+            "text2vec --rerank --model_name xxx --model_path xxx`"
+        },
+    )
     log_level: Optional[str] = field(
         default=None,
         metadata={

--- a/dbgpt/app/component_configs.py
+++ b/dbgpt/app/component_configs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
 from dbgpt._private.config import Config
 from dbgpt.app.base import WebServerParameters
@@ -18,9 +19,14 @@ def initialize_components(
     system_app: SystemApp,
     embedding_model_name: str,
     embedding_model_path: str,
+    rerank_model_name: Optional[str] = None,
+    rerank_model_path: Optional[str] = None,
 ):
     # Lazy import to avoid high time cost
-    from dbgpt.app.initialization.embedding_component import _initialize_embedding_model
+    from dbgpt.app.initialization.embedding_component import (
+        _initialize_embedding_model,
+        _initialize_rerank_model,
+    )
     from dbgpt.app.initialization.scheduler import DefaultScheduler
     from dbgpt.app.initialization.serve_initialization import register_serve_apps
     from dbgpt.datasource.manages.connector_manager import ConnectorManager
@@ -45,6 +51,7 @@ def initialize_components(
     _initialize_embedding_model(
         param, system_app, embedding_model_name, embedding_model_path
     )
+    _initialize_rerank_model(param, system_app, rerank_model_name, rerank_model_path)
     _initialize_model_cache(system_app)
     _initialize_awel(system_app, param)
     # Initialize resource manager of agent
@@ -89,6 +96,11 @@ def _initialize_agent(system_app: SystemApp):
 
 def _initialize_resource_manager(system_app: SystemApp):
     from dbgpt.agent.expand.resources.dbgpt_tool import list_dbgpt_support_models
+    from dbgpt.agent.expand.resources.host_tool import (
+        get_current_host_cpu_status,
+        get_current_host_memory_status,
+        get_current_host_system_load,
+    )
     from dbgpt.agent.expand.resources.search_tool import baidu_search
     from dbgpt.agent.resource.base import ResourceType
     from dbgpt.agent.resource.manage import get_resource_manager, initialize_resource
@@ -104,6 +116,10 @@ def _initialize_resource_manager(system_app: SystemApp):
     # Register a search tool
     rm.register_resource(resource_instance=baidu_search)
     rm.register_resource(resource_instance=list_dbgpt_support_models)
+    # Register host tools
+    rm.register_resource(resource_instance=get_current_host_cpu_status)
+    rm.register_resource(resource_instance=get_current_host_memory_status)
+    rm.register_resource(resource_instance=get_current_host_system_load)
 
 
 def _initialize_openapi(system_app: SystemApp):

--- a/dbgpt/app/initialization/embedding_component.py
+++ b/dbgpt/app/initialization/embedding_component.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Type
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 from dbgpt.component import ComponentType, SystemApp
-from dbgpt.rag.embedding.embedding_factory import EmbeddingFactory
+from dbgpt.core import Embeddings, RerankEmbeddings
+from dbgpt.rag.embedding.embedding_factory import (
+    EmbeddingFactory,
+    RerankEmbeddingFactory,
+)
 
 if TYPE_CHECKING:
     from langchain.embeddings.base import Embeddings
@@ -29,6 +33,26 @@ def _initialize_embedding_model(
             LocalEmbeddingFactory,
             default_model_name=embedding_model_name,
             default_model_path=embedding_model_path,
+        )
+
+
+def _initialize_rerank_model(
+    param: "WebServerParameters",
+    system_app: SystemApp,
+    rerank_model_name: Optional[str] = None,
+    rerank_model_path: Optional[str] = None,
+):
+    if not rerank_model_name:
+        return
+    if param.remote_rerank:
+        logger.info("Register remote RemoteRerankEmbeddingFactory")
+        system_app.register(RemoteRerankEmbeddingFactory, model_name=rerank_model_name)
+    else:
+        logger.info(f"Register local LocalRerankEmbeddingFactory")
+        system_app.register(
+            LocalRerankEmbeddingFactory,
+            default_model_name=rerank_model_name,
+            default_model_path=rerank_model_path,
         )
 
 
@@ -105,3 +129,81 @@ class LocalEmbeddingFactory(EmbeddingFactory):
         loader = EmbeddingLoader()
         # Ignore model_name args
         return loader.load(self._default_model_name, model_params)
+
+
+class RemoteRerankEmbeddingFactory(RerankEmbeddingFactory):
+    def __init__(self, system_app, model_name: str = None, **kwargs: Any) -> None:
+        super().__init__(system_app=system_app)
+        self._default_model_name = model_name
+        self.kwargs = kwargs
+        self.system_app = system_app
+
+    def init_app(self, system_app):
+        self.system_app = system_app
+
+    def create(
+        self, model_name: str = None, embedding_cls: Type = None
+    ) -> "RerankEmbeddings":
+        from dbgpt.model.cluster import WorkerManagerFactory
+        from dbgpt.model.cluster.embedding.remote_embedding import (
+            RemoteRerankEmbeddings,
+        )
+
+        if embedding_cls:
+            raise NotImplementedError
+        worker_manager = self.system_app.get_component(
+            ComponentType.WORKER_MANAGER_FACTORY, WorkerManagerFactory
+        ).create()
+        return RemoteRerankEmbeddings(
+            model_name or self._default_model_name, worker_manager
+        )
+
+
+class LocalRerankEmbeddingFactory(RerankEmbeddingFactory):
+    def __init__(
+        self,
+        system_app,
+        default_model_name: str = None,
+        default_model_path: str = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(system_app=system_app)
+        self._default_model_name = default_model_name
+        self._default_model_path = default_model_path
+        self._kwargs = kwargs
+        self._model = self._load_model()
+
+    def init_app(self, system_app):
+        pass
+
+    def create(
+        self, model_name: str = None, embedding_cls: Type = None
+    ) -> "RerankEmbeddings":
+        if embedding_cls:
+            raise NotImplementedError
+        return self._model
+
+    def _load_model(self) -> "RerankEmbeddings":
+        from dbgpt.model.adapter.embeddings_loader import (
+            EmbeddingLoader,
+            _parse_embedding_params,
+        )
+        from dbgpt.model.parameter import (
+            EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG,
+            BaseEmbeddingModelParameters,
+            EmbeddingModelParameters,
+        )
+
+        param_cls = EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG.get(
+            self._default_model_name, EmbeddingModelParameters
+        )
+        model_params: BaseEmbeddingModelParameters = _parse_embedding_params(
+            model_name=self._default_model_name,
+            model_path=self._default_model_path,
+            param_cls=param_cls,
+            **self._kwargs,
+        )
+        logger.info(model_params)
+        loader = EmbeddingLoader()
+        # Ignore model_name args
+        return loader.load_rerank_model(self._default_model_name, model_params)

--- a/dbgpt/configs/model_config.py
+++ b/dbgpt/configs/model_config.py
@@ -209,6 +209,11 @@ EMBEDDING_MODEL_CONFIG = {
     # Common HTTP embedding model
     "proxy_http_openapi": "proxy_http_openapi",
     "proxy_ollama": "proxy_ollama",
+    # Rerank model, rerank mode is a special embedding model
+    "bge-reranker-base": os.path.join(MODEL_PATH, "bge-reranker-base"),
+    "bge-reranker-large": os.path.join(MODEL_PATH, "bge-reranker-large"),
+    # Proxy rerank model
+    "rerank_proxy_http_openapi": "rerank_proxy_http_openapi",
 }
 
 

--- a/dbgpt/core/__init__.py
+++ b/dbgpt/core/__init__.py
@@ -7,7 +7,7 @@ from dbgpt.core.interface.cache import (  # noqa: F401
     CachePolicy,
     CacheValue,
 )
-from dbgpt.core.interface.embeddings import Embeddings  # noqa: F401
+from dbgpt.core.interface.embeddings import Embeddings, RerankEmbeddings  # noqa: F401
 from dbgpt.core.interface.knowledge import Chunk, Document  # noqa: F401
 from dbgpt.core.interface.llm import (  # noqa: F401
     DefaultMessageConverter,
@@ -106,6 +106,7 @@ __ALL__ = [
     "QuerySpec",
     "StorageError",
     "Embeddings",
+    "RerankEmbeddings",
     "Chunk",
     "Document",
 ]

--- a/dbgpt/core/interface/embeddings.py
+++ b/dbgpt/core/interface/embeddings.py
@@ -1,7 +1,22 @@
 """Interface for embedding models."""
+
 import asyncio
 from abc import ABC, abstractmethod
 from typing import List
+
+
+class RerankEmbeddings(ABC):
+    """Interface for rerank models."""
+
+    @abstractmethod
+    def predict(self, query: str, candidates: List[str]) -> List[float]:
+        """Predict the scores of the candidates."""
+
+    async def apredict(self, query: str, candidates: List[str]) -> List[float]:
+        """Asynchronously predict the scores of the candidates."""
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.predict, query, candidates
+        )
 
 
 class Embeddings(ABC):

--- a/dbgpt/core/schema/api.py
+++ b/dbgpt/core/schema/api.py
@@ -166,6 +166,23 @@ class EmbeddingsResponse(BaseModel):
     usage: UsageInfo = Field(..., description="Usage info")
 
 
+class RelevanceRequest(BaseModel):
+    """Relevance request entity."""
+
+    model: str = Field(..., description="Rerank model name")
+    query: str = Field(..., description="Query text")
+    documents: List[str] = Field(..., description="Document texts")
+
+
+class RelevanceResponse(BaseModel):
+    """Relevance response entity."""
+
+    object: str = Field("list", description="Object type")
+    model: str = Field(..., description="Rerank model name")
+    data: List[float] = Field(..., description="Data list, relevance scores")
+    usage: UsageInfo = Field(..., description="Usage info")
+
+
 class ModelPermission(BaseModel):
     """Model permission entity."""
 

--- a/dbgpt/model/adapter/model_adapter.py
+++ b/dbgpt/model/adapter/model_adapter.py
@@ -147,15 +147,14 @@ def _dynamic_model_parser() -> Optional[List[Type[BaseModelParameters]]]:
     model_path = pre_args.get("model_path")
     worker_type = pre_args.get("worker_type")
     model_type = pre_args.get("model_type")
-    if model_name is None and model_type != ModelType.VLLM:
-        return None
     if worker_type == WorkerType.TEXT2VEC:
         return [
             EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG.get(
                 model_name, EmbeddingModelParameters
             )
         ]
-
+    if model_name is None and model_type != ModelType.VLLM:
+        return None
     llm_adapter = get_llm_model_adapter(model_name, model_path, model_type=model_type)
     param_class = llm_adapter.model_param_class()
     return [param_class]

--- a/dbgpt/model/cluster/base.py
+++ b/dbgpt/model/cluster/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dbgpt._private.pydantic import BaseModel
 from dbgpt.core.interface.message import ModelMessage
@@ -31,7 +31,9 @@ class PromptRequest(BaseModel):
 class EmbeddingsRequest(BaseModel):
     model: str
     input: List[str]
-    span_id: str = None
+    span_id: Optional[str] = None
+    query: Optional[str] = None
+    """For rerank model, query is required"""
 
 
 class CountTokenRequest(BaseModel):

--- a/dbgpt/rag/embedding/__init__.py
+++ b/dbgpt/rag/embedding/__init__.py
@@ -15,6 +15,7 @@ from .embeddings import (  # noqa: F401
     OllamaEmbeddings,
     OpenAPIEmbeddings,
 )
+from .rerank import CrossEncoderRerankEmbeddings, OpenAPIRerankEmbeddings  # noqa: F401
 
 __ALL__ = [
     "Embeddings",
@@ -28,4 +29,6 @@ __ALL__ = [
     "DefaultEmbeddingFactory",
     "EmbeddingFactory",
     "WrappedEmbeddingFactory",
+    "CrossEncoderRerankEmbeddings",
+    "OpenAPIRerankEmbeddings",
 ]

--- a/dbgpt/rag/embedding/embedding_factory.py
+++ b/dbgpt/rag/embedding/embedding_factory.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Type
 
 from dbgpt.component import BaseComponent, SystemApp
-from dbgpt.core import Embeddings
+from dbgpt.core import Embeddings, RerankEmbeddings
 from dbgpt.core.awel import DAGVar
 from dbgpt.core.awel.flow import ResourceCategory, register_resource
 from dbgpt.util.i18n_utils import _
@@ -31,6 +31,26 @@ class EmbeddingFactory(BaseComponent, ABC):
 
         Returns:
             Embeddings: The embedding instance.
+        """
+
+
+class RerankEmbeddingFactory(BaseComponent, ABC):
+    """Class for RerankEmbeddingFactory."""
+
+    name = "rerank_embedding_factory"
+
+    @abstractmethod
+    def create(
+        self, model_name: Optional[str] = None, embedding_cls: Optional[Type] = None
+    ) -> RerankEmbeddings:
+        """Create an embedding instance.
+
+        Args:
+            model_name (str): The model name.
+            embedding_cls (Type): The embedding class.
+
+        Returns:
+            RerankEmbeddings: The embedding instance.
         """
 
 

--- a/dbgpt/rag/embedding/embeddings.py
+++ b/dbgpt/rag/embedding/embeddings.py
@@ -1,6 +1,5 @@
 """Embedding implementations."""
 
-
 from typing import Any, Dict, List, Optional
 
 import aiohttp

--- a/dbgpt/rag/embedding/rerank.py
+++ b/dbgpt/rag/embedding/rerank.py
@@ -1,0 +1,131 @@
+"""Re-rank embeddings."""
+
+from typing import Any, Dict, List, Optional, cast
+
+import aiohttp
+import requests
+
+from dbgpt._private.pydantic import EXTRA_FORBID, BaseModel, ConfigDict, Field
+from dbgpt.core import RerankEmbeddings
+
+
+class CrossEncoderRerankEmbeddings(BaseModel, RerankEmbeddings):
+    """CrossEncoder Rerank Embeddings."""
+
+    model_config = ConfigDict(extra=EXTRA_FORBID, protected_namespaces=())
+
+    client: Any  #: :meta private:
+    model_name: str = "BAAI/bge-reranker-base"
+    max_length: Optional[int] = None
+    """Max length for input sequences. Longer sequences will be truncated. If None, max
+        length of the model will be used"""
+    """Model name to use."""
+    model_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    """Keyword arguments to pass to the model."""
+
+    def __init__(self, **kwargs: Any):
+        """Initialize the sentence_transformer."""
+        try:
+            from sentence_transformers import CrossEncoder
+        except ImportError:
+            raise ImportError(
+                "please `pip install sentence-transformers`",
+            )
+
+        kwargs["client"] = CrossEncoder(
+            kwargs.get("model_name"),
+            max_length=kwargs.get("max_length"),
+            **kwargs.get("model_kwargs"),
+        )
+        super().__init__(**kwargs)
+
+    def predict(self, query: str, candidates: List[str]) -> List[float]:
+        """Predict the rank scores of the candidates.
+
+        Args:
+            query: The query text.
+            candidates: The list of candidate texts.
+
+        Returns:
+            List[float]: The rank scores of the candidates.
+        """
+        from sentence_transformers import CrossEncoder
+
+        query_content_pairs = [[query, candidate] for candidate in candidates]
+        _model = cast(CrossEncoder, self.client)
+        rank_scores = _model.predict(sentences=query_content_pairs)
+        return rank_scores.tolist()
+
+
+class OpenAPIRerankEmbeddings(BaseModel, RerankEmbeddings):
+    """OpenAPI Rerank Embeddings."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
+
+    api_url: str = Field(
+        default="http://localhost:8100/v1/beta/relevance",
+        description="The URL of the embeddings API.",
+    )
+    api_key: Optional[str] = Field(
+        default=None, description="The API key for the embeddings API."
+    )
+    model_name: str = Field(
+        default="bge-reranker-base", description="The name of the model to use."
+    )
+    timeout: int = Field(
+        default=60, description="The timeout for the request in seconds."
+    )
+
+    session: Optional[requests.Session] = None
+
+    def __init__(self, **kwargs):
+        """Initialize the OpenAPIEmbeddings."""
+        try:
+            import requests
+        except ImportError:
+            raise ValueError(
+                "The requests python package is not installed. "
+                "Please install it with `pip install requests`"
+            )
+        if "session" not in kwargs:  # noqa: SIM401
+            session = requests.Session()
+        else:
+            session = kwargs["session"]
+        api_key = kwargs.get("api_key")
+        if api_key:
+            session.headers.update({"Authorization": f"Bearer {api_key}"})
+        kwargs["session"] = session
+        super().__init__(**kwargs)
+
+    def predict(self, query: str, candidates: List[str]) -> List[float]:
+        """Predict the rank scores of the candidates.
+
+        Args:
+            query: The query text.
+            candidates: The list of candidate texts.
+
+        Returns:
+            List[float]: The rank scores of the candidates.
+        """
+        if not candidates:
+            return []
+        data = {"model": self.model_name, "query": query, "documents": candidates}
+        response = self.session.post(  # type: ignore
+            self.api_url, json=data, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response.json()["data"]
+
+    async def apredict(self, query: str, candidates: List[str]) -> List[float]:
+        """Predict the rank scores of the candidates asynchronously."""
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        async with aiohttp.ClientSession(
+            headers=headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
+        ) as session:
+            data = {"model": self.model_name, "query": query, "documents": candidates}
+            async with session.post(self.api_url, json=data) as resp:
+                resp.raise_for_status()
+                response_data = await resp.json()
+                if "data" not in response_data:
+                    raise RuntimeError(response_data["detail"])
+                return response_data["data"]

--- a/dbgpt/rag/retriever/embedding.py
+++ b/dbgpt/rag/retriever/embedding.py
@@ -1,4 +1,5 @@
 """Embedding retriever."""
+
 from functools import reduce
 from typing import Any, Dict, List, Optional, cast
 
@@ -207,7 +208,7 @@ class EmbeddingRetriever(BaseRetriever):
                 "rerank_cls": self._rerank.__class__.__name__,
             },
         ):
-            new_candidates_with_score = self._rerank.rank(
+            new_candidates_with_score = await self._rerank.arank(
                 new_candidates_with_score, query
             )
             return new_candidates_with_score

--- a/docs/docs/installation/advanced_usage/OpenAI_SDK_call.md
+++ b/docs/docs/installation/advanced_usage/OpenAI_SDK_call.md
@@ -55,7 +55,6 @@ curl http://127.0.0.1:8100/api/v1/embeddings \
 ```
 
 
-
 ## Verify via OpenAI SDK
 
 ```bash
@@ -72,3 +71,49 @@ completion = openai.ChatCompletion.create(
 print(completion.choices[0].message.content)
 ```
 
+## (Experimental) Rerank Open API
+
+The rerank API is an experimental feature that can be used to rerank the candidate list. 
+
+1. Use cURL to verify the rerank API.
+```bash
+curl http://127.0.0.1:8100/api/v1/beta/relevance \
+-H "Authorization: Bearer EMPTY" \
+-H "Content-Type: application/json" \
+-d '{
+    "model": "bge-reranker-base",
+    "query": "what is awel talk about?",
+    "documents": [
+      "Agentic Workflow Expression Language(AWEL) is a set of intelligent agent workflow expression language specially designed for large model application development.",
+      "Autonomous agents have long been a research focus in academic and industry communities",
+      "AWEL is divided into three levels in deign, namely the operator layer, AgentFream layer and DSL layer.",
+      "Elon musk is a famous entrepreneur and inventor, he is the founder of SpaceX and Tesla."
+    ]
+}'
+```
+
+2. Use python to verify the rerank API.
+```python
+from dbgpt.rag.embedding import OpenAPIRerankEmbeddings
+
+rerank = OpenAPIRerankEmbeddings(api_key="EMPTY", model_name="bge-reranker-base")
+rerank.predict(
+    query="what is awel talk about?", 
+    candidates=[
+        "Agentic Workflow Expression Language(AWEL) is a set of intelligent agent workflow expression language specially designed for large model application development.",
+        "Autonomous agents have long been a research focus in academic and industry communities",
+        "AWEL is divided into three levels in deign, namely the operator layer, AgentFream layer and DSL layer.",
+        "Elon musk is a famous entrepreneur and inventor, he is the founder of SpaceX and Tesla."
+    ]
+)
+```
+
+The output is as follows:
+```bash
+[
+ 0.9685816764831543,
+ 3.7338297261158004e-05,
+ 0.03692878410220146,
+ 3.73825132555794e-05
+]
+```

--- a/docs/docs/installation/model_service/cluster.md
+++ b/docs/docs/installation/model_service/cluster.md
@@ -3,21 +3,21 @@
 ## Install command line tools
 All the following operations are completed through the `dbgpt` command. To use the `dbgpt` command, you first need to install the `DB-GPT` project. You can install it through the following command
 
-```python
+```shell
 $ pip install -e ".[default]"
 ```
 It can also be used in script mode
-```python
+```shell
 $ python pilot/scripts/cli_scripts.py
 ```
 
 ## Start Model Controller
-```python
+```shell
 $ dbgpt start controller
 ```
 
 ## View log
-```python
+```shell
 $ docker logs db-gpt-webserver-1 -f
 ```
 By default, `Model Server` will start on port `8000`
@@ -28,7 +28,7 @@ By default, `Model Server` will start on port `8000`
 Start `chatglm2-6b` model Worker
 :::
 
-```python
+```shell
 dbgpt start worker --model_name chatglm2-6b \
 --model_path /app/models/chatglm2-6b \
 --port 8001 \
@@ -40,7 +40,7 @@ dbgpt start worker --model_name chatglm2-6b \
 Start `vicuna-13b-v1.5` model Worker
 :::
 
-```python
+```shell
 dbgpt start worker --model_name vicuna-13b-v1.5 \
 --model_path /app/models/vicuna-13b-v1.5 \
 --port 8002 \
@@ -54,7 +54,7 @@ dbgpt start worker --model_name vicuna-13b-v1.5 \
 
 ## Start Embedding Model Worker
 
-```python
+```shell
 dbgpt start worker --model_name text2vec \
 --model_path /app/models/text2vec-large-chinese \
 --worker_type text2vec \
@@ -68,7 +68,7 @@ dbgpt start worker --model_name text2vec \
 
 ## Start Reranking Model Worker
 
-```python
+```shell
 dbgpt start worker --model_name text2vec \
 --rerank \
 --model_path /app/models/bge-reranker-base \
@@ -86,7 +86,7 @@ View and inspect deployed models
 :::
 
 
-```python
+```shell
 $ dbgpt model list
 
 +-------------------+------------+------------+------+---------+---------+-----------------+----------------------------+
@@ -108,13 +108,13 @@ $ dbgpt model list
 
 The model service deployed as above can be used through dbgpt_server. First modify the `.env` configuration file to change the connection model address
 
-```python
+```shell
 dbgpt start webserver --light
 ```
 
 ## Start Webserver 
 
-```python
+```shell
 LLM_MODEL=vicuna-13b-v1.5
 # The current default MODEL_SERVER address is the address of the Model Controller
 MODEL_SERVER=http://127.0.0.1:8000
@@ -123,7 +123,7 @@ MODEL_SERVER=http://127.0.0.1:8000
 
 
 Or it can be started directly by command to formulate the model.
-```python
+```shell
 LLM_MODEL=chatglm2-6b dbgpt start webserver --light
 ```
 
@@ -135,7 +135,7 @@ For more information about the use of the command line, you can view the command
 View dbgpt help `dbgpt --help`
 :::
 
-```python
+```shell
 dbgpt --help
 
 Already connect 'dbgpt'
@@ -160,7 +160,7 @@ Commands:
 Check the dbgpt start command `dbgpt start --help`
 :::
 
-```python
+```shell
 dbgpt start --help
 
 Already connect 'dbgpt'
@@ -183,7 +183,7 @@ Commands:
 View the dbgpt start model service help command `dbgpt start worker --help`
 :::
 
-```python
+```shell
 dbgpt start worker --help
 
 Already connect 'dbgpt'
@@ -256,7 +256,7 @@ Options:
 View dbgpt model service related commands `dbgpt model --help`
 :::
 
-```python
+```shell
 dbgpt model --help
 
 

--- a/docs/docs/installation/model_service/cluster.md
+++ b/docs/docs/installation/model_service/cluster.md
@@ -52,13 +52,28 @@ dbgpt start worker --model_name vicuna-13b-v1.5 \
 :::
 
 
-## Start the embedding model service
+## Start Embedding Model Worker
 
 ```python
 dbgpt start worker --model_name text2vec \
 --model_path /app/models/text2vec-large-chinese \
 --worker_type text2vec \
 --port 8003 \
+--controller_addr http://127.0.0.1:8000
+```
+:::info note
+⚠️  Make sure to use your own model name and model path.
+
+:::
+
+## Start Reranking Model Worker
+
+```python
+dbgpt start worker --model_name text2vec \
+--rerank \
+--model_path /app/models/bge-reranker-base \
+--worker_type bge-reranker-base \
+--port 8004 \
 --controller_addr http://127.0.0.1:8000
 ```
 :::info note
@@ -74,16 +89,18 @@ View and inspect deployed models
 ```python
 $ dbgpt model list
 
-+-----------------+------------+------------+------+---------+---------+-----------------+----------------------------+
-|    Model Name   | Model Type |    Host    | Port | Healthy | Enabled | Prompt Template |       Last Heartbeat       |
-+-----------------+------------+------------+------+---------+---------+-----------------+----------------------------+
-|   chatglm2-6b   |    llm     | 172.17.0.2 | 8001 |   True  |   True  |                 | 2023-09-12T23:04:31.287654 |
-|  WorkerManager  |  service   | 172.17.0.2 | 8001 |   True  |   True  |                 | 2023-09-12T23:04:31.286668 |
-|  WorkerManager  |  service   | 172.17.0.2 | 8003 |   True  |   True  |                 | 2023-09-12T23:04:29.845617 |
-|  WorkerManager  |  service   | 172.17.0.2 | 8002 |   True  |   True  |                 | 2023-09-12T23:04:24.598439 |
-|     text2vec    |  text2vec  | 172.17.0.2 | 8003 |   True  |   True  |                 | 2023-09-12T23:04:29.844796 |
-| vicuna-13b-v1.5 |    llm     | 172.17.0.2 | 8002 |   True  |   True  |                 | 2023-09-12T23:04:24.597775 |
-+-----------------+------------+------------+------+---------+---------+-----------------+----------------------------+
++-------------------+------------+------------+------+---------+---------+-----------------+----------------------------+
+|    Model Name     | Model Type |    Host    | Port | Healthy | Enabled | Prompt Template |       Last Heartbeat       |
++-------------------+------------+------------+------+---------+---------+-----------------+----------------------------+
+|   chatglm2-6b     |    llm     | 172.17.0.2 | 8001 |   True  |   True  |                 | 2023-09-12T23:04:31.287654 |
+|  WorkerManager    |  service   | 172.17.0.2 | 8001 |   True  |   True  |                 | 2023-09-12T23:04:31.286668 |
+|  WorkerManager    |  service   | 172.17.0.2 | 8003 |   True  |   True  |                 | 2023-09-12T23:04:29.845617 |
+|  WorkerManager    |  service   | 172.17.0.2 | 8002 |   True  |   True  |                 | 2023-09-12T23:04:24.598439 |
+|  WorkerManager    |  service   | 172.21.0.5 | 8004 |   True  |   True  |                 | 2023-09-12T23:04:24.598439 |
+|     text2vec      |  text2vec  | 172.17.0.2 | 8003 |   True  |   True  |                 | 2023-09-12T23:04:29.844796 |
+| vicuna-13b-v1.5   |    llm     | 172.17.0.2 | 8002 |   True  |   True  |                 | 2023-09-12T23:04:24.597775 |
+| bge-reranker-base |  text2vec  | 172.21.0.5 | 8004 |   True  |   True  |                 | 2024-05-15T11:36:12.935012 |
++-------------------+------------+------------+------+---------+---------+-----------------+----------------------------+
 ```
 
 

--- a/docs/docs/installation/model_service/cluster.md
+++ b/docs/docs/installation/model_service/cluster.md
@@ -69,10 +69,10 @@ dbgpt start worker --model_name text2vec \
 ## Start Reranking Model Worker
 
 ```shell
-dbgpt start worker --model_name text2vec \
+dbgpt start worker --worker_type text2vec \
 --rerank \
 --model_path /app/models/bge-reranker-base \
---worker_type bge-reranker-base \
+--model_name bge-reranker-base \
 --port 8004 \
 --controller_addr http://127.0.0.1:8000
 ```

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -14,3 +14,4 @@ types-beautifulsoup4
 types-Markdown
 types-tqdm
 pandas-stubs
+types-psutil


### PR DESCRIPTION
# Description


DB-GPT now supports deploying rerank models in SMMF, also supports deploying in standalone mode.

# How Has This Been Tested?

### Method 1: Deploy rerank when starting DB-GPT webserver.
1. Download the rerank model and put it in the `models` directory.
Here we take the `bge-reranker-base` model as an example.
```shell
cd DB-GPT/models
git clone https://huggingface.co/BAAI/bge-reranker-base
```
2. Modify `.env` file, just like the following:
```shell
## Rerank model
RERANK_MODEL=bge-reranker-base
## If you not set RERANK_MODEL_PATH, DB-GPT will read the model path from EMBEDDING_MODEL_CONFIG based on the RERANK_MODEL.
# RERANK_MODEL_PATH=
## The number of rerank results to return
RERANK_TOP_K=3
```
3. Restart the DB-GPT webserver.
4. Use `Chat Knowledge` to test the rerank model.
If we start a rerank model, it will automatically use the rerank model to rerank the 
results after retrieving the results from the vector store.

### Method 2: Deploy rerank in SMMF.

1. Download the rerank model and put it in the `models` directory.
Here we take the `bge-reranker-base` model as an example.
```shell
cd DB-GPT/models
git clone https://huggingface.co/BAAI/bge-reranker-base
```
2. Start Model Controller.
```shell
dbgpt start controller --port 8000
```
3. Start rerank worker.
```shell
dbgpt start worker --model_name text2vec \
--rerank \
--model_path /app/models/bge-reranker-base \
--worker_type bge-reranker-base \
--port 8004 \
--controller_addr http://127.0.0.1:8000
```
4. Use rerank model in DB-GPT.
Modify the `.env` file, just like the following:
```shell
## Rerank model
RERANK_MODEL=bge-reranker-base
## If you not set RERANK_MODEL_PATH, DB-GPT will read the model path from EMBEDDING_MODEL_CONFIG based on the RERANK_MODEL.
# RERANK_MODEL_PATH=
## The number of rerank results to return
RERANK_TOP_K=3
```
5. Start the DB-GPT webserver
```shell
dbgpt start webserver --remote_rerank
```
6. Use `Chat Knowledge` to test the rerank model.


### Method 3: Use the rerank model through the API of `API Server`.
1. Deploy the rerank model in the cluster as the above method.
2. Start apiserver
```shell
dbgpt start apiserver \
--controller_addr http://127.0.0.1:8000 \
--api_keys EMPTY \
--port 8100
```
3. Use rerank model in DB-GPT.
Modify the `.env` file, just like the following:
```shell
## Common HTTP rerank model
RERANK_MODEL=rerank_proxy_http_openapi
rerank_proxy_http_openapi_proxy_server_url=http://127.0.0.1:8100/api/v1/beta/relevance
rerank_proxy_http_openapi_proxy_api_key=EMPTY
rerank_proxy_http_openapi_proxy_backend=bge-reranker-base
```
4. Start the DB-GPT webserver
5. Use `Chat Knowledge` to test the rerank model.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
