### PR TITLE
Use fuzzy matching when searching dbgpts

### DIFF
--- a/dbgpt/serve/dbgpts/hub/service/service.py
+++ b/dbgpt/serve/dbgpts/hub/service/service.py
@@ -41,7 +41,7 @@ class Service(BaseService[ServeEntity, ServeRequest, ServerResponse]):
         self._system_app = system_app
 
     @property
-    def dao(self) -> BaseDao[ServeEntity, ServeRequest, ServerResponse]:
+    def dao(self) -> ServeDao:
         """Returns the internal DAO."""
         return self._dao
 
@@ -130,7 +130,7 @@ class Service(BaseService[ServeEntity, ServeRequest, ServerResponse]):
             installed=request.installed,
         )
 
-        return self.dao.get_list_page(query_request, page, page_size)
+        return self.dao.dbgpts_list(query_request, page, page_size)
 
     def refresh_hub_from_git(
         self,

--- a/dbgpt/storage/metadata/_base_dao.py
+++ b/dbgpt/storage/metadata/_base_dao.py
@@ -297,7 +297,7 @@ class BaseDao(Generic[T, REQ, RES]):
                 elif isinstance(value, (tuple, dict, set)):
                     continue
                 else:
-                    query = query.filter(getattr(model_cls, key).like(f"%{value}%"))
+                    query = query.filter(getattr(model_cls, key) == value)
 
         if desc_order_column:
             query = query.order_by(desc(getattr(model_cls, desc_order_column)))

--- a/dbgpt/storage/metadata/_base_dao.py
+++ b/dbgpt/storage/metadata/_base_dao.py
@@ -297,7 +297,7 @@ class BaseDao(Generic[T, REQ, RES]):
                 elif isinstance(value, (tuple, dict, set)):
                     continue
                 else:
-                    query = query.filter(getattr(model_cls, key) == value)
+                    query = query.filter(getattr(model_cls, key).like(f"%{value}%"))
 
         if desc_order_column:
             query = query.order_by(desc(getattr(model_cls, desc_order_column)))


### PR DESCRIPTION
# Description

When I search for keywords in the DBGPTS community, I would prefer to use fuzzy matching to find relevant content. But now, I can only perform an exact match for the entire keyword.

# How Has This Been Tested?

- make fmt
- make mypy
- make test

# Snapshots:

It's better to match '%flow%' for all dbgpts, rather than only the dbgpt named 'flow'.
![image](https://github.com/user-attachments/assets/a50e4cd3-3587-4d35-8a14-8386a5a93e8d)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
