### PR TITLE
fix bug - Tongyiproxy embedding model error

### DIFF
--- a/dbgpt/rag/embedding/embeddings.py
+++ b/dbgpt/rag/embedding/embeddings.py
@@ -888,12 +888,17 @@ class TongYiEmbeddings(BaseModel, Embeddings):
         super().__init__(**kwargs)
         self._api_key = kwargs.get("api_key")
 
-
-    def embed_documents(self, texts: List[str], max_batch_chunks_size=25) -> List[List[float]]:
+    def embed_documents(
+        self, texts: List[str], max_batch_chunks_size=25
+    ) -> List[List[float]]:
         """Get the embeddings for a list of texts.
+
+        refer:https://help.aliyun.com/zh/model-studio/getting-started/models?
+        spm=a2c4g.11186623.0.0.62524a77NlILDI#c05fe72732770
 
         Args:
             texts (Documents): A list of texts to get embeddings for.
+            max_batch_chunks_size: The max batch size for embedding.
 
         Returns:
             Embedded texts as List[List[float]], where each inner List[float]
@@ -902,13 +907,14 @@ class TongYiEmbeddings(BaseModel, Embeddings):
         from dashscope import TextEmbedding
 
         embeddings = []
-        # batch size too longer may cause embedding error,eg: qwen online embedding models must not be larger than 25
+        # batch size too longer may cause embedding error,eg: qwen online embedding
+        # models must not be larger than 25
         # text-embedding-v3  embedding batch size should not be larger than 6
         if str(self.model_name) == "text-embedding-v3":
             max_batch_chunks_size = 6
 
         for i in range(0, len(texts), max_batch_chunks_size):
-            batch_texts = texts[i:i + max_batch_chunks_size]
+            batch_texts = texts[i : i + max_batch_chunks_size]
             resp = TextEmbedding.call(
                 model=self.model_name, input=batch_texts, api_key=self._api_key
             )

--- a/dbgpt/rag/embedding/embeddings.py
+++ b/dbgpt/rag/embedding/embeddings.py
@@ -902,13 +902,17 @@ class TongYiEmbeddings(BaseModel, Embeddings):
         from dashscope import TextEmbedding
 
         embeddings = []
-
         # batch size too longer may cause embedding error,eg: qwen online embedding models must not be larger than 25
+        # text-embedding-v3  embedding batch size should not be larger than 6
+        if str(self.model_name) == "text-embedding-v3":
+            max_batch_chunks_size = 6
+
         for i in range(0, len(texts), max_batch_chunks_size):
             batch_texts = texts[i:i + max_batch_chunks_size]
             resp = TextEmbedding.call(
                 model=self.model_name, input=batch_texts, api_key=self._api_key
             )
+            print(resp)
             if "output" not in resp:
                 raise RuntimeError(resp["message"])
 

--- a/dbgpt/rag/embedding/embeddings.py
+++ b/dbgpt/rag/embedding/embeddings.py
@@ -912,7 +912,6 @@ class TongYiEmbeddings(BaseModel, Embeddings):
             resp = TextEmbedding.call(
                 model=self.model_name, input=batch_texts, api_key=self._api_key
             )
-            print(resp)
             if "output" not in resp:
                 raise RuntimeError(resp["message"])
 


### PR DESCRIPTION
 #  raw issues: 
 https://github.com/eosphoros-ai/DB-GPT/issues/1748 
 
 #  why cause this bug:batch size too longer may cause embedding error
  qwen online embedding models must not be larger than 25 
  
 #  error detail:
  {"status_code": 400, "request_id": "cabd7ddb-386c- 9a25-a488-94fb05b4f8b8", "code": "InvalidParameter", "message": "batch size is invalid, it should not be larger than 25.: payload.input.contents", "output": null, "usage": null}
  
  # how to solve this issue
  data   streaming processing
  
#  How Has This Been Tested?
Use tongyi embedding: text-embedding-v1
Start DB-GPT and pass in the pdf file for parsing





