### PR TITLE
web package support cross-environment.

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,14 +11,14 @@
   "license": "ISC",
   "repository": "https://github.com/eosphoros-ai/DB-GPT-Web.git",
   "scripts": {
-    "start": "NODE_OPTIONS=--max_old_space_size=8192 next start",
-    "dev": "NODE_OPTIONS=--max_old_space_size=8192 next dev",
-    "build": "NODE_OPTIONS=--max_old_space_size=8192 next build",
-    "build:prod": "APP_ENV=prod  NODE_OPTIONS=--max_old_space_size=8192 next build",
+    "start": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next start",
+    "dev": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next dev",
+    "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build",
+    "build:prod": "cross-env APP_ENV=prod  NODE_OPTIONS=--max_old_space_size=8192 next build",
     "lint": "eslint '**/*.{ts,tsx}' --fix",
     "format": "prettier --write '**/*.{ts,tsx}'",
     "export": "next export",
-    "compile": " NODE_OPTIONS=--max_old_space_size=8192 next build && next export"
+    "compile": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build && next export"
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.18.4",


### PR DESCRIPTION
# Description
        I added "cross-env" to the package.json file to support cross-environment functionality.
When I run the front-end program independently on Windows, a problem has arisen, see:
--------------------------------------------------------------------------------
E:\git_project\DB-GPT\web>npm run dev

> db-gpt-web@0.1.0 dev
> NODE_OPTIONS=--max_old_space_size=8192 next dev

'NODE_OPTIONS' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
--------------------------------------------------------------------------------



# How Has This Been Tested?
        You should install the cross-env first, cmd:

--------------------------------------------------------------------------------
npm install --save-dev cross-env
--------------------------------------------------------------------------------

now you can run the following commad: 

--------------------------------------------------------------------------------
npm run dev
--------------------------------------------------------------------------------

# Snapshots:

--------------------------------------------------------------------------------
"scripts": {
    "start": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next start",
    "dev": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next dev",
    "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build",
    "build:prod": "cross-env APP_ENV=prod  NODE_OPTIONS=--max_old_space_size=8192 next build",
    "lint": "eslint '**/*.{ts,tsx}' --fix",
    "format": "prettier --write '**/*.{ts,tsx}'",
    "export": "next export",
    "compile": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build && next export"
  }
--------------------------------------------------------------------------------

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
