### PR TITLE
fix: pgvector_store  read connection_string from env

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/pgvector_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/pgvector_store.py
@@ -1,7 +1,7 @@
 """Postgres vector store."""
 
-import os
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 


### PR DESCRIPTION
pgvector_store not use PGVECTOR_CONNECTION_STRING from .env

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
