### PR TITLE
fix the issue that lost prev observation memory in toolExpert bug (#2136)

### DIFF
--- a/dbgpt/agent/core/profile/base.py
+++ b/dbgpt/agent/core/profile/base.py
@@ -129,11 +129,13 @@ _DEFAULT_WRITE_MEMORY_TEMPLATE = """\
 {% if question %}Question: {{ question }} {% endif %}
 {% if thought %}Thought: {{ thought }} {% endif %}
 {% if action %}Action: {{ action }} {% endif %}
+{% if observation %}Observation: {{ observation }} {% endif %}
 """
 _DEFAULT_WRITE_MEMORY_TEMPLATE_ZH = """\
 {% if question %}问题: {{ question }} {% endif %}
 {% if thought %}思考答案: {{ thought }} {% endif %}
 {% if action %}行动结果: {{ action }} {% endif %}
+{% if observation %}观察: {{ observation }} {% endif %}
 """
 
 


### PR DESCRIPTION
…136)

# Description

fix bug (#2136)

# How Has This Been Tested?

prompt after fix
```
human: 最近消息记录:
Question: 使用get_current_system_time获取当前时间戳 
Thought: {
  "thought": "用户希望使用get_current_system_time工具来获取当前的时间戳。",
  "tool_name": "get_current_system_time",
  "args": {}
} 
Observation: 1731575527 
用户输入: Read the result data of the dependent steps in the above historical message to complete the current goal:使用format_time_stamp将时间戳转换为'yy-mm-dd'格式
```
output after fix
```
full stream output:
{
  "thought": "为了满足用户需求，需要先从历史消息中提取出当前的时间戳，然后使用format_time_stamp工具将其转换成指定的日期格式。",
  "tool_name": "format_time_stamp",
  "args": {
    "timestamp_str": "1731575527"
  }
}

>>>>>>>>LuBan Action report: 
execution succeeded,
24:11:14 17:12:07
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
