### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -1,0 +1,19 @@
+name: Validate Skill
+on:
+  pull_request:
+    paths:
+      - 'SKILL.md'
+      - 'skill.json'
+  workflow_dispatch:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashgraph-online/skill-publish@v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
I opened this as a small validate-only check for the skill metadata in the repo.

A couple of repo-specific details I checked first:
- An open-source AI data assistant that connects to your data, writes SQL and code, runs skills in sandboxed environments, and turns analysis into reports, insights, and action
- DB-GPT is also a platform for building AI-native data agents, workflows, and applications with agents, AWEL, RAG, and multi-model support
- Plan tasks, break work into steps, call tools, and complete analysis workflows end to end

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.