### PR TITLE
feat(model): Support siliconflow rerank models

### DIFF
--- a/dbgpt/configs/model_config.py
+++ b/dbgpt/configs/model_config.py
@@ -322,6 +322,7 @@ EMBEDDING_MODEL_CONFIG = {
     "bge-reranker-large": os.path.join(MODEL_PATH, "bge-reranker-large"),
     # Proxy rerank model
     "rerank_proxy_http_openapi": "rerank_proxy_http_openapi",
+    "rerank_proxy_silicon_flow": "rerank_proxy_silicon_flow",
 }
 
 

--- a/dbgpt/model/adapter/embeddings_loader.py
+++ b/dbgpt/model/adapter/embeddings_loader.py
@@ -109,6 +109,18 @@ class EmbeddingLoader:
                 if proxy_param.proxy_backend:
                     openapi_param["model_name"] = proxy_param.proxy_backend
                 return OpenAPIRerankEmbeddings(**openapi_param)
+            elif model_name in ["rerank_proxy_silicon_flow"]:
+                from dbgpt.rag.embedding.rerank import SiliconFlowRerankEmbeddings
+
+                proxy_param = cast(ProxyEmbeddingParameters, param)
+                openapi_param = {}
+                if proxy_param.proxy_server_url:
+                    openapi_param["api_url"] = proxy_param.proxy_server_url
+                if proxy_param.proxy_api_key:
+                    openapi_param["api_key"] = proxy_param.proxy_api_key
+                if proxy_param.proxy_backend:
+                    openapi_param["model_name"] = proxy_param.proxy_backend
+                return SiliconFlowRerankEmbeddings(**openapi_param)
             else:
                 from dbgpt.rag.embedding.rerank import CrossEncoderRerankEmbeddings
 

--- a/dbgpt/model/parameter.py
+++ b/dbgpt/model/parameter.py
@@ -613,7 +613,16 @@ class ProxyEmbeddingParameters(BaseEmbeddingModelParameters):
 
 
 _EMBEDDING_PARAMETER_CLASS_TO_NAME_CONFIG = {
-    ProxyEmbeddingParameters: "proxy_openai,proxy_azure,proxy_http_openapi,proxy_ollama,proxy_tongyi,proxy_qianfan,rerank_proxy_http_openapi",
+    ProxyEmbeddingParameters: [
+        "proxy_openai",
+        "proxy_azure",
+        "proxy_http_openapi",
+        "proxy_ollama",
+        "proxy_tongyi",
+        "proxy_qianfan",
+        "rerank_proxy_http_openapi",
+        "rerank_proxy_silicon_flow",
+    ]
 }
 
 EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG = {}
@@ -622,7 +631,6 @@ EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG = {}
 def _update_embedding_config():
     global EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG
     for param_cls, models in _EMBEDDING_PARAMETER_CLASS_TO_NAME_CONFIG.items():
-        models = [m.strip() for m in models.split(",")]
         for model in models:
             if model not in EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG:
                 EMBEDDING_NAME_TO_PARAMETER_CLASS_CONFIG[model] = param_cls

--- a/dbgpt/rag/embedding/__init__.py
+++ b/dbgpt/rag/embedding/__init__.py
@@ -17,7 +17,11 @@ from .embeddings import (  # noqa: F401
     QianFanEmbeddings,
     TongYiEmbeddings,
 )
-from .rerank import CrossEncoderRerankEmbeddings, OpenAPIRerankEmbeddings  # noqa: F401
+from .rerank import (  # noqa: F401
+    CrossEncoderRerankEmbeddings,
+    OpenAPIRerankEmbeddings,
+    SiliconFlowRerankEmbeddings,
+)
 
 __ALL__ = [
     "CrossEncoderRerankEmbeddings",
@@ -32,6 +36,7 @@ __ALL__ = [
     "OllamaEmbeddings",
     "OpenAPIEmbeddings",
     "OpenAPIRerankEmbeddings",
+    "SiliconFlowRerankEmbeddings",
     "QianFanEmbeddings",
     "TongYiEmbeddings",
     "WrappedEmbeddingFactory",


### PR DESCRIPTION
# Description

Additions to #2157

# How Has This Been Tested?

1. Using siliconflow rerank models in DB-GPT webserver

```bash
# .env
RERANK_MODEL=rerank_proxy_silicon_flow
rerank_proxy_silicon_flow_proxy_server_url=https://api.siliconflow.cn/v1/rerank
rerank_proxy_silicon_flow_proxy_api_key={your-siliconflow-api-key}
rerank_proxy_silicon_flow_proxy_backend=BAAI/bge-reranker-v2-m3
```
2. Using `SiliconFlowRerankEmbeddings`

```python
from dbgpt.rag.embedding import SiliconFlowRerankEmbeddings

embedding = SiliconFlowRerankEmbeddings(api_key='{your_api_key}')
res = embedding.predict("Apple", candidates=["苹果", "香蕉", "水果", "蔬菜"])
print(res)
```

You will see the following output:
```bash
[0.9953725, 0.00046734812, 0.0020992735, 1.7502925e-05]
```

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
