### PR TITLE
fix: 解决创建tugraph的无效子图命名问题

### DIFF
--- a/dbgpt/app/knowledge/service.py
+++ b/dbgpt/app/knowledge/service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from datetime import datetime
 
 from dbgpt._private.config import Config
@@ -79,6 +80,12 @@ class KnowledgeService:
         )
         if request.vector_type == "VectorStore":
             request.vector_type = CFG.VECTOR_STORE_TYPE
+        if request.vector_type == 'KnowledgeGraph':
+            knowledge_space_name_pattern = r'^[a-zA-Z0-9\u4e00-\u9fa5]+$'
+            if re.match(knowledge_space_name_pattern, request.name):
+                return True
+            else:
+                raise Exception(f"space name:{request.name} invalid")
         spaces = knowledge_space_dao.get_knowledge_space(query)
         if len(spaces) > 0:
             raise Exception(f"space name:{request.name} have already named")


### PR DESCRIPTION
description: 使用 tugraph 时，前端的命名约束中会允许 "-" , 但在 tugraph 中此类命名是不允许的，会出现创建失败的问题；连带会错误创建已有知识库并且无法删除。


![image](https://github.com/user-attachments/assets/7773e3f5-9fab-49e0-86b0-d313690f71da)
![image](https://github.com/user-attachments/assets/08e24bd4-64c2-49f9-9813-d427e1a6eea0)
![image](https://github.com/user-attachments/assets/49eb6e75-c47e-437c-851c-e5f0cde3ad59)
