### PR TITLE
Fixed the error caused by file format when docx loading files

### DIFF
--- a/dbgpt/rag/knowledge/docx.py
+++ b/dbgpt/rag/knowledge/docx.py
@@ -15,32 +15,31 @@ from dbgpt.rag.knowledge.base import (
 
 
 def load_from_xml_v2(base_uri, rels_item_xml):
+    """Return |_SerializedRelationships| instance loaded with the relationships.
+
+    contained in *rels_item_xml*.collection if *rels_item_xml* is |None|.
     """
-    Return |_SerializedRelationships| instance loaded with the
-    relationships contained in *rels_item_xml*. Returns an empty
-    collection if *rels_item_xml* is |None|.
-    """
-    serial_rels = _SerializedRelationships()
+    srels = _SerializedRelationships()
     if rels_item_xml is not None:
         rels_elm = parse_xml(rels_item_xml)
         for rel_elm in rels_elm.Relationship_lst:
-            if rel_elm.target_ref in ('../NULL', 'NULL'):
+            if rel_elm.target_ref in ("../NULL", "NULL"):
                 continue
-            serial_rels.srels.append(_SerializedRelationship(base_uri, rel_elm))
-    return serial_rels
+            srels._srels.append(_SerializedRelationship(base_uri, rel_elm))
+    return srels
 
 
 class DocxKnowledge(Knowledge):
     """Docx Knowledge."""
 
     def __init__(
-            self,
-            file_path: Optional[str] = None,
-            knowledge_type: Any = KnowledgeType.DOCUMENT,
-            encoding: Optional[str] = "utf-8",
-            loader: Optional[Any] = None,
-            metadata: Optional[Dict[str, Union[str, List[str]]]] = None,
-            **kwargs: Any,
+        self,
+        file_path: Optional[str] = None,
+        knowledge_type: Any = KnowledgeType.DOCUMENT,
+        encoding: Optional[str] = "utf-8",
+        loader: Optional[Any] = None,
+        metadata: Optional[Dict[str, Union[str, List[str]]]] = None,
+        **kwargs: Any,
     ) -> None:
         """Create Docx Knowledge with Knowledge arguments.
 

--- a/dbgpt/rag/knowledge/docx.py
+++ b/dbgpt/rag/knowledge/docx.py
@@ -1,5 +1,7 @@
 """Docx Knowledge."""
 from typing import Any, Dict, List, Optional, Union
+from docx.opc.pkgreader import _SerializedRelationships, _SerializedRelationship
+from docx.opc.oxml import parse_xml
 
 import docx
 
@@ -12,17 +14,33 @@ from dbgpt.rag.knowledge.base import (
 )
 
 
+def load_from_xml_v2(baseURI, rels_item_xml):
+    """
+    Return |_SerializedRelationships| instance loaded with the
+    relationships contained in *rels_item_xml*. Returns an empty
+    collection if *rels_item_xml* is |None|.
+    """
+    srels = _SerializedRelationships()
+    if rels_item_xml is not None:
+        rels_elm = parse_xml(rels_item_xml)
+        for rel_elm in rels_elm.Relationship_lst:
+            if rel_elm.target_ref in ('../NULL', 'NULL'):
+                continue
+            srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
+    return srels
+
+
 class DocxKnowledge(Knowledge):
     """Docx Knowledge."""
 
     def __init__(
-        self,
-        file_path: Optional[str] = None,
-        knowledge_type: Any = KnowledgeType.DOCUMENT,
-        encoding: Optional[str] = "utf-8",
-        loader: Optional[Any] = None,
-        metadata: Optional[Dict[str, Union[str, List[str]]]] = None,
-        **kwargs: Any,
+            self,
+            file_path: Optional[str] = None,
+            knowledge_type: Any = KnowledgeType.DOCUMENT,
+            encoding: Optional[str] = "utf-8",
+            loader: Optional[Any] = None,
+            metadata: Optional[Dict[str, Union[str, List[str]]]] = None,
+            **kwargs: Any,
     ) -> None:
         """Create Docx Knowledge with Knowledge arguments.
 
@@ -47,8 +65,10 @@ class DocxKnowledge(Knowledge):
             documents = self._loader.load()
         else:
             docs = []
+            _SerializedRelationships.load_from_xml = load_from_xml_v2
             doc = docx.Document(self._path)
             content = []
+
             for i in range(len(doc.paragraphs)):
                 para = doc.paragraphs[i]
                 text = para.text

--- a/dbgpt/rag/knowledge/docx.py
+++ b/dbgpt/rag/knowledge/docx.py
@@ -64,7 +64,7 @@ class DocxKnowledge(Knowledge):
             documents = self._loader.load()
         else:
             docs = []
-            _SerializedRelationships.load_from_xml = load_from_xml_v2
+            _SerializedRelationships.load_from_xml = load_from_xml_v2   # type: ignore
             doc = docx.Document(self._path)
             content = []
 

--- a/dbgpt/rag/knowledge/docx.py
+++ b/dbgpt/rag/knowledge/docx.py
@@ -1,9 +1,9 @@
 """Docx Knowledge."""
 from typing import Any, Dict, List, Optional, Union
-from docx.opc.pkgreader import _SerializedRelationships, _SerializedRelationship
-from docx.opc.oxml import parse_xml
 
 import docx
+from docx.opc.oxml import parse_xml
+from docx.opc.pkgreader import _SerializedRelationship, _SerializedRelationships
 
 from dbgpt.core import Document
 from dbgpt.rag.knowledge.base import (
@@ -14,20 +14,20 @@ from dbgpt.rag.knowledge.base import (
 )
 
 
-def load_from_xml_v2(baseURI, rels_item_xml):
+def load_from_xml_v2(base_uri, rels_item_xml):
     """
     Return |_SerializedRelationships| instance loaded with the
     relationships contained in *rels_item_xml*. Returns an empty
     collection if *rels_item_xml* is |None|.
     """
-    srels = _SerializedRelationships()
+    serial_rels = _SerializedRelationships()
     if rels_item_xml is not None:
         rels_elm = parse_xml(rels_item_xml)
         for rel_elm in rels_elm.Relationship_lst:
             if rel_elm.target_ref in ('../NULL', 'NULL'):
                 continue
-            srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
-    return srels
+            serial_rels.srels.append(_SerializedRelationship(base_uri, rel_elm))
+    return serial_rels
 
 
 class DocxKnowledge(Knowledge):


### PR DESCRIPTION
# Description
When uploading a doc file to the knowledge base, docx will occur an error when loading a file with a specific format. The reason is that docx does not parse the file element correctly and returns a null value.

The error message is :
> 2024-10-12 15:00:56 | ERROR | dbgpt.serve.rag.service.service | document embedding, failed:海外市场相关研究-补充材料.docx, "There is no item named 'NULL' in the archive"

sample file:
[海外市场相关研究-补充材料.docx](https://github.com/user-attachments/files/17349141/-.docx)

sample code:
```python
import docx
from docx.document import Document

doc = docx.Document('/Users/zhaoyu/Desktop/海外市场相关研究-补充材料.docx')
```

# How To Fix
[This problem has been solved in the docx issues on the git](https://github.com/python-openxml/python-docx/issues/1105)
We just need to rewrite the load_from_xml_v2 method, and when the target element to be parsed is NULL, do not throw an exception and continue parsing.
This method allows users to upload doc files in a specific format without being bothered by errors.
