### PR TITLE
fix: Fix knowledge api report error when call create space api

### DIFF
--- a/dbgpt/client/schema.py
+++ b/dbgpt/client/schema.py
@@ -222,7 +222,7 @@ class AppModel(BaseModel):
 class SpaceModel(BaseModel):
     """Space model."""
 
-    id: str = Field(
+    id: int = Field(
         default=None,
         description="space id",
     )


### PR DESCRIPTION
Closes #1783

# Description

Fix space id error type. Id type should be int not str

![image](https://github.com/user-attachments/assets/943a8b68-484a-4d3f-a018-38dc0a56772e)

 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
