### PR TITLE
fix: Fix long message response error

### DIFF
--- a/assets/schema/dbgpt.sql
+++ b/assets/schema/dbgpt.sql
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS `chat_history_message`
     `conv_uid`       varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Conversation record unique id',
     `index`          int                                     NOT NULL COMMENT 'Message index',
     `round_index`    int                                     NOT NULL COMMENT 'Round of conversation',
-    `message_detail` text COLLATE utf8mb4_unicode_ci COMMENT 'Message details, json format',
+    `message_detail` longtext COLLATE utf8mb4_unicode_ci COMMENT 'Message details, json format',
     `gmt_created`  timestamp NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'created time',
     `gmt_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'update time',
     UNIQUE KEY `message_uid_index` (`conv_uid`, `index`),


### PR DESCRIPTION
# Description

When I chat with a large database, the LLM will response a large content. The pymysql will feedback this error message: Data too long for column 'message_detail' at row 1.
This PR change the type of message_detail from text to longtext. 

# How Has This Been Tested?

Reproduct that case I wrote before, the bug has been fix.

# Snapshots:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
