### PR TITLE
fix(knowledge recall test): Add system_app parameter to knowledgeSpaceRetriever initialization

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
+++ b/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
@@ -341,7 +341,7 @@ class KnowledgeService:
                     top_k = max(int(CFG.RERANK_TOP_K), 20)
 
             knowledge_space_retriever = KnowledgeSpaceRetriever(
-                space_id=space.id, top_k=top_k
+                space_id=space.id, top_k=top_k, system_app=CFG.SYSTEM_APP
             )
             chunks = await knowledge_space_retriever.aretrieve_with_scores(
                 question, score_threshold


### PR DESCRIPTION

# Description
![e2c3b061d126248735c4841475fc8fa](https://github.com/user-attachments/assets/c118bb36-d465-440c-8c11-efb45d535abc)


The knowledgebase recall test did not respond to anything, and the log showed an error:
' dbgpt_app.knowledge.service[25544] ERROR  recall_test error: 'NoneType' object has no attribute 'config''
and debug the code find missing system_app param

# How Has This Been Tested?
# Snapshots:

![2409760059e282f775109a387e6ffa7](https://github.com/user-attachments/assets/e0b67f30-ffec-4350-a5cf-201770d7b9ad)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
