### PR TITLE
feat(agent): Add count field and support non-ASCII characters in DataScientist action output

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
@@ -87,9 +87,17 @@ class ChartAction(Action[SqlInput]):
 
             param_dict = model_to_dict(param)
             if not data_df.empty:
+                param_dict["count"] = len(data_df)
+
                 param_dict["data"] = json.loads(
-                    data_df.to_json(orient="records", date_format="iso", date_unit="s")
+                    data_df.to_json(
+                        orient="records",
+                        force_ascii=False,
+                        date_format="iso",
+                        date_unit="s",
+                    )
                 )
+
             content = json.dumps(param_dict)
 
             return ActionOutput(

--- a/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/expand/actions/chart_action.py
@@ -98,7 +98,7 @@ class ChartAction(Action[SqlInput]):
                     )
                 )
 
-            content = json.dumps(param_dict)
+            content = json.dumps(param_dict, ensure_ascii=False)
 
             return ActionOutput(
                 is_exe_success=True,


### PR DESCRIPTION

# Description

1. The count field is added to the DataScientist action output result, so that the summarizer can correctly obtain the number of data records
2. fixbug #2741 DataScientist action output is converted to json,  ASCII escaping is not disabled, when there is Chinese data, it will be changed to unicode characters, so there will be errors when the summary agent recognizes unicode

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
