### PR TITLE
Fix Clickhouse SQL syntax error for RdbmsSummary

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_clickhouse.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_clickhouse.py
@@ -181,7 +181,7 @@ class ClickhouseConnector(RDBMSConnector):
         session = self.client
 
         _query_sql = f"""
-                    SELECT name AS table, primary_key, from system.tables where
+                    SELECT name AS table, primary_key from system.tables where
                      database ='{self.client.database}' and table = '{table_name}'
                 """
         with session.query_row_block_stream(_query_sql) as stream:


### PR DESCRIPTION
used ClickHouse Version: `22.8.15.23`
