### PR TITLE
feat(api): Add chat_dashboard support to V2 API

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
@@ -128,6 +128,7 @@ async def chat_completions(
         or request.chat_mode == ChatMode.CHAT_KNOWLEDGE.value
         or request.chat_mode == ChatMode.CHAT_DATA.value
         or request.chat_mode == ChatMode.CHAT_DB_QA.value
+        or request.chat_mode == ChatMode.CHAT_DASHBOARD.value
     ):
         with root_tracer.start_span(
             "get_chat_instance",
@@ -157,7 +158,7 @@ async def chat_completions(
             detail={
                 "error": {
                     "message": "chat mode now only support chat_normal, chat_app, "
-                    "chat_flow, chat_knowledge, chat_data",
+                    "chat_flow, chat_knowledge, chat_data, chat_dashboard",
                     "type": "invalid_request_error",
                     "param": None,
                     "code": "invalid_chat_mode",

--- a/packages/dbgpt-client/src/dbgpt_client/schema.py
+++ b/packages/dbgpt-client/src/dbgpt_client/schema.py
@@ -94,6 +94,7 @@ class ChatMode(Enum):
     CHAT_KNOWLEDGE = "chat_knowledge"
     CHAT_DATA = "chat_data"
     CHAT_DB_QA = "chat_with_db_qa"
+    CHAT_DASHBOARD = "chat_dashboard"
 
 
 class AWELTeamModel(BaseModel):


### PR DESCRIPTION
- Add CHAT_DASHBOARD to ChatMode enum
- Enable chat_dashboard mode in V2 chat completions API
- Fix database config lookup to handle missing configurations gracefully

# Description
This PR implements support for chat_dashboard mode in the v2 API, ensuring that the stream parameter works correctly in this mode. The implementation follows the same functionality as in v1 API but adapts it to the v2 API architecture and design patterns.

This PR addresses the issue where the dashboard mode was only available in v1 API, while project maintainers recommend using v2 API for new features.

Fixes #2699

# How Has This Been Tested?

1. Setting up a local instance of DB-GPT
2. Making API calls to the v2 endpoint with chat_dashboard mode enabled
3. Verifying that the stream parameter works correctly in dashboard mode

# Snapshots:
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/ebce311d-e696-4c43-a5ae-807a937400e3" />
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/2a376294-fec6-492b-8bac-b2e043a81903" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
