### PR TITLE
fix(docs): Fix build doc image error

### DIFF
--- a/docs/Dockerfile-deploy.dockerignore
+++ b/docs/Dockerfile-deploy.dockerignore
@@ -1,0 +1,15 @@
+.env
+./.mypy_cache/
+models/
+plugins/
+pilot/data
+pilot/message
+logs/
+venv/
+web/node_modules/
+web/.next/
+web/.env
+docs/node_modules/
+build/
+docs/build/
+docs/Dockerfile-deploy


### PR DESCRIPTION
# Description

Fix build doc image error.

# How Has This Been Tested?

```bash
# Use the default NPM_REGISTRY=https://registry.npmjs.org
# Use https://www.npmmirror.com/
NPM_REGISTRY=https://registry.npmmirror.com
docker build -f docs/Dockerfile-deploy \
-t eosphorosai/dbgpt-docs \
--build-arg NPM_REGISTRY=$NPM_REGISTRY \
--build-arg CI=false \
--build-arg NUM_VERSION=2 .
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
