### PR TITLE
fix: postgresql read schema_info with characters truncated if too long

### DIFF
--- a/dbgpt/datasource/rdbms/conn_postgresql.py
+++ b/dbgpt/datasource/rdbms/conn_postgresql.py
@@ -192,7 +192,10 @@ class PostgreSQLConnector(RDBMSConnector):
             """
         cursor = self.session.execute(text(_sql))
         results = cursor.fetchall()
-        return results
+        results_str = []
+        for result in results:
+            results_str.append((str(result[0]), str(result[1])))
+        return results_str
 
     def get_fields_wit_schema(self, table_name, schema_name="public"):
         """Get column fields about specified table."""


### PR DESCRIPTION
# Description

当使用postgresql数据库时，当读取表的字段较多时，这时使用sqlalchemy读取后并转为字符串后，会出现中间部分字段被”characters truncated“现象。debug查看变量发现，所有字段是都在的，只不过在加入大模型的prompt模板时，自动的toString功能会自动进行truncated。改问题记录在 [1426](https://github.com/eosphoros-ai/DB-GPT/issues/1426)

# How Has This Been Tested?

使用postgresql数据库，并设计一个超过30个字段的表，且每个字段名称的长度约大于10个字符。这时，如果在chat dashboard时，生成的prompt中会发现有中间部分的字段名称被”characters truncated“了。更新本代码后，问题解决。

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
