### PR TITLE
fix(ci): Fix build docker image error

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -16,6 +16,13 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
# Description

Previously, the DB-GPT docker image build failed due to the large disk space occupied, such as https://github.com/eosphoros-ai/DB-GPT/actions/runs/11967971790

I fixed it according to https://github.com/orgs/community/discussions/26351#discussioncomment-3251595


# How Has This Been Tested?

It works on [my workflow](https://github.com/fangyinc/DB-GPT/actions/runs/12410571824/job/34646481309)

# Snapshots:

This is the image uploaded by [my workflow](https://github.com/fangyinc/DB-GPT/actions/runs/12410571824/job/34646481309)

![image](https://github.com/user-attachments/assets/32902976-900a-4757-80bf-1ae1f537f575)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
