### PR TITLE
Bugfix/elasticsearch store read config dict

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/elastic_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/elastic_store.py
@@ -167,7 +167,7 @@ class ElasticStore(VectorStoreBase):
         self._vector_store_config = vector_store_config
 
         connect_kwargs = {}
-        elasticsearch_vector_config = vector_store_config.dict()
+        elasticsearch_vector_config = vector_store_config.to_dict()
         self.uri = os.getenv(
             "ELASTICSEARCH_URL", "localhost"
         ) or elasticsearch_vector_config.get("uri")
@@ -224,7 +224,10 @@ class ElasticStore(VectorStoreBase):
                 "`pip install elasticsearch`."
             )
         try:
-            if self.username != "" and self.password != "":
+            # The condition should check for both None and empty string ("")
+            # When reading non-existent keys from env/config files,
+            # the value will be None
+            if self.username and self.password:
                 self.es_client_python = Elasticsearch(
                     f"http://{self.uri}:{self.port}",
                     basic_auth=(self.username, self.password),
@@ -248,7 +251,7 @@ class ElasticStore(VectorStoreBase):
 
         # create es index
         try:
-            if self.username != "" and self.password != "":
+            if self.username and self.password:
                 self.db_init = ElasticsearchStore(
                     es_url=f"http://{self.uri}:{self.port}",
                     index_name=self.index_name,


### PR DESCRIPTION
# Description
Fixes #2576 

fix: Resolves an issue where the ES initialization process fails when no username/password is configured, as it incorrectly reads None values for credentials during client setup.

# How Has This Been Tested?

### Set Elasticsearch as the Vector Storage Component for RAG  

This PR configures Elasticsearch as the vector storage backend for RAG (Retrieval-Augmented Generation). The following TOML settings are added/updated:  

```toml
[rag.storage]  
[rag.storage.vector]  
type = "elasticsearch"  
host = "127.0.0.1"  
port = 9200  
```  

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
