### PR TITLE
bugfix: the issue is the app_code can't be stored in the chat_history…

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/scene/base_chat.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/base_chat.py
@@ -86,6 +86,7 @@ def _build_conversation(
         chat_mode=chat_mode.value(),
         user_name=chat_param.user_name,
         sys_code=chat_param.sys_code,
+        app_code=chat_param.app_code,
         model_name=model_name,
         param_type=param_type,
         param_value=param_value,


### PR DESCRIPTION
… table when a new customized app's conversation is started, the app_code will be used to refere to the dedicated prompt code

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
