### PR TITLE
fix: Fix can't read the milvus url config

### DIFF
--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -98,7 +98,7 @@ class MilvusVectorConfig(VectorStoreConfig):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    uri: str = Field(
+    uri: Optional[str] = Field(
         default=None,
         description="The uri of milvus store, if not set, will use the default uri.",
     )

--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
                 "The uri of milvus store, if not set, will use the default " "uri."
             ),
             optional=True,
-            default="localhost",
+            default=None,
         ),
         Parameter.build_from(
             _("Port"),
@@ -99,7 +99,7 @@ class MilvusVectorConfig(VectorStoreConfig):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     uri: str = Field(
-        default="localhost",
+        default=None,
         description="The uri of milvus store, if not set, will use the default uri.",
     )
     port: str = Field(


### PR DESCRIPTION
Close issue #1785 
# Description

fix issue1785

# How Has This Been Tested?

set .env `VECTOR_STORE_TYPE=Milvus`

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
