### PR TITLE
fix: 修复chroma_store.py中unsupported-operand-type问题

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/chroma_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/chroma_store.py
@@ -114,9 +114,7 @@ class ChromaStore(VectorStoreBase):
         except ImportError:
             raise ImportError("Please install chroma package first.")
         chroma_vector_config = vector_store_config.to_dict()
-        chroma_path = chroma_vector_config.get(
-            "persist_path", os.path.join(PILOT_PATH, "data")
-        )
+        chroma_path = chroma_vector_config.get("persist_path") or os.path.join(PILOT_PATH, "data")
         self.persist_dir = os.path.join(resolve_root_path(chroma_path) + "/chromadb")
         self.embeddings = embedding_fn
         if not self.embeddings:


### PR DESCRIPTION
# Description

在使用Chroma vector store没有指定ChromaVectorConfig中的persist_path属性时，项目启动会报错如下：
<img width="1082" alt="1747457384407" src="https://github.com/user-attachments/assets/cc5938fd-7dbb-4750-a63f-553d0f80e3bc" />
其中chroma_vector_config.get("persist_path", os.path.join(PILOT_PATH, "data"))  执行结果是None而不是os.path.join(PILOT_PATH, "data")的值，因为字典类型的get方法只有当不包含此键时才会使用指定的默认值，但是chroma_vector_config字典中persist_path键值存在只不过值为None

# How Has This Been Tested?

使用Chroma vector store ->新增一个数据库 -> 项目启动   问题可复现，测试流程也如此


# Checklist:

- [√] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [√] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
