### PR TITLE
fix: add default value for response parser.

### DIFF
--- a/dbgpt/app/scene/chat_db/auto_execute/out_parser.py
+++ b/dbgpt/app/scene/chat_db/auto_execute/out_parser.py
@@ -56,6 +56,7 @@ class DbChatOutputParser(BaseOutputParser):
         else:
             try:
                 response = json.loads(clean_str, strict=False)
+                display, resp = "", ""
                 for key in sorted(response):
                     if key.strip() == "sql":
                         sql = response[key]


### PR DESCRIPTION
# Description

fix #2158 

In the ChatDB mode, when performing database Q&A based on the DeepSeek model, the returned data contains SQL but is not correctly parsed due to the absence of the direct_response field. Here, we set default empty string values for the display_type and direct_response fields to avoid situations where the large model cannot fully return as required (but still returns SQL), leading to an inability to answer questions.

# How Has This Been Tested?

- make fmt
- make mypy
- make test

# Snapshots:

问答结果显示 Can not find sql in response：
![image](https://github.com/user-attachments/assets/fe1a88e2-3fc8-4a54-8b0f-94e967345eba)

是因为返回的 json 内容包含 thoughs、sql、和direct_response，但是缺少display_type：
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/89abaf85-14f0-4eb0-9c28-dfd3e5183f5f" />


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
