### PR TITLE
fix(datasource): Correct the import path for StarRocks dialect

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/__init__.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/__init__.py
@@ -18,6 +18,6 @@ from sqlalchemy.dialects import registry
 
 registry.register(
     "starrocks",
-    "dbgpt.datasource.rdbms.dialect.starrocks.sqlalchemy.dialect",
+    "dbgpt_ext.datasource.rdbms.dialect.starrocks.sqlalchemy.dialect",
     "StarRocksDialect",
 )

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/dialect.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/dialect.py
@@ -20,7 +20,7 @@ from sqlalchemy import exc, log, text
 from sqlalchemy.dialects.mysql.pymysql import MySQLDialect_pymysql
 from sqlalchemy.engine import Connection
 
-from dbgpt.datasource.rdbms.dialect.starrocks.sqlalchemy import datatype
+from dbgpt_ext.datasource.rdbms.dialect.starrocks.sqlalchemy import datatype
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

fix https://github.com/eosphoros-ai/DB-GPT/issues/2453
Version 0.7.0 changes the code package structure, and the path to register the database dialect changes and needs to be changed

# How Has This Been Tested?

make fmt
make mypy
make test

# Snapshots:

![image](https://github.com/user-attachments/assets/d9a39d48-8cb1-4fb7-bbd7-b703ed34f601)


# Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
