### PR TITLE
fix: resolve KeyError: 'question' in chat_dashboard prompt template

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
@@ -94,12 +94,14 @@ class ChatDashboard(BaseChat):
             "supported_chat_type": self.dashboard_template["supported_chart_type"],
         }
 
-        # 变量名兼容映射：兼容自定义prompt模板变量名
-        # 获取当前prompt的input_variables
+        # Mapping variable names: compatible with custom prompt template variable names
+        # Get the input_variables of the current prompt
         input_variables = []
-        if hasattr(self.prompt_template, 'prompt') and hasattr(self.prompt_template.prompt, 'input_variables'):
+        if hasattr(self.prompt_template, "prompt") and hasattr(
+            self.prompt_template.prompt, "input_variables"
+        ):
             input_variables = self.prompt_template.prompt.input_variables
-        # 兼容question和user_input
+        # Compatible with question and user_input
         if "question" in input_variables:
             input_values["question"] = self.current_user_input
         if "user_input" in input_variables:

--- a/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
@@ -94,6 +94,17 @@ class ChatDashboard(BaseChat):
             "supported_chat_type": self.dashboard_template["supported_chart_type"],
         }
 
+        # 变量名兼容映射：兼容自定义prompt模板变量名
+        # 获取当前prompt的input_variables
+        input_variables = []
+        if hasattr(self.prompt_template, 'prompt') and hasattr(self.prompt_template.prompt, 'input_variables'):
+            input_variables = self.prompt_template.prompt.input_variables
+        # 兼容question和user_input
+        if "question" in input_variables:
+            input_values["question"] = self.current_user_input
+        if "user_input" in input_variables:
+            input_values["user_input"] = self.current_user_input
+
         return input_values
 
     def do_action(self, prompt_response):

--- a/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
@@ -216,7 +216,7 @@ class ChatPromptTemplate(BasePromptTemplate):
                         "You are a helpful AI assistant."
                     ),
                     MessagesPlaceholder(variable_name="chat_history"),
-                    HumanPromptTemplate.from_template("{question}"),
+                    HumanPromptTemplate.from_template("{input}"),
                 ]
             )
     """

--- a/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
@@ -216,7 +216,7 @@ class ChatPromptTemplate(BasePromptTemplate):
                         "You are a helpful AI assistant."
                     ),
                     MessagesPlaceholder(variable_name="chat_history"),
-                    HumanPromptTemplate.from_template("{input}"),
+                    HumanPromptTemplate.from_template("{question}"),
                 ]
             )
     """


### PR DESCRIPTION
Fixes #2694
  
修复chat_dashboard场景下自定义提示词模板变量名不匹配的问题。