### PR TITLE
fix(model): Stream object can't use await

### DIFF
--- a/dbgpt/model/proxy/llms/moonshot.py
+++ b/dbgpt/model/proxy/llms/moonshot.py
@@ -1,7 +1,10 @@
+import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Optional, Union, cast
 
-from dbgpt.core import ModelRequest, ModelRequestContext
+from openai._streaming import Stream
+
+from dbgpt.core import MessageConverter, ModelOutput, ModelRequest, ModelRequestContext
 from dbgpt.model.proxy.llms.proxy_model import ProxyModel
 
 from .chatgpt import OpenAILLMClient
@@ -13,6 +16,8 @@ if TYPE_CHECKING:
     ClientType = Union[AsyncAzureOpenAI, AsyncOpenAI]
 
 _MOONSHOT_DEFAULT_MODEL = "moonshot-v1-8k"
+
+logger = logging.getLogger(__name__)
 
 
 async def moonshot_generate_stream(
@@ -99,3 +104,26 @@ class MoonshotLLMClient(OpenAILLMClient):
         if not model:
             model = _MOONSHOT_DEFAULT_MODEL
         return model
+
+    async def generate_stream(
+        self,
+        request: ModelRequest,
+        message_converter: Optional[MessageConverter] = None,
+    ) -> AsyncIterator[ModelOutput]:
+        request = self.local_covert_message(request, message_converter)
+        messages = request.to_common_messages()
+        payload = self._build_request(request, stream=True)
+        logger.info(
+            f"Send request to moonshot({self._openai_version}), payload: {payload}\n\n messages:\n{messages}"
+        )
+        chat_completion: Stream = self.client.chat.completions.create(
+            messages=messages, **payload
+        )
+        text = ""
+        for r in chat_completion:
+            if len(r.choices) == 0:
+                continue
+            if r.choices[0].delta.content is not None:
+                content = r.choices[0].delta.content
+                text += content
+                yield ModelOutput(text=text, error_code=0)

--- a/dbgpt/rag/knowledge/url.py
+++ b/dbgpt/rag/knowledge/url.py
@@ -40,7 +40,7 @@ class URLKnowledge(Knowledge):
             from langchain.document_loaders import WebBaseLoader  # mypy: ignore
 
             if self._path is not None:
-                web_reader = WebBaseLoader(web_path=self._path)
+                web_reader = WebBaseLoader(web_path=self._path, encoding="utf8")
                 documents = web_reader.load()
             else:
                 # Handle the case where self._path is None


### PR DESCRIPTION
# Description
1. moonshot proxy api port call fails because the returned object is a Stream and can't be awaited. 

2. The knowledge base loads below URL will be garbled
https://mp.weixin.qq.com/s?__biz=MzU3MjE2MzY4OA==&mid=2247488988&idx=1&sn=2f0863dd2f1598b6341f7576697e379f&chksm=fcd446dbcba3cfcd017d8053cb1a83b7525e4c0940f71751ad50a577f858f450047683529c3f&scene=27
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/5dd2ca32-b1f0-48ab-8c2f-8eea3b598b8d">

# How Has This Been Tested?
1. After
<img width="768" alt="image" src="https://github.com/user-attachments/assets/7cc997d4-61bd-485d-9b7f-fec2b61f3223">

2. After
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/72220c35-f516-41bb-b46f-c32d916946c0">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
