### PR TITLE
feat: Enhance the triplets extraction in the knowledge graph by the batch size

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -167,7 +167,7 @@ TRIPLET_GRAPH_ENABLED=True  # enable the graph search for triplets
 DOCUMENT_GRAPH_ENABLED=True  # enable the graph search for documents and chunks
 
 KNOWLEDGE_GRAPH_CHUNK_SEARCH_TOP_SIZE=5  # the top size of knowledge graph search for chunks
-TRIPLET_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
+KNOWLEDGE_GRAPH_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
 
 ### Chroma vector db config
 #CHROMA_PERSIST_PATH=/root/DB-GPT/pilot/data

--- a/.env.template
+++ b/.env.template
@@ -167,6 +167,7 @@ TRIPLET_GRAPH_ENABLED=True  # enable the graph search for triplets
 DOCUMENT_GRAPH_ENABLED=True  # enable the graph search for documents and chunks
 
 KNOWLEDGE_GRAPH_CHUNK_SEARCH_TOP_SIZE=5  # the top size of knowledge graph search for chunks
+TRIPLET_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
 
 ### Chroma vector db config
 #CHROMA_PERSIST_PATH=/root/DB-GPT/pilot/data

--- a/dbgpt/rag/transformer/base.py
+++ b/dbgpt/rag/transformer/base.py
@@ -2,9 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
-
-from dbgpt.core import Chunk
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +41,7 @@ class ExtractorBase(TransformerBase, ABC):
     @abstractmethod
     async def batch_extract(
         self,
-        texts: Union[List[str], List[Chunk]],
+        texts: List[str],
         batch_size: int = 1,
         limit: Optional[int] = None,
     ) -> List:

--- a/dbgpt/rag/transformer/base.py
+++ b/dbgpt/rag/transformer/base.py
@@ -1,7 +1,10 @@
 """Transformer base class."""
+
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Union
+
+from dbgpt.core import Chunk
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +39,15 @@ class ExtractorBase(TransformerBase, ABC):
     @abstractmethod
     async def extract(self, text: str, limit: Optional[int] = None) -> List:
         """Extract results from text."""
+
+    @abstractmethod
+    async def batch_extract(
+        self,
+        texts: Union[List[str], List[Chunk]],
+        batch_size: int = 1,
+        limit: Optional[int] = None,
+    ) -> List:
+        """Batch extract results from texts."""
 
 
 class TranslatorBase(TransformerBase, ABC):

--- a/dbgpt/rag/transformer/llm_extractor.py
+++ b/dbgpt/rag/transformer/llm_extractor.py
@@ -31,6 +31,9 @@ class LLMExtractor(ExtractorBase, ABC):
         limit: Optional[int] = None,
     ) -> List:
         """Batch extract by LLM."""
+        if batch_size < 1:
+            raise ValueError("batch_size >= 1")
+
         results = []
 
         for i in range(0, len(texts), batch_size):

--- a/dbgpt/rag/transformer/triplet_extractor.py
+++ b/dbgpt/rag/transformer/triplet_extractor.py
@@ -1,4 +1,5 @@
 """TripletExtractor class."""
+
 import logging
 import re
 from typing import Any, List, Optional, Tuple
@@ -12,7 +13,7 @@ TRIPLET_EXTRACT_PT = (
     "Some text is provided below. Given the text, "
     "extract up to knowledge triplets as more as possible "
     "in the form of (subject, predicate, object).\n"
-    "Avoid stopwords.\n"
+    "Avoid stopwords. The subject, predicate, object can not be none.\n"
     "---------------------\n"
     "Example:\n"
     "Text: Alice is Bob's mother.\n"

--- a/dbgpt/storage/graph_store/base.py
+++ b/dbgpt/storage/graph_store/base.py
@@ -27,14 +27,6 @@ class GraphStoreConfig(BaseModel):
         default=False,
         description="Enable graph community summary or not.",
     )
-    document_graph_enabled: bool = Field(
-        default=True,
-        description="Enable document graph search or not.",
-    )
-    triplet_graph_enabled: bool = Field(
-        default=True,
-        description="Enable knowledge graph search or not.",
-    )
 
 
 class GraphStoreBase(ABC):

