### PR TITLE
feat(AWEL):Add operator for structured output data of datasource in AWEL

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/flow/compat/0.7.0_compat_flow.json
+++ b/packages/dbgpt-serve/src/dbgpt_serve/flow/compat/0.7.0_compat_flow.json
@@ -2842,6 +2842,24 @@
             ],
             "version": "v1"
         },
+                {
+            "type": "operator",
+            "type_cls": "dbgpt_app.operators.datasource.HODatasourceStructedOperator",
+            "type_name": "HODatasourceStructedOperator",
+            "name": "higher_order_datasource_structed_operator",
+            "id": "operator_higher_order_datasource_structed_operator___$$___database___$$___v1",
+            "category": "database",
+            "parameters": [
+                "datasource"
+            ],
+            "outputs": [
+                "sql_result"
+            ],
+            "inputs": [
+                "sql_dict_list"
+            ],
+            "version": "v1"
+        },
         {
             "type": "operator",
             "type_cls": "dbgpt_app.operators.datasource.HODatasourceRetrieverOperator",


### PR DESCRIPTION
# Description

- Add a new operator to structure the output of database workflow execution results. This operator provides users with a structured representation of workflow execution outcomes, decoupling them from the frontend visualization architecture. This enhancement allows users to flexibly utilize workflow output data.   

- Output format:  
```json
{
    "data": [
        {
            "thoughts": "query something",
            "sql": "sql",
            "display_type": "response_table",
            "data": [

            ]
        }
    ]
}
```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
