### PR TITLE
fix the issue that OceanBase config in .env does not take effect

### DIFF
--- a/dbgpt/storage/vector_store/oceanbase_store.py
+++ b/dbgpt/storage/vector_store/oceanbase_store.py
@@ -130,24 +130,24 @@ class OceanBaseConfig(VectorStoreConfig):
         arbitrary_types_allowed = True
 
     """OceanBase config"""
-    ob_host: str = Field(
-        default="127.0.0.1",
+    ob_host: Optional[str] = Field(
+        default=None,
         description="oceanbase host",
     )
-    ob_port: int = Field(
-        default=2881,
+    ob_port: Optional[int] = Field(
+        default=None,
         description="oceanbase port",
     )
-    ob_user: str = Field(
-        default="root@test",
+    ob_user: Optional[str] = Field(
+        default=None,
         description="user to login",
     )
-    ob_password: str = Field(
-        default="",
+    ob_password: Optional[str] = Field(
+        default=None,
         description="password to login",
     )
-    ob_database: str = Field(
-        default="test",
+    ob_database: Optional[str] = Field(
+        default=None,
         description="database for vector tables",
     )
 


### PR DESCRIPTION
# Description

`OceanBaseConfig` items override the configurations in `.env` because `OceanBaseConfig` items set the default values.

# How Has This Been Tested?

- Test the knowledge base function using OceanBase + DB-GPT.
- make fmt
- make mypy
- make test

# Snapshots:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
