### PR TITLE
feat(agent): The SQL execution result of the DataScientist can be passed to the next agent

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import List, Optional
 
-from dbgpt._private.pydantic import BaseModel, Field, model_to_json
+from dbgpt._private.pydantic import BaseModel, Field, model_to_dict, model_to_json
 from dbgpt.vis.tags.vis_chart import Vis, VisChart
 
 from ...core.action.base import Action, ActionOutput
@@ -85,9 +85,16 @@ class ChartAction(Action[SqlInput]):
                 chart=json.loads(model_to_json(param)), data_df=data_df
             )
 
+            param_dict = model_to_dict(param)
+            if not data_df.empty:
+                param_dict["data"] = json.loads(
+                    data_df.to_json(orient="records", date_format="iso", date_unit="s")
+                )
+            content = json.dumps(param_dict)
+
             return ActionOutput(
                 is_exe_success=True,
-                content=model_to_json(param),
+                content=content,
                 view=view,
                 resource_type=self.resource_need.value,
                 resource_value=db._db_name,


### PR DESCRIPTION

# Description

By default,the sql execution result of DataScientistis Agent displayed only in vis chart, if you want to use the Summary Agent to summarize the results of DataScientistis Agent, you can only analyze whether the SQL execution is correct, but cannot analyze the data queried by the SQL, which does not meet our expectations,I pass the SQL query results to the Content node. Other agents can do the  processing

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/4265f32c-279c-4b77-9582-95c1a75f22bf)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
