### PR TITLE
Print the necessary resource for the action in error log

### DIFF
--- a/dbgpt/agent/core/base_agent.py
+++ b/dbgpt/agent/core/base_agent.py
@@ -80,7 +80,7 @@ class ConversableAgent(Role, Agent):
                     or not self.resource.get_resource_by_type(action.resource_need)
                 ):
                     raise ValueError(
-                        f"{self.name}[{self.role}] Missing resources required for "
+                        f"{self.name}[{self.role}] Missing resources[{action.resource_need}] required for "
                         "runtime！"
                     )
         else:


### PR DESCRIPTION
# Description

After deploying the project, I attempted to complete my functionality using the `agent[Indicator]`, but encountered an error: `'chat abnormal termination! Indicator[Indicator] Missing resources required for runtime!'`. Initially, this error led me to believe that the agent was missing during deployment. However, after debugging, I found that the issue arises because the knowledge base is required when using the Indicator.

I believe that the error log should provide a more detailed explanation of the cause, or there should alert users in UI.


# Snapshots:

before :

![error_log_before](https://github.com/user-attachments/assets/d699e09a-f0e5-44d1-a8bd-d11377c7579e)

after:

![error_log_after](https://github.com/user-attachments/assets/3bcd47c0-3ebf-42a2-8c6c-05135ecc173b)




