### PR TITLE
fix(VectorStore) fix MilvusStore to use serialize function for metadata json encoding

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -413,11 +413,10 @@ class MilvusStore(VectorStoreBase):
         # self.fields.extend(metadatas[0].keys())
         if len(self.fields) > 2 and metadatas is not None:
             for d in metadatas:
+                metadata_json = json.dumps(d, default=serialize, ensure_ascii=False)
                 # for key, value in d.items():
-                insert_dict.setdefault("metadata", []).append(
-                    json.dumps(d, default=serialize, ensure_ascii=False)
-                )
-                insert_dict.setdefault("props_field", []).append(d)
+                insert_dict.setdefault("metadata", []).append(metadata_json)
+                insert_dict.setdefault("props_field", []).append(metadata_json)
         # Convert dict to list of lists for insertion
         insert_list = [insert_dict[x] for x in self.fields]
         # Insert into the collection.

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -19,6 +19,7 @@ from dbgpt.storage.vector_store.base import (
 from dbgpt.storage.vector_store.filters import FilterOperator, MetadataFilters
 from dbgpt.util import string_utils
 from dbgpt.util.i18n_utils import _
+from dbgpt.util.json_utils import serialize
 
 logger = logging.getLogger(__name__)
 
@@ -413,7 +414,9 @@ class MilvusStore(VectorStoreBase):
         if len(self.fields) > 2 and metadatas is not None:
             for d in metadatas:
                 # for key, value in d.items():
-                insert_dict.setdefault("metadata", []).append(json.dumps(d))
+                insert_dict.setdefault("metadata", []).append(
+                    json.dumps(d, default=serialize, ensure_ascii=False)
+                )
                 insert_dict.setdefault("props_field", []).append(d)
         # Convert dict to list of lists for insertion
         insert_list = [insert_dict[x] for x in self.fields]


### PR DESCRIPTION
# Description

2025-04-30 01:02:47 | ERROR | dbgpt.agent.core.base_agent | Generate reply exception!
Traceback (most recent call last):
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/base_agent.py", line 500, in generate_reply
    await self.write_memories(
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/role.py", line 261, in write_memories
    await self.memory.write(fragment)
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/memory/agent_memory.py", line 248, in write
    return await self.memory.write(memory_fragment, now)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/memory/hybrid.py", line 186, in write
    return await self._write_single(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/memory/hybrid.py", line 233, in _write_single
    await self._long_term_memory.write_batch(all_memories, self.now)
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/memory/long_term.py", line 274, in write_batch
    await self.write(short_term_memory, now=current_datetime)
  File "/app/packages/dbgpt-core/src/dbgpt/agent/core/memory/long_term.py", line 255, in write
    await blocking_func_to_async(
  File "/app/packages/dbgpt-core/src/dbgpt/util/executor_utils.py", line 70, in blocking_func_to_async
    return await loop.run_in_executor(executor, run_with_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-core/src/dbgpt/util/executor_utils.py", line 67, in run_with_context
    return ctx.run(partial(func, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-core/src/dbgpt/rag/retriever/time_weighted.py", line 152, in load_document
    return self._index_store.load_document_with_limit(dup_docs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-core/src/dbgpt/storage/base.py", line 146, in load_document_with_limit
    success_ids = future.result()
                  ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py", line 439, in load_document
    doc_ids.extend(self._load_documents(doc_batch))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py", line 391, in _load_documents
    return self._add_documents(texts, metadatas)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py", line 416, in _add_documents
    insert_dict.setdefault("metadata", []).append(json.dumps(d))
                                                  ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
