### PR TITLE
fix(knowledge):Fix KB document questions list check logic

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/service/service.py
@@ -322,7 +322,7 @@ class Service(BaseService[KnowledgeSpaceEntity, SpaceServeRequest, SpaceServeRes
             if update_chunk:
                 update_chunk.doc_name = request.doc_name
                 self._chunk_dao.update({"id": update_chunk.id}, update_chunk)
-        if len(request.questions) == 0:
+        if not request.questions:
             entity.questions = ""
         else:
             questions = [


### PR DESCRIPTION
# Description

When editing the name of a KB document, if there are no question and answer pairs by default, the frontend will not pass the questions field, and the questions on the backend are None instead of empty list

![5d108cdaefd14c9700953814a923bdc](https://github.com/user-attachments/assets/fce314bf-6d73-4029-8fc8-8cb79213af9c)


# How Has This Been Tested?


![dc9dce87a748de3c50f3c27b473b275](https://github.com/user-attachments/assets/5eb5fc14-9acf-4857-9997-342e808bae24)


# Snapshots:

![image](https://github.com/user-attachments/assets/dc65eb1a-6f41-41a8-ad3f-cc23e0a2b829)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
