### PR TITLE
Fix Bug #2224

### DIFF
--- a/dbgpt/serve/rag/connector.py
+++ b/dbgpt/serve/rag/connector.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 import os
+import chromadb
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Type, cast
 
@@ -224,6 +225,8 @@ class VectorStoreConnector:
         try:
             if self.vector_name_exists():
                 self.client.delete_vector_name(vector_name)
+                chromadb.api.client.SharedSystemClient.clear_system_cache()
+                del pools[self._vector_store_type][vector_name]
         except Exception as e:
             logger.error(f"delete vector name {vector_name} failed: {e}")
             raise Exception(f"delete name {vector_name} failed")

--- a/dbgpt/serve/rag/connector.py
+++ b/dbgpt/serve/rag/connector.py
@@ -3,7 +3,6 @@
 import copy
 import logging
 import os
-import chromadb
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Type, cast
 
@@ -225,7 +224,6 @@ class VectorStoreConnector:
         try:
             if self.vector_name_exists():
                 self.client.delete_vector_name(vector_name)
-                chromadb.api.client.SharedSystemClient.clear_system_cache()
                 del pools[self._vector_store_type][vector_name]
         except Exception as e:
             logger.error(f"delete vector name {vector_name} failed: {e}")

--- a/dbgpt/storage/vector_store/chroma_store.py
+++ b/dbgpt/storage/vector_store/chroma_store.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 from chromadb import PersistentClient
 from chromadb.config import Settings
+from chromadb.api.client import SharedSystemClient
 
 from dbgpt._private.pydantic import ConfigDict, Field
 from dbgpt.configs.model_config import PILOT_PATH
@@ -201,6 +202,7 @@ class ChromaStore(VectorStoreBase):
         logger.info(f"chroma vector_name:{vector_name} begin delete...")
         # self.vector_store_client.delete_collection()
         self._chroma_client.delete_collection(self._collection.name)
+        SharedSystemClient.clear_system_cache()
         self._clean_persist_folder()
         return True
 

--- a/dbgpt/storage/vector_store/chroma_store.py
+++ b/dbgpt/storage/vector_store/chroma_store.py
@@ -4,8 +4,8 @@ import os
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 from chromadb import PersistentClient
-from chromadb.config import Settings
 from chromadb.api.client import SharedSystemClient
+from chromadb.config import Settings
 
 from dbgpt._private.pydantic import ConfigDict, Field
 from dbgpt.configs.model_config import PILOT_PATH


### PR DESCRIPTION
# Description

Resolved the issue of repeatedly creating the same database, which prevented the creation of a vector store with identical metadata.

# How Has This Been Tested?

Repeatedly creating and deleting the same database ensures that the vector store with metadata is created correctly.