### PR TITLE
fix: Fix milvus vector_name_exists bug

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -649,15 +649,17 @@ class MilvusStore(VectorStoreBase):
     def vector_name_exists(self):
         """Whether vector name exists."""
         try:
-            from pymilvus import utility
-        except ImportError:
-            raise ValueError(
-                "Could not import pymilvus python package. "
-                "Please install it with `pip install pymilvus`."
-            )
+            if not self._milvus_client.has_collection(self.collection_name):
+                logger.info(f"Collection {self.collection_name} does not exist")
+                return False
 
-        """is vector store name exist."""
-        return utility.has_collection(self.collection_name)
+            stats = self._milvus_client.get_collection_stats(self.collection_name)
+            row_count = stats.get("row_count", 0)
+            return row_count > 0
+
+        except Exception as e:
+            logger.error(f"vector_name_exists error, {str(e)}")
+            return False
 
     def delete_vector_name(self, vector_name: str):
         """Delete vector name."""


### PR DESCRIPTION
# Description

Fix the MilvusStore.vector_name_exists method which previously only checked whether a collection exists, but not whether it contains any data.

When testing ChatDB with Milvus as the vector store, this caused a bug: even if the collection was empty, it was treated as valid, leading to skipped document ingestion and missing database summaries during initialization.

This PR adds a row_count check to ensure the collection not only exists, but also contains data before returning True.

# How Has This Been Tested?

Test the ChatDB function using  Mivus + DB-GPT

# Snapshots:
 


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
