### PR TITLE
fix:Object of type time is not JSON serializable

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/json_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/json_utils.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from dataclasses import asdict, is_dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,8 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, date):
+            return obj.isoformat()
+        if isinstance(obj, time):
             return obj.isoformat()
         return super().default(obj)
 


### PR DESCRIPTION
# Description

Fix: JSON serialization error for time cells in chat excel

# Description

When using the chat excel feature with Excel files containing time cells (e.g., 12:30:00), a TypeError: Object of type time is not JSON serializable occurs. This issue arises because Python's time objects (generated when parsing time-formatted cells) cannot be directly serialized to JSON, disrupting the data processing workflow.​
This PR resolves the problem by converting time objects to string representations before JSON serialization, ensuring seamless handling of time-formatted cells in Excel files.

# Fix Details​
Added type checks for time objects during Excel cell value parsing (packages/dbgpt-core/src/dbgpt/util/[json_utils.py](http://json_utils.py/)).​
​
# Testing​
Tested with an Excel file containing time cells (12:30:00, 09:15:00), date cells, string cells, and numeric cells.​
Verified that the chat excel feature no longer throws the JSON serialization error and correctly processes/returns time cell values as strings.​
Confirmed no regression in handling other cell types (all previously functional formats remain operational).​
Additional Notes​
No new dependencies are introduced.​
​
Hope this fix helps improve the chat excel functionality! Please let me know if any adjustments are needed.
