### PR TITLE
fix(#2995): ignore leading vis-thinking block in react parser

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
@@ -3,6 +3,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
+from dbgpt.vis.tags.vis_thinking import VisThinking
+
 
 @dataclass
 class ReActStep:
@@ -61,6 +63,37 @@ class ReActOutputParser:
         self.action_input_prefix_escaped = re.escape(action_input_prefix)
         self.observation_prefix_escaped = re.escape(observation_prefix)
 
+    def _strip_leading_vis_thinking_block(self, text: str) -> str:
+        """Remove the leading vis-thinking wrapper produced by VisThinking."""
+        if not text:
+            return text
+
+        stripped = text.lstrip()
+        fence = "`" * 6
+        opening = f"{fence}{VisThinking.vis_tag()}"
+        if not stripped.startswith(opening):
+            return text
+
+        lines = stripped.splitlines()
+        if len(lines) < 3 or lines[0].strip() != opening:
+            return text
+
+        closing_index = None
+        for idx in range(1, len(lines)):
+            if lines[idx].strip() == fence:
+                trailing_content = "\n".join(lines[idx + 1 :]).lstrip()
+                if not trailing_content or trailing_content.startswith(
+                    self.thought_prefix
+                ):
+                    closing_index = idx
+                    break
+
+        if closing_index is None:
+            return text
+
+        stripped_content = "\n".join(lines[closing_index + 1 :]).lstrip()
+        return stripped_content
+
     def parse(self, text: str) -> List[ReActStep]:
         """
         Parse the ReAct format output text into structured steps.
@@ -76,7 +109,7 @@ class ReActOutputParser:
         steps = []
 
         # Remove any leading/trailing whitespace
-        text = text.strip()
+        text = self._strip_leading_vis_thinking_block(text).strip()
 
         # Find all instances of the thought prefix
         thought_matches = list(re.finditer(rf"{self.thought_prefix_escaped}\s*", text))


### PR DESCRIPTION
# Description

更新了react_parser.py，让 ReAct 解析在提取 Thought / Phase / Action / Action Input 之前，先忽略前置的 vis-thinking 包装内容。

这次改动只发生在 parser 层，范围很小：
当模型输出以前置 VisThinking 块开头时，parser 会先剥离这段 thinking 包装，再继续解析正文。
如果剥离之后没有正文内容，parser 会返回空步骤列表，而不是把 thinking 内容误当成可执行的 ReAct step。
thinking 结束位置的判断也做了收敛，避免两类边界问题：
不会因为 thinking 内部出现 fence 而过早截断
不会把后续真实正文错误吞进 thinking 区域
这个修改修复了 deepseek-reasoner 在 ReAct 场景下，因 reasoning 内容被误解析成多个 step，从而触发 Only one action is allowed each time. 的问题。

# How Has This Been Tested?

测试覆盖的场景包括：
标准 ReAct 文本解析行为保持不变
前置 vis-thinking 块会被正确忽略
只有 vis-thinking、没有正文时，返回空步骤
thinking 内容内部包含 standalone fence 时，仍能正确跳过 thinking
正文本身包含 standalone fence 时，不会被错误吞掉，仍能正常解析

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
