### PR TITLE
fix(chat knowledge): add missing context property

### DIFF
--- a/dbgpt/serve/rag/models/models.py
+++ b/dbgpt/serve/rag/models/models.py
@@ -158,4 +158,5 @@ class KnowledgeSpaceDao(BaseDao):
             vector_type=entity.vector_type,
             desc=entity.desc,
             owner=entity.owner,
+            context=entity.context,
         )


### PR DESCRIPTION
# Description
Missing `context` attribute prevents knowledge base configuration from taking effect.

# Snapshots:
<img width="834" alt="image" src="https://github.com/user-attachments/assets/180bc6f6-2f26-464f-a6d7-c5c0bdd34ef5">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
