### PR TITLE
fix(schema): change flow_data column type from text to longtext

### DIFF
--- a/assets/schema/dbgpt.sql
+++ b/assets/schema/dbgpt.sql
@@ -295,7 +295,7 @@ CREATE TABLE `dbgpt_serve_flow` (
   `uid` varchar(128) NOT NULL COMMENT 'Unique id',
   `dag_id` varchar(128) DEFAULT NULL COMMENT 'DAG id',
   `name` varchar(128) DEFAULT NULL COMMENT 'Flow name',
-  `flow_data` text COMMENT 'Flow data, JSON format',
+  `flow_data` longtext COMMENT 'Flow data, JSON format',
   `user_name` varchar(128) DEFAULT NULL COMMENT 'User name',
   `sys_code` varchar(128) DEFAULT NULL COMMENT 'System code',
   `gmt_created` datetime DEFAULT NULL COMMENT 'Record creation time',

--- a/assets/schema/upgrade/v0_7_1/upgrade_to_v0.7.1.sql
+++ b/assets/schema/upgrade/v0_7_1/upgrade_to_v0.7.1.sql
@@ -4,3 +4,6 @@ USE dbgpt;
 -- Change message_detail column type from text to longtext in chat_history_message table
 ALTER TABLE `gpts_messages`
     MODIFY COLUMN `action_report` longtext COMMENT 'Current conversation action report';
+
+ALTER TABLE `dbgpt_serve_flow`
+    MODIFY COLUMN `flow_data` longtext null COMMENT 'Flow data, JSON format';

--- a/assets/schema/upgrade/v0_7_1/v0.7.0.sql
+++ b/assets/schema/upgrade/v0_7_1/v0.7.0.sql
@@ -294,7 +294,7 @@ CREATE TABLE `dbgpt_serve_flow` (
   `uid` varchar(128) NOT NULL COMMENT 'Unique id',
   `dag_id` varchar(128) DEFAULT NULL COMMENT 'DAG id',
   `name` varchar(128) DEFAULT NULL COMMENT 'Flow name',
-  `flow_data` text COMMENT 'Flow data, JSON format',
+  `flow_data` longtext COMMENT 'Flow data, JSON format',
   `user_name` varchar(128) DEFAULT NULL COMMENT 'User name',
   `sys_code` varchar(128) DEFAULT NULL COMMENT 'System code',
   `gmt_created` datetime DEFAULT NULL COMMENT 'Record creation time',


### PR DESCRIPTION
- Update flow_data column type in dbgpt_serve_flow table from text to longtext
- Modify flow_data column type in v0.7.0.sql and upgrade_to_v0.7.1.sql

# Description
When there are too many workflow nodes, saving the workflow will error flow_data data fields are too long

![img_v3_02l4_16276396-30ad-4d5d-aa7e-7ae6116fd35p](https://github.com/user-attachments/assets/67636887-0bf8-4c7a-80aa-c4818437cc45)

# How Has This Been Tested?

Just change the flow_data field type text to longtext

# Snapshots:

N/A

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
