### PR TITLE
fix: 修复提示词输出结构无法回显问题

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/prompt/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/prompt/models/models.py
@@ -139,6 +139,7 @@ class ServeDao(BaseDao[ServeEntity, ServeRequest, ServerResponse]):
             user_code=entity.user_code,
             model=entity.model,
             input_variables=entity.input_variables,
+            response_schema=entity.response_schema,
             prompt_language=entity.prompt_language,
             sys_code=entity.sys_code,
             gmt_created=gmt_created_str,

--- a/web/pages/construct/prompt/[type]/index.tsx
+++ b/web/pages/construct/prompt/[type]/index.tsx
@@ -349,6 +349,7 @@ const AddOrEditPrompt: React.FC = () => {
       const editData = JSON.parse(localStorage.getItem('edit_prompt_data') || '{}');
       setVariables(JSON.parse(editData.input_variables ?? '[]'));
       setValue(editData?.content);
+      setResponseTemplate(JSON.parse(editData.response_schema));
       topForm.setFieldsValue({
         prompt_type: editData.prompt_type,
         prompt_name: editData.prompt_name,


### PR DESCRIPTION
# Description
修复前：
提示詞在编辑的时候，输出结构没有回显，如下所示：
![image](https://github.com/user-attachments/assets/78731f7f-6b7a-4ae3-b4ca-bb17cd3f7aa0)
修复后：
![image](https://github.com/user-attachments/assets/884aa71f-1be1-4575-b248-c1e227971fe1)

# How Has This Been Tested?

新建有输出结构的提示词后再进入编辑页面