### PR TITLE
fix: aembed_query type error

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/model/cluster/embedding/remote_embedding.py
+++ b/packages/dbgpt-core/src/dbgpt/model/cluster/embedding/remote_embedding.py
@@ -26,7 +26,8 @@ class RemoteEmbeddings(Embeddings):
 
     async def aembed_query(self, text: str) -> List[float]:
         """Asynchronous Embed query text."""
-        return await self.aembed_documents([text])[0]
+        result = await self.aembed_documents([text])
+        return result[0]
 
 
 class RemoteRerankEmbeddings(RerankEmbeddings):


### PR DESCRIPTION
# Description

The previous implementation incorrectly used the `await` keyword directly on the indexing operation, which caused a `TypeError` when `enable_summary="True"` was set. like
> 2025-03-11 19:14:25 hostname dbgpt_serve.rag.service.service[788143] ERROR document embedding, failed:74.txt, RetryError[<Future at 0x7b5c86f44f90 state=finished raised TypeError>]

The fix involves awaiting the result of the asynchronous `aembed_documents` method before indexing. This change ensures that the asynchronous operation is handled correctly, preventing the error.


# How Has This Been Tested?

Pass!

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and made the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
