### PR TITLE
fix:doris_conn cannot get table comment to store vectordb

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_doris.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_doris.py
@@ -201,6 +201,21 @@ class DorisConnector(RDBMSConnector):
             tables = cursor.fetchall()
             return [(table[0], table[1]) for table in tables]
 
+    def get_table_comment(self, table_name=None):
+        """Get table comment."""
+        cursor = self.get_session().execute(
+            text(
+                f"SELECT TABLE_COMMENT "
+                f"FROM information_schema.tables "
+                f'where TABLE_NAME="{table_name}" and TABLE_SCHEMA=database()'
+            )
+        )
+        table_comment = cursor.fetchone()
+        if table_comment:
+            return {'text': str(table_comment[0])}
+        else:
+            return {'text': None}
+
     def get_database_names(self):
         """Get database names."""
         with self.session_scope() as session:

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_doris.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_doris.py
@@ -207,14 +207,14 @@ class DorisConnector(RDBMSConnector):
             text(
                 f"SELECT TABLE_COMMENT "
                 f"FROM information_schema.tables "
-                f'where TABLE_NAME="{table_name}" and TABLE_SCHEMA=database()'
+                f"where TABLE_NAME={table_name} and TABLE_SCHEMA=database()"
             )
         )
         table_comment = cursor.fetchone()
         if table_comment:
-            return {'text': str(table_comment[0])}
+            return {"text": str(table_comment[0])}
         else:
-            return {'text': None}
+            return {"text": None}
 
     def get_database_names(self):
         """Get database names."""


### PR DESCRIPTION
# Description

When working with Doris as a data source for visualization, I discovered that the vector data queried lacked the corresponding table comments. This absence of table comments was causing a decrease in matching accuracy. To address this issue, I implemented a solution by rewriting the get_table_comment method in the conn_doris module. This enhancement ensures proper retrieval and association of table comments with the vector data, ultimately improving the overall accuracy of data matching and visualization results.