### PR TITLE
fix(model): Fix  vllm inference error

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,1 @@
+print("demo")

--- a/demo.py
+++ b/demo.py
@@ -1,1 +1,2 @@
+print("demo1")
 print("demo")

--- a/demo.py
+++ b/demo.py
@@ -1,2 +1,0 @@
-print("demo1")
-print("demo")


### PR DESCRIPTION
Fix the default parameter configuration error when starting the `vllm` inference framework

[Bug]vllm error，ValueError: mutable default <class 'list'> for field ignore_patterns is not allowed: use default_factory

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
