### PR TITLE
fix(ChatKnowledge):full text storage truncate method error.

### DIFF
--- a/dbgpt/storage/full_text/base.py
+++ b/dbgpt/storage/full_text/base.py
@@ -67,3 +67,7 @@ class FullTextStoreBase(IndexStoreBase):
 
     def delete_vector_name(self, index_name: str):
         """Delete name."""
+
+    def truncate(self) -> List[str]:
+        """Truncate the collection."""
+        raise NotImplementedError

--- a/dbgpt/storage/vector_store/base.py
+++ b/dbgpt/storage/vector_store/base.py
@@ -187,3 +187,7 @@ class VectorStoreBase(IndexStoreBase, ABC):
             List[str]: chunk ids.
         """
         return await blocking_func_to_async(self._executor, self.load_document, chunks)
+
+    def truncate(self) -> List[str]:
+        """Truncate the collection."""
+        raise NotImplementedError


### PR DESCRIPTION
Close #1990 
# Description

full text storage truncate method error.

# How Has This Been Tested?

chat knowledge with full text

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
