### PR TITLE
Add HOL skill validate workflow

### DIFF
--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -1,0 +1,19 @@
+name: Validate Skill
+on:
+  pull_request:
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  workflow_dispatch:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashgraph-online/skill-publish@v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
## Hi 👋

Adding a **validate-only** workflow for skill packages. This runs on every PR that touches SKILL.md or skill.json — no API keys needed.

### What's included
- `.github/workflows/validate-skill.yml`

### Why
- Free to run (no secrets)
- Catches formatting issues early
- Sets you up for optional publishing later

Let me know if you'd like changes!