### PR TITLE
fix(2965): correct the number of arguments in BuiltinKnowledgeGraph.aload_document call 

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/storage/base.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/base.py
@@ -55,7 +55,9 @@ class IndexStoreBase(ABC):
         """
 
     @abstractmethod
-    async def aload_document(self, chunks: List[Chunk],  file_id: Optional[str] = None) -> List[str]:
+    async def aload_document(
+        self, chunks: List[Chunk], file_id: Optional[str] = None
+    ) -> List[str]:
         """Load document in index database.
 
         Args:


### PR DESCRIPTION
# Description
In the ./packages/dbgpt-core/src/dbgpt/storage/base.pyBuiltinKnowledgeGraph file, the call to aload_document was passing two arguments (chunk_group and file_id) but the method only expects one (chunks). This caused an error when using BuiltinKnowledgeGraph for document embedding.

Error: document embedding failedBuiltinKnowledgeGraph.aload_document() takes 2 positional arguments but 3 were given

The fix removes the extra argument (file_id) from the call. Resolves: #issue_number (if applicable)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Models information
LLM: "Qwen/Qwen3-8B"
Embedding: "BAAI/bge-large-zh-v1.5"


使用官方镜像启动DB-GPT服务。
1. 选择知识库
2. 新增知识库-> Knowledge Graph
3. 上传文件
4. 对文件进行分割
观察日志，会看到上述错误。


# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
