### PR TITLE
fix(scene): fix chat scene config custom prompt

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/chat_dashboard/chat.py
@@ -95,19 +95,6 @@ class ChatDashboard(BaseChat):
             "supported_chat_type": self.dashboard_template["supported_chart_type"],
         }
 
-        # Mapping variable names: compatible with custom prompt template variable names
-        # Get the input_variables of the current prompt
-        input_variables = []
-        if hasattr(self.prompt_template, "prompt") and hasattr(
-            self.prompt_template.prompt, "input_variables"
-        ):
-            input_variables = self.prompt_template.prompt.input_variables
-        # Compatible with question and user_input
-        if "question" in input_variables:
-            input_values["question"] = self.current_user_input
-        if "user_input" in input_variables:
-            input_values["user_input"] = self.current_user_input
-
         return input_values
 
     def do_action(self, prompt_response):

--- a/packages/dbgpt-serve/src/dbgpt_serve/prompt/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/prompt/models/models.py
@@ -139,6 +139,7 @@ class ServeDao(BaseDao[ServeEntity, ServeRequest, ServerResponse]):
             user_code=entity.user_code,
             model=entity.model,
             input_variables=entity.input_variables,
+            response_schema=entity.response_schema,
             prompt_language=entity.prompt_language,
             sys_code=entity.sys_code,
             gmt_created=gmt_created_str,


### PR DESCRIPTION
# Description

fix chat scene use custom prompt template problem. It has [response]、[question] keyword parsed exception

Closes #2628 

# How Has This Been Tested?

1. create new prompt template with scene type
2. use it in chat data scene

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
