### PR TITLE
fix(milvus): Fix milvus store search with topk always set to 4

### DIFF
--- a/dbgpt/storage/vector_store/milvus_store.py
+++ b/dbgpt/storage/vector_store/milvus_store.py
@@ -458,7 +458,7 @@ class MilvusStore(VectorStoreBase):
         # convert to milvus expr filter.
         milvus_filter_expr = self.convert_metadata_filters(filters) if filters else None
         _, docs_and_scores = self._search(
-            query=text, topk=topk, expr=milvus_filter_expr
+            query=text, k=topk, expr=milvus_filter_expr
         )
         if any(score < 0.0 or score > 1.0 for _, score, id in docs_and_scores):
             logger.warning(


### PR DESCRIPTION
# Description

Previously, the search topk in Milvus storage was always fixed at 4. This commit fixes the issue by allowing users to specify topk dynamically.

# How Has This Been Tested?

When the parameter `VECTOR_STORE_TYPE` is set to `Milvus`, the `KNOWLEDGE_SEARCH_TOP_SIZE` parameter becomes ineffective, and the system can only match up to 4 documents from the Milvus database. The issue lies in the _search method of the MilvusStore class, where the letter `k` represents the meaning of topk and is set to a default value of 4. However, during the method call, the keyword argument passed is `topk` (instead of `k`), causing the parameter to be ignored and the value of `k` to remain fixed at the default value of 4.

After I modified the keyword argument passed during the method call, the KNOWLEDGE_SEARCH_TOP_SIZE parameter started working as expected.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
