### PR TITLE
Bugfix(RAG):handle exceptions in aload_document_with_limit results

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM eosphorosai/dbgpt-full:latest
 ARG PYTHON_VERSION=3.11
 ARG PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
 ARG USERNAME
-ARG EXTRAS="base,proxy_openai,rag,storage_chromadb, storage_elasticsearch,cuda121,hf,quant_bnb,dbgpts"
+ARG EXTRAS="base,proxy_openai,graph_rag,rag,storage_chromadb, storage_elasticsearch,cuda121,hf,quant_bnb,dbgpts"
 ARG DEFAULT_VENV=/opt/.uv.venv
 WORKDIR /app
 COPY . .
@@ -22,6 +22,11 @@ RUN apt-get update && apt-get install -y \
     python${PYTHON_VERSION}-dev \
     default-libmysqlclient-dev \
     ssh zsh autojump curl git-flow vim sudo \
+    fonts-wqy-microhei fonts-noto-cjk \
+    locales \
+    && sed -i '/zh_CN.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen zh_CN.UTF-8 \
+    && update-locale LANG=zh_CN.UTF-8 \
     && python${PYTHON_VERSION} -m pip install --upgrade pip \
     && python${PYTHON_VERSION} -m pip install --upgrade pipx \
     && pipx install -i $PIP_INDEX_URL uv --global \
@@ -35,7 +40,9 @@ ENV UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=$DEFAULT_VENV \
     UV_PYTHON=$DEFAULT_VENV/bin/python3 \
     UV_INDEX=$PIP_INDEX_URL \
-    UV_DEFAULT_INDEX=$PIP_INDEX_URL
+    UV_DEFAULT_INDEX=$PIP_INDEX_URL \
+    LANG=zh_CN.UTF-8 \
+    LC_ALL=zh_CN.UTF-8
 
 RUN sed -i "s|/app/\.venv|${FINAL_VENV_NAME}|g" /${DEFAULT_VENV}/bin/activate && \
     pip config set global.index-url $PIP_INDEX_URL && \

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -44,7 +44,8 @@ export ZSH="\$HOME/.oh-my-zsh"
 ZSH_THEME="robbyrussell"
 plugins=(git zsh-autosuggestions zsh-syntax-highlighting autojump)
 source \$ZSH/oh-my-zsh.sh
-
+export LANG=zh_CN.UTF-8
+export LC_ALL=zh_CN.UTF-8
 # Enable autojump
 [[ -s /usr/share/autojump/autojump.sh ]] && source /usr/share/autojump/autojump.sh
 EOF

--- a/packages/dbgpt-core/src/dbgpt/storage/base.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/base.py
@@ -129,7 +129,7 @@ class IndexStoreBase(ABC):
         max_threads = max_threads or self._max_threads
         # Group the chunks into chunks of size max_chunks
         chunk_groups = [
-            chunks[i : i + max_chunks_once_load]
+            chunks[i: i + max_chunks_once_load]
             for i in range(0, len(chunks), max_chunks_once_load)
         ]
         logger.info(
@@ -187,7 +187,11 @@ class IndexStoreBase(ABC):
 
         ids = []
         loaded_cnt = 0
-        for success_ids in results:
+        for idx, success_ids in enumerate(results):
+            if isinstance(success_ids, Exception):
+                raise RuntimeError(
+                    f"Failed to load chunk group {idx + 1}: {str(success_ids)}"
+                ) from success_ids
             ids.extend(success_ids)
             loaded_cnt += len(success_ids)
             logger.info(f"Loaded {loaded_cnt} chunks, total {len(chunks)} chunks.")

--- a/packages/dbgpt-core/src/dbgpt/storage/base.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/base.py
@@ -129,7 +129,7 @@ class IndexStoreBase(ABC):
         max_threads = max_threads or self._max_threads
         # Group the chunks into chunks of size max_chunks
         chunk_groups = [
-            chunks[i: i + max_chunks_once_load]
+            chunks[i : i + max_chunks_once_load]
             for i in range(0, len(chunks), max_chunks_once_load)
         ]
         logger.info(


### PR DESCRIPTION
# Description

Fixes #2710 

- fix: handle exceptions in aload_document_with_limit results
  - The `_run_tasks_with_concurrency` method uses `return_exceptions=True`, which allows `results` to contain both successful outputs and Exception objects. The original code assumed all `success_ids` were lists of strings, leading to potential `AttributeError` (e.g., iterating an Exception object) or incorrect ID aggregation.
  - This commit adds a check for `isinstance(success_ids, Exception)`. If an Exception is detected, it is raised explicitly to avoid silent failure and ensure only valid chunk IDs are collected.  

- feat: add devcontainer `zh_CN` LANG support

# How Has This Been Tested?



# Snapshots:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
