### PR TITLE
Fix bug fail to delete files when deleting the knowledge space

### DIFF
--- a/dbgpt/app/knowledge/api.py
+++ b/dbgpt/app/knowledge/api.py
@@ -97,7 +97,20 @@ def space_list(request: KnowledgeSpaceRequest):
 @router.post("/knowledge/space/delete")
 def space_delete(request: KnowledgeSpaceRequest):
     print(f"/space/delete params:")
+    print(request.name)
     try:
+        # delete Files in 'pilot/data/
+        safe_space_name = os.path.basename(request.name)
+
+        # obtain absolute paths of uploaded space-docfiles
+        space_dir = os.path.abspath(
+            os.path.join(KNOWLEDGE_UPLOAD_ROOT_PATH, safe_space_name)
+        )
+        try:
+            if os.path.exists(space_dir):
+                shutil.rmtree(space_dir)
+        except Exception as e:
+            print(e)
         return Result.succ(knowledge_space_service.delete_space(request.name))
     except Exception as e:
         return Result.failed(code="E000X", msg=f"space delete error {e}")


### PR DESCRIPTION
# Description

Fix delete the knowldege uploading file in the 'pilot/data' when deleteing the space by dbgpt CLI. There's no dependencies that are required for this change.

# How Has This Been Tested?

On the command terminal, executing `dbgpt  knowledge load --space_name testnewspace --local_doc_path \testpath\testfile.txt`, and then executing `dbgpt knowledge delete --sapce_name testnewspace`. From observing the direcotry $(dbgpt_path)/pilot/data/.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
