### PR TITLE
fix: column alias bug fix

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,9 +45,17 @@
 🚀 **データ3.0時代には、モデルとデータベースを基盤として、企業や開発者がより少ないコードで独自のアプリケーションを構築できます。**
 
 ### AIネイティブデータアプリ
----
-- 🔥🔥🔥 [V0.5.0リリース | ワークフローとエージェントを通じてネイティブデータアプリケーションを開発](https://docs.dbgpt.site/docs/changelog/Released_V0.5.0)
----
+- 🔥🔥🔥 [V0.7.0 リリース | 重要なアップグレードのセット](https://docs.dbgpt.cn/docs/changelog/Released_V0.6.0)
+  - [サポート MCP Protocol](https://github.com/eosphoros-ai/DB-GPT/pull/2497)
+  - [サポート DeepSeek R1](https://github.com/deepseek-ai/DeepSeek-R1)
+  - [サポート QwQ-32B](https://huggingface.co/Qwen/QwQ-32B)
+  - [基本モジュールをリファクタリングする]()
+    - [dbgpt-app](./packages/dbgpt-app)
+    - [dbgpt-core](./packages/dbgpt-core)
+    - [dbgpt-serve](./packages/dbgpt-serve)
+    - [dbgpt-client](./packages/dbgpt-client)
+    - [dbgpt-accelerator](./packages/dbgpt-accelerator)
+    - [dbgpt-ext](./packages/dbgpt-ext)
 
 ![Data-awels](https://github.com/eosphoros-ai/DB-GPT/assets/17919400/37d116fc-d9dd-4efa-b4df-9ab02b22541c)
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,17 @@ The purpose is to build infrastructure in the field of large models, through the
 
 ### AI-Native Data App 
 ---
-- 🔥🔥🔥 [Released V0.6.0 | A set of significant upgrades](https://docs.dbgpt.cn/docs/changelog/Released_V0.6.0)
-  - [The AWEL upgrade to 2.0]()
-  - [GraphRAG]()
-  - [AI Native Data App construction and management]()
-  - [The GPT-Vis upgrade, supporting a variety of visualization charts]()
-  - [Support Text2NLU and Text2GQL fine-tuning]()
-  - [Support Intent recognition, slot filling, and Prompt management]()
-
+- 🔥🔥🔥 [Released V0.7.0 | A set of significant upgrades](https://docs.dbgpt.cn/docs/changelog/Released_V0.6.0)
+  - [Suppport MCP Protocol](https://github.com/eosphoros-ai/DB-GPT/pull/2497)
+  - [Support DeepSeek R1](https://github.com/deepseek-ai/DeepSeek-R1)
+  - [Support QwQ-32B](https://huggingface.co/Qwen/QwQ-32B)
+  - [Refactor the basic modules]()
+    - [dbgpt-app](./packages/dbgpt-app)
+    - [dbgpt-core](./packages/dbgpt-core)
+    - [dbgpt-serve](./packages/dbgpt-serve)
+    - [dbgpt-client](./packages/dbgpt-client)
+    - [dbgpt-accelerator](./packages/dbgpt-accelerator)
+    - [dbgpt-ext](./packages/dbgpt-ext)
 ---
 
 ![app_chat_v0 6](https://github.com/user-attachments/assets/a2f0a875-df8c-4f0d-89a3-eed321c02113)
@@ -114,9 +117,6 @@ The core capabilities include the following parts:
   - [x] Qwen
   - [x] XVERSE
   - [x] ChatGLM2
-
--  SFT Accuracy
-As of October 10, 2023, through the fine-tuning of an open-source model with 13 billion parameters using this project, we have achieved execution accuracy on the Spider dataset that surpasses even GPT-4!
 
 [More Information about Text2SQL finetune](https://github.com/eosphoros-ai/DB-GPT-Hub)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -48,15 +48,16 @@
 
 ### AI原生数据智能应用
 ---
-- [V0.6.0发布——一系列重大功能更新](https://www.yuque.com/eosphoros/dbgpt-docs/fho86kk4e9y4rkpd)
-  - AWEL协议升级2.0，支持更复杂的编排，同时优化了前端可视化与交互能力。
-  - 支持数据应用的创建与生命周期管理，提供多种应用构建模式。1. 多智能体自动规划模式、2. 任务流编排模式、3. 单一智能体模式、4. 原生应用模式
-  - GraphRAG支持图社区摘要与混合检索，性能与检索效果有显著优势，同时支持丰富的前端可视化。
-  - 支持意图识别、槽位填充与Prompt管理。
-  - GPT-Vis前端可视化升级，支持更丰富的可视化图表。 
-  - 支持Text2NLU与Text2GQL微调, 即新增意图分类与从自然语言到图语言的微调。 
-
-
+- [V0.7.0发布——一系列重大功能更新](https://www.yuque.com/eosphoros/dbgpt-docs/asweou4i9rhnwchm)
+  - [支持MCP协议](https://github.com/eosphoros-ai/DB-GPT/pull/2497)
+  - 支持DeepSeek-R1、QwQ-32B等推理模型
+  - 重构基础模块
+    - [dbgpt-app](./packages/dbgpt-app)
+    - [dbgpt-core](./packages/dbgpt-core)
+    - [dbgpt-serve](./packages/dbgpt-serve)
+    - [dbgpt-client](./packages/dbgpt-client)
+    - [dbgpt-accelerator](./packages/dbgpt-accelerator)
+    - [dbgpt-ext](./packages/dbgpt-ext)
 ### Data Agents 
 
 ![app_chat_v0 6](https://github.com/user-attachments/assets/a2f0a875-df8c-4f0d-89a3-eed321c02113)
@@ -316,16 +317,6 @@ The MIT License (MIT)
           钉钉
         </p>
     </figure>
-    <figure style="display: flex; flex-direction: column;">
-        <img src="./assets/wechat.jpg" alt="图片1" style="width: 200px;">
-        <p style="text-align: center;">
-          微信
-        </p> 
-    </figure>
 </div>
-
-<!-- <p align="center">
-  <img src="./assets/wechat.jpg" width="300px" />
-</p> -->
 
 [![Star History Chart](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)

--- a/packages/dbgpt-core/src/dbgpt/storage/metadata/db_storage.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/metadata/db_storage.py
@@ -3,7 +3,7 @@
 from contextlib import contextmanager
 from typing import Dict, Iterator, List, Optional, Type, Union
 
-from sqlalchemy import URL
+from sqlalchemy import URL, inspect
 from sqlalchemy.orm import DeclarativeMeta, Session
 
 from dbgpt.core import Serializer
@@ -20,11 +20,12 @@ from .db_manager import BaseModel, BaseQuery, DatabaseManager
 
 def _copy_public_properties(src: BaseModel, dest: BaseModel):
     """Copy public properties from src to dest."""
-    for column in src.__table__.columns:  # type: ignore
-        if column.name != "id":
-            value = getattr(src, column.name)
+    for column in inspect(src).mapper.column_attrs:
+        if column.key != "id":
+            alais = column.key
+            value = getattr(src, alais)
             if value is not None:
-                setattr(dest, column.name, value)
+                setattr(dest, column.key, value)
 
 
 class SQLAlchemyStorage(StorageInterface[T, BaseModel]):


### PR DESCRIPTION
# Description

When column has alias name, there will be error occur.
```
def _copy_public_properties(src: BaseModel, dest: BaseModel):
    """Copy public properties from src to dest."""
    for column in src.__table__.columns:  # type: ignore
        if column.name != "id":
            value = getattr(src, column.name)
            if value is not None:
                setattr(dest, column.name, value)

```
I fix this with follow code
```
def _copy_public_properties(src: BaseModel, dest: BaseModel):
    """Copy public properties from src to dest."""
    for column in inspect(src).mapper.column_attrs:
        if column.key != "id":
            alais = column.key
            value = getattr(src, alais)
            if value is not None:
                setattr(dest, column.key, value)

```


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