--- a/dbgpt/storage/graph_store/tugraph_store.py
+++ b/dbgpt/storage/graph_store/tugraph_store.py
@@ -83,14 +83,6 @@ class TuGraphStore(GraphStoreBase):
             os.getenv("GRAPH_COMMUNITY_SUMMARY_ENABLED", "").lower() == "true"
             or config.enable_summary
         )
-        self._enable_document_graph = (
-            os.getenv("DOCUMENT_GRAPH_ENABLED", "").lower() == "true"
-            or config.document_graph_enabled
-        )
-        self._enable_triplet_graph = (
-            os.getenv("TRIPLET_GRAPH_ENABLED", "").lower() == "true"
-            or config.triplet_graph_enabled
-        )
         self._plugin_names = (
             os.getenv("TUGRAPH_PLUGIN_NAMES", "leiden").split(",")
             or config.plugin_names

--- a/dbgpt/storage/knowledge_graph/community/tugraph_store_adapter.py
+++ b/dbgpt/storage/knowledge_graph/community/tugraph_store_adapter.py
@@ -728,7 +728,7 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
         from neo4j import graph
 
         def filter_properties(
-            properties: dict[str, Any], white_list: List[str] = None
+            properties: dict[str, Any], white_list: Optional[List[str]] = None
         ) -> Dict[str, Any]:
             """Filter the properties.
 

--- a/dbgpt/storage/knowledge_graph/community/tugraph_store_adapter.py
+++ b/dbgpt/storage/knowledge_graph/community/tugraph_store_adapter.py
@@ -465,12 +465,14 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
         (vertices) and edges in the graph.
         """
         if graph_elem_type.is_vertex():  # vertex
-            data = json.dumps({
-                "label": graph_elem_type.value,
-                "type": "VERTEX",
-                "primary": "id",
-                "properties": graph_properties,
-            })
+            data = json.dumps(
+                {
+                    "label": graph_elem_type.value,
+                    "type": "VERTEX",
+                    "primary": "id",
+                    "properties": graph_properties,
+                }
+            )
             gql = f"""CALL db.createVertexLabelByJson('{data}')"""
         else:  # edge
 
@@ -496,12 +498,14 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
                 else:
                     raise ValueError("Invalid graph element type.")
 
-            data = json.dumps({
-                "label": graph_elem_type.value,
-                "type": "EDGE",
-                "constraints": edge_direction(graph_elem_type),
-                "properties": graph_properties,
-            })
+            data = json.dumps(
+                {
+                    "label": graph_elem_type.value,
+                    "type": "EDGE",
+                    "constraints": edge_direction(graph_elem_type),
+                    "properties": graph_properties,
+                }
+            )
             gql = f"""CALL db.createEdgeLabelByJson('{data}')"""
 
         self.graph_store.conn.run(gql)
@@ -577,11 +581,13 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
                 chain_query = (
                     f"MATCH p=(n:{GraphElemType.DOCUMENT.value})-"
                     f"[:{GraphElemType.INCLUDE.value}*1..{depth + 1}]->"
-                    f"(leaf_chunk:{GraphElemType.CHUNK.value})-[:{GraphElemType.INCLUDE.value}]->"
+                    f"(leaf_chunk:{GraphElemType.CHUNK.value})-"
+                    f"[:{GraphElemType.INCLUDE.value}]->"
                     f"(m:{GraphElemType.ENTITY.value}) "
                     f"WHERE m.name IN {[self._escape_quotes(sub) for sub in subs]} "
                     # "WITH n, leaf_chunk "
-                    # f"MATCH p = (n)-[:{GraphElemType.INCLUDE.value}*1..{depth}]->(leaf_chunk:{GraphElemType.CHUNK.value}) "
+                    # f"MATCH p = (n)-[:{GraphElemType.INCLUDE.value}*1..{depth}]->"
+                    # f"(leaf_chunk:{GraphElemType.CHUNK.value}) "
                     "RETURN p"
                 )
                 # Filter all the properties by with_list
@@ -599,9 +605,9 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
                     self.query(query=leaf_chunk_query, white_list=["content"])
                 )
             else:
-                _subs_condition = " OR ".join([
-                    f"m.content CONTAINS '{self._escape_quotes(sub)}'" for sub in subs
-                ])
+                _subs_condition = " OR ".join(
+                    [f"m.content CONTAINS '{self._escape_quotes(sub)}'" for sub in subs]
+                )
 
                 # Query the chain from documents to chunks,
                 # document -> chunk -> chunk -> chunk -> ... -> chunk
@@ -693,15 +699,19 @@ class TuGraphStoreAdapter(GraphStoreAdapter):
                     rels = list(record["p"].relationships)
                     formatted_path = []
                     for i in range(len(nodes)):
-                        formatted_path.append({
-                            "id": nodes[i]._properties["id"],
-                            "description": nodes[i]._properties["description"],
-                        })
+                        formatted_path.append(
+                            {
+                                "id": nodes[i]._properties["id"],
+                                "description": nodes[i]._properties["description"],
+                            }
+                        )
                         if i < len(rels):
-                            formatted_path.append({
-                                "id": rels[i]._properties["id"],
-                                "description": rels[i]._properties["description"],
-                            })
+                            formatted_path.append(
+                                {
+                                    "id": rels[i]._properties["id"],
+                                    "description": rels[i]._properties["description"],
+                                }
+                            )
                     for i in range(0, len(formatted_path), 2):
                         mg.upsert_vertex(
                             Vertex(

--- a/dbgpt/storage/knowledge_graph/community_summary.py
+++ b/dbgpt/storage/knowledge_graph/community_summary.py
@@ -393,7 +393,7 @@ class CommunitySummaryKnowledgeGraph(BuiltinKnowledgeGraph):
 
 HYBRID_SEARCH_PT = """
 =====
-[Context]、[Knowledge Graph]和[Original Text From RAG]的信息，可以帮助你回答更好地用户的问题。
+The following information from [Context], [Knowledge Graph], and [Original Text From RAG] can help you answer user questions better.
 
 [Context]:
 {context}

--- a/dbgpt/storage/knowledge_graph/community_summary.py
+++ b/dbgpt/storage/knowledge_graph/community_summary.py
@@ -9,7 +9,6 @@ from dbgpt._private.pydantic import ConfigDict, Field
 from dbgpt.core import Chunk
 from dbgpt.rag.transformer.community_summarizer import CommunitySummarizer
 from dbgpt.rag.transformer.graph_extractor import GraphExtractor
-from dbgpt.storage.graph_store.graph import MemoryGraph
 from dbgpt.storage.knowledge_graph.base import ParagraphChunk
 from dbgpt.storage.knowledge_graph.community.community_store import CommunityStore
 from dbgpt.storage.knowledge_graph.knowledge_graph import (
@@ -334,7 +333,7 @@ class CommunitySummaryKnowledgeGraph(BuiltinKnowledgeGraph):
         document_graph_enabled = self._document_graph_enabled
 
         if triplet_graph_enabled:
-            subgraph: MemoryGraph = self._graph_store_apdater.explore(
+            subgraph = self._graph_store_apdater.explore(
                 subs=keywords, limit=topk, search_scope="knowledge_graph"
             )
 

--- a/dbgpt/storage/knowledge_graph/community_summary.py
+++ b/dbgpt/storage/knowledge_graph/community_summary.py
@@ -108,19 +108,15 @@ class CommunitySummaryKnowledgeGraph(BuiltinKnowledgeGraph):
                 config.community_score_threshold,
             )
         )
-        self._document_graph_enabled = bool(
-            (
-                os.environ["DOCUMENT_GRAPH_ENABLED"].lower() == "true"
-                if "DOCUMENT_GRAPH_ENABLED" in os.environ
-                else config.document_graph_enabled
-            )
+        self._document_graph_enabled = (
+            os.environ["DOCUMENT_GRAPH_ENABLED"].lower() == "true"
+            if "DOCUMENT_GRAPH_ENABLED" in os.environ
+            else config.document_graph_enabled
         )
-        self._triplet_graph_enabled = bool(
-            (
-                os.environ["TRIPLET_GRAPH_ENABLED"].lower() == "true"
-                if "TRIPLET_GRAPH_ENABLED" in os.environ
-                else config.triplet_graph_enabled
-            )
+        self._triplet_graph_enabled = (
+            os.environ["TRIPLET_GRAPH_ENABLED"].lower() == "true"
+            if "TRIPLET_GRAPH_ENABLED" in os.environ
+            else config.triplet_graph_enabled
         )
         self._knowledge_graph_chunk_search_top_size = int(
             os.getenv(

--- a/dbgpt/storage/knowledge_graph/community_summary.py
+++ b/dbgpt/storage/knowledge_graph/community_summary.py
@@ -450,7 +450,7 @@ answering the user's questions accurately and appropriately, and ensuring that n
 - Support with specific references to sources
 - Include relevant entity-relationship pairs
 - Conclude with confidence assessment
-- Use the markdown format of the "quote" to highlight the original text from "GraphRAG"
+- Use the markdown format of the "quote" to highlight the original text (in details) from "GraphRAG"
 
 =====
 """  # noqa: E501

--- a/docs/docs/cookbook/rag/graph_rag_app_develop.md
+++ b/docs/docs/cookbook/rag/graph_rag_app_develop.md
@@ -116,7 +116,7 @@ GRAPH_COMMUNITY_SUMMARY_ENABLED=True  # enable the graph community summary
 TRIPLET_GRAPH_ENABLED=True  # enable the graph search for the triplets
 DOCUMENT_GRAPH_ENABLED=True  # enable the graph search for documents and chunks
 KNOWLEDGE_GRAPH_CHUNK_SEARCH_TOP_SIZE=5  # the number of the searched triplets in a retrieval
-TRIPLET_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
+KNOWLEDGE_GRAPH_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
 ```
 
 

--- a/docs/docs/cookbook/rag/graph_rag_app_develop.md
+++ b/docs/docs/cookbook/rag/graph_rag_app_develop.md
@@ -116,6 +116,7 @@ GRAPH_COMMUNITY_SUMMARY_ENABLED=True  # enable the graph community summary
 TRIPLET_GRAPH_ENABLED=True  # enable the graph search for the triplets
 DOCUMENT_GRAPH_ENABLED=True  # enable the graph search for documents and chunks
 KNOWLEDGE_GRAPH_CHUNK_SEARCH_TOP_SIZE=5  # the number of the searched triplets in a retrieval
+TRIPLET_EXTRACTION_BATCH_SIZE=20  # the batch size of triplet extraction from the text
 ```
 
 


### PR DESCRIPTION
# Description

It calls the async function to accelerate the process of triplets extraction from the chunk text. The config can be set in the `.env` `TRIPLET_EXTRACTION_BATCH_SIZE` (default to 20).

# How Has This Been Tested?

I have run the app server by set the value of TRIPLET_EXTRACTION_BATCH_SIZE differently. (1, 5, 100), and the running time varies.

# Snapshots:

``` python
        batch_size = self._triplet_extraction_batch_size

        for i in range(0, len(chunks), batch_size):
            batch_chunks = chunks[i : i + batch_size]

            extraction_tasks = [
                self._graph_extractor.extract(chunk.content) for chunk in batch_chunks
            ]
            async_graphs: List[List[MemoryGraph]] = await asyncio.gather(
                *extraction_tasks
            )

            for chunk, graphs in zip(batch_chunks, async_graphs):
                for graph in graphs:
                    if document_graph_enabled:
                        # append the chunk id to the edge
                        for edge in graph.edges():
                            edge.set_prop("_chunk_id", chunk.chunk_id)
                            graph.append_edge(edge=edge)

                    # upsert the graph
                    self._graph_store_apdater.upsert_graph(graph)

                    # chunk -> include -> entity
                    if document_graph_enabled:
                        for vertex in graph.vertices():
                            self._graph_store_apdater.upsert_chunk_include_entity(
                                chunk=chunk, entity=vertex
                            )

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
