### PR TITLE
fix: milvus collection search param

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -561,7 +561,7 @@ class MilvusStore(VectorStoreBase):
         # use default index params.
         if param is None:
             index_type = self.col.indexes[0].params["index_type"]
-            param = self.index_params_map[index_type].get("params")
+            param = self.index_params_map[index_type]
         #  query text embedding.
         query_vector = self.embedding.embed_query(query)
         # Determine result metadata fields.


### PR DESCRIPTION
line 564: 
param = self.index_params_map[index_type].get("params") should remove get("params");

# Description

查询 milvus 的时候，逻辑是：_search 方法的 param 参数为 None 时，会读取 index_params_map 对应索引的配置参数。但是不应再调用 get("params")，会导致传递给 milvus 的 search 参数是错误的格式，使得参数无效，milvus 会以它自己的默认参数查询。可以参考 milvus 官网：https://milvus.io/api-reference/pymilvus/v2.5.x/MilvusClient/Vector/search.md

# Snapshots:

<img width="999" alt="image" src="https://github.com/user-attachments/assets/cd44304c-81f2-4073-81b9-c68d066657bb" />

<img width="768" alt="image" src="https://github.com/user-attachments/assets/f2249186-b04b-454b-97f7-b67f958515a1" />

