### PR TITLE
Fix postgresql

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_postgresql.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_postgresql.py
@@ -46,6 +46,8 @@ class PostgreSQLParameters(RDBMSDatasourceParameters):
         """Create PostgreSQL connector."""
         return PostgreSQLConnector.from_parameters(self)
 
+    def db_url(self, ssl: bool = False, charset: Optional[str] = None) -> str:
+        return f"{self.driver}://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
 
 class PostgreSQLConnector(RDBMSConnector):
     """PostgreSQL connector."""

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_postgresql.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_postgresql.py
@@ -49,6 +49,7 @@ class PostgreSQLParameters(RDBMSDatasourceParameters):
     def db_url(self, ssl: bool = False, charset: Optional[str] = None) -> str:
         return f"{self.driver}://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
 
+
 class PostgreSQLConnector(RDBMSConnector):
     """PostgreSQL connector."""
 


### PR DESCRIPTION
# Description
When using PostgreSQL as a metadata db, the application starts incorrectly ...
**psycopg2.ProgrammingError: invalid dsn: invalid connection option "charset"**
The db_url method of the default MySQL uses the chartset parameter, which is not valid in the PostgreSQL scenario
We need to override the db_url method in the PostgreSQL Connector

![image](https://github.com/user-attachments/assets/0b46e8cc-684e-4454-9a1b-d46c3a6bf499)


# How Has This Been Tested?

The app is able to launch successfully

# Snapshots:

Include snapshots for easier review.
![image](https://github.com/user-attachments/assets/17b97a95-7781-4c48-b06d-018b4bb5e144)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
