### PR TITLE
fix sql not found error for chat data

### DIFF
--- a/dbgpt/app/scene/chat_db/auto_execute/prompt.py
+++ b/dbgpt/app/scene/chat_db/auto_execute/prompt.py
@@ -71,6 +71,7 @@ PROMPT_SCENE_DEFINE = (
 
 RESPONSE_FORMAT_SIMPLE = {
     "thoughts": "thoughts summary to say to user",
+    "direct_response": "If the context is sufficient to answer user, reply directly without sql",
     "sql": "SQL Query to run",
     "display_type": "Data display method",
 }


### PR DESCRIPTION
# Description

Fixed the issue that the `chat data` function occasionally raises "Can not find sql in response" error when there is the answer in the context.
<img width="1569" alt="截屏2024-11-22 17 52 02" src="https://github.com/user-attachments/assets/2379e62a-210f-44b9-9c8e-409e95bd9636">

# How Has This Been Tested?

- Chat Data
- make test

# Snapshots:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
