### PR TITLE
fix:issue2484

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/string_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/string_utils.py
@@ -41,6 +41,17 @@ def is_scientific_notation(string):
         return False
 
 
+def is_valid_ipv4(address):
+    """Check if the address is a valid IPv4 address."""
+    pattern = re.compile(
+        r"^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\."
+        r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\."
+        r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\."
+        r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    )
+    return pattern.match(address) is not None
+
+
 def extract_content(long_string, s1, s2, is_include: bool = False) -> Dict[int, str]:
     # extract text
     match_map = {}


### PR DESCRIPTION
Close #issue2484
# Description
Fix  Chroma Collection name rules
"(1) contains 3-63 characters, "
"(2) starts and ends with an alphanumeric character, "
"(3) otherwise contains only alphanumeric characters, underscores or hyphens (-), "
"(4) contains no two consecutive periods (..) and "
"(5) is not a valid IPv4 address, "
# How Has This Been Tested?

# Snapshots:

create knowledge name rule as below.
"(1) contains 3-63 characters, "
"(2) starts and ends with an alphanumeric character, "
"(3) otherwise contains only alphanumeric characters, underscores or hyphens (-), "
"(4) contains no two consecutive periods (..) and "
"(5) is not a valid IPv4 address, "

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
