### PR TITLE
bugfix:fix table scroll bug

### DIFF
--- a/web/components/chat/chat-content/config.tsx
+++ b/web/components/chat/chat-content/config.tsx
@@ -233,7 +233,7 @@ const extraComponents: MarkdownComponent = {
     const DataItem = {
       key: 'data',
       label: 'Data',
-      children: <Table dataSource={data?.data} columns={columns} />,
+      children: <Table dataSource={data?.data} columns={columns}  scroll={{x:true}} />,
     };
     const TabItems: TabsProps['items'] = data?.type === 'response_table' ? [DataItem, SqlItem] : [ChartItem, SqlItem, DataItem];
 


### PR DESCRIPTION
# Description

chat-data等场景以表格形式展示时，会存在表格宽度超过页面宽度的情况，此前的代码逻辑中未对该情况进行适配，导致表格显示不全，因此修改部分前端样式以修复该情况，当表格宽度溢出时会自动添加滚动条，可进行左右滑动，可解决表格显示不全的问题

# How Has This Been Tested?

启动修改后的前端代码和后端代码，创建测试数据库，利用chat-data场景查询一张宽表，结果符合预期。由于改动非常简单，并无特殊测试配置

# Snapshots:
![修改后](https://github.com/user-attachments/assets/b676f50b-6d28-401b-89cb-6bee9dfb6b3d)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
