### PR TITLE
fix(LLM extractor): handle empty response in LLM extractor

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
+++ b/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
@@ -99,7 +99,7 @@ class KnowledgeService:
         if request.vector_type == "VectorStore":
             request.vector_type = self.rag_config.storage.vector.get_type_value()
         if request.vector_type == "KnowledgeGraph":
-            knowledge_space_name_pattern = r"^[a-zA-Z0-9\u4e00-\u9fa5]+$"
+            knowledge_space_name_pattern = r"^[_a-zA-Z0-9\u4e00-\u9fa5]+$"
             if not re.match(knowledge_space_name_pattern, request.name):
                 raise Exception(f"space name:{request.name} invalid")
         spaces = knowledge_space_dao.get_knowledge_space(query)

--- a/packages/dbgpt-core/src/dbgpt/rag/transformer/llm_extractor.py
+++ b/packages/dbgpt-core/src/dbgpt/rag/transformer/llm_extractor.py
@@ -84,7 +84,10 @@ class LLMExtractor(ExtractorBase, ABC):
             logger.error(f"request llm failed ({code}) {reason}")
             return []
 
-        return self._parse_response(response.text, limit)
+        if response.has_text:
+            return self._parse_response(response.text, limit)
+        else:
+            return []
 
     def truncate(self):
         """Do nothing by default."""


### PR DESCRIPTION
Update the extract function to check for empty response before parsing

# Description

![image](https://github.com/user-attachments/assets/45a9a7ac-41b9-4308-bcde-42c85729fed3)
![image](https://github.com/user-attachments/assets/7952ee59-d09d-427a-9f9c-43a113d8e7fa)

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/dad55e7c-f9bf-41b2-ae33-bc42cc2d3489)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
