### PR TITLE
fix: Fix SummaryExtractor not found error

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/assembler/summary.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/assembler/summary.py
@@ -59,7 +59,7 @@ class SummaryAssembler(BaseAssembler):
         model_name = model_name or os.getenv("LLM_MODEL")
 
         if not extractor:
-            from ..transformer.summary import SummaryExtractor
+            from dbgpt.rag.extractor.summary import SummaryExtractor
 
             if not llm_client:
                 raise ValueError("llm_client must be provided.")


### PR DESCRIPTION
# Description

复现：当前版本为最新的0.7.1版本，本地启动后，通过DBGPTS社区来下载了awel_flow_rag_summary_example的工作流后，使用该工作流对话，会提示相关查找不到SummaryExtractor的报错
根本原因：应该是进行版本重构将原本大目录进行分包处理后，该处的改动遗漏导致，调整为新包对应的引用文件即可

# How Has This Been Tested?

修复后可以正常进行对话
![image](https://github.com/user-attachments/assets/7ea918fc-e930-46f6-b5d7-fa86f22751fa)

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
