### PR TITLE
fix(reranker) The rerank model is used during the recall test

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
+++ b/packages/dbgpt-app/src/dbgpt_app/knowledge/service.py
@@ -340,11 +340,14 @@ class KnowledgeService:
                 else 0.3
             )
 
-            if CFG.RERANK_MODEL is not None:
-                if top_k < int(CFG.RERANK_TOP_K) or top_k < 20:
+            app_config = CFG.SYSTEM_APP.config.configs.get("app_config")
+            rerank_top_k = app_config.rag.rerank_top_k
+
+            if app_config.models.rerankers:
+                if top_k < int(rerank_top_k) or top_k < 20:
                     # We use reranker, so if the top_k is less than 20,
                     # we need to set it to 20
-                    top_k = max(int(CFG.RERANK_TOP_K), 20)
+                    top_k = max(int(rerank_top_k), 20)
 
             knowledge_space_retriever = KnowledgeSpaceRetriever(
                 space_id=space.id, top_k=top_k, system_app=CFG.SYSTEM_APP
@@ -360,7 +363,8 @@ class KnowledgeService:
             )
 
             recall_top_k = int(doc_recall_test_request.recall_top_k)
-            if CFG.RERANK_MODEL is not None:
+
+            if app_config.models.rerankers:
                 rerank_embeddings = RerankEmbeddingFactory.get_instance(
                     CFG.SYSTEM_APP
                 ).create()


### PR DESCRIPTION
fix https://github.com/eosphoros-ai/DB-GPT/issues/2636 

The logic for determining whether to use reranking and setting the `top_k` value now depends on the `app_config` instead of directly using `CFG.RERANK_MODEL` and `CFG.RERANK_TOP_K`. This change ensures that the application's specific configuration settings are respected.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
