### PR TITLE
fix:core agent dependent prompt service bug

### DIFF
--- a/dbgpt/agent/core/plan/awel/agent_operator.py
+++ b/dbgpt/agent/core/plan/awel/agent_operator.py
@@ -22,7 +22,6 @@ from dbgpt.core.interface.message import ModelMessageRoleType
 
 # TODO: Don't dependent on MixinLLMOperator
 from dbgpt.model.operators.llm_operator import MixinLLMOperator
-from dbgpt.serve.prompt.api.endpoints import get_service
 from dbgpt.util.i18n_utils import _
 
 from .... import ActionOutput
@@ -291,6 +290,7 @@ class AWELAgentOperator(
 
         prompt_template = None
         if self.awel_agent.agent_prompt:
+            from dbgpt.serve.prompt.api.endpoints import get_service
             prompt_service = get_service()
             prompt_template = prompt_service.get_template(
                 self.awel_agent.agent_prompt.code

--- a/dbgpt/agent/core/plan/awel/agent_operator_resource.py
+++ b/dbgpt/agent/core/plan/awel/agent_operator_resource.py
@@ -12,8 +12,6 @@ from dbgpt.core.awel.flow import (
     ResourceCategory,
     register_resource,
 )
-from dbgpt.serve.prompt.api.endpoints import get_service
-
 from ....resource.base import AgentResource, ResourceType
 from ....resource.manage import get_resource_manager
 from ....util.llm.llm import LLMConfig, LLMStrategyType
@@ -21,6 +19,7 @@ from ...agent_manage import get_agent_manager
 
 
 def _agent_resource_prompt_values() -> List[OptionValue]:
+    from dbgpt.serve.prompt.api.endpoints import get_service
     prompt_service = get_service()
     prompts = prompt_service.get_target_prompt()
     return [


### PR DESCRIPTION
Close #2097 
# Description

core agent dependent prompt service bug (Temporary solution)

# How Has This Been Tested?

```python

import asyncio
import os

from dbgpt.agent import AgentContext, AgentMemory, LLMConfig, UserProxyAgent
from dbgpt.agent.expand.tool_assistant_agent import ToolAssistantAgent
from dbgpt.agent.resource import ToolPack, tool
from dbgpt.model.proxy.llms.chatgpt import OpenAILLMClient
from pydantic import BaseModel, Field


class ArgsSchema(BaseModel):
    a: int = Field(description="The first number.")
    b: int = Field(description="The second number.")


@tool(args_schema=ArgsSchema)
def two_sum(a: int, b: int) -> int:
    """Add two numbers and return the sum."""
    return a + b


tools = ToolPack([two_sum])


async def main():
    llm_client = OpenAILLMClient(
        model_alias="gpt-4o",
        api_base=os.getenv("OPENAI_API_BASE"),
        api_key=os.getenv("OPENAI_API_KEY"),
    )

    context: AgentContext = AgentContext(
        conv_id="test123", language="en", temperature=0.5, max_new_tokens=2048
    )
    agent_memory = AgentMemory()

    user_proxy = await UserProxyAgent().bind(agent_memory).bind(context).build()

    tool_man = (
        await ToolAssistantAgent()
        .bind(context)
        .bind(LLMConfig(llm_client=llm_client))
        .bind(agent_memory)
        .bind(tools)
        .build()
    )

    await user_proxy.initiate_chat(
        recipient=tool_man,
        reviewer=user_proxy,
        message="Calculate the product of 10 and 99",
    )

    await user_proxy.initiate_chat(
        recipient=tool_man,
        reviewer=user_proxy,
        message="Count the number of files in /tmp",
    )

    print("Done!")


if __name__ == "__main__":
    asyncio.run(main())
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
