### PR TITLE
fix: Add missing file_id parameter to BuiltinKnowledgeGraph.aload_doc…

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/knowledge_graph/knowledge_graph.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/knowledge_graph/knowledge_graph.py
@@ -212,11 +212,14 @@ class BuiltinKnowledgeGraph(KnowledgeGraphBase):
         loop.close()
         return result
 
-    async def aload_document(self, chunks: List[Chunk]) -> List[str]:  # type: ignore
+    async def aload_document(
+        self, chunks: List[Chunk], file_id: Optional[str] = None
+    ) -> List[str]:  # type: ignore
         """Extract and persist triplets to graph store.
 
         Args:
             chunks: List[Chunk]: document chunks.
+            file_id: Optional[str]: file id for document-level graph structure tracking.
         Return:
             List[str]: chunk ids.
         """


### PR DESCRIPTION
…ument()

In v0.7.0, the file_id parameter was added to the knowledge graph loading pipeline to support document-level graph structure tracking. However, the BuiltinKnowledgeGraph.aload_document() method was not updated accordingly.

This commit adds the file_id parameter to match the interface used by:
- IndexStoreBase.aload_document_with_limit() (caller)
- VectorStoreBase.aload_document() (correct implementation)
- CommunitySummaryKnowledgeGraph.aload_document() (correct implementation)

Changes:
- Added file_id: Optional[str] = None parameter to the method signature
- Updated docstring to document the new parameter
- Maintained the # type: ignore comment for base class signature compatibility

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
