### PR TITLE
fix: use explicit UTF-8 encoding when writing code_interpreter temp script

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -1698,7 +1698,7 @@ print(json.dumps(summary, ensure_ascii=False))
 
         try:
             tmp_path = os.path.join(work_dir, "_run.py")
-            with open(tmp_path, "w") as tmp:
+            with open(tmp_path, "w", encoding="utf-8") as tmp:
                 tmp.write(full_code)
 
             proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
Fixes #3020

## Problem

On Windows, `open()` in text mode without an explicit `encoding=` argument uses the locale-dependent default encoding (e.g. GBK/CP936) instead of UTF-8. When the AI-generated `_run.py` script contains non-ASCII characters (e.g. Chinese string literals), Python interprets the source file as UTF-8 and raises a `SyntaxError`:

```
SyntaxError: Non-UTF-8 code starting with '\xce' in file ..._run.py on line 11, but no encoding declared
```

This is a cross-platform correctness issue because Python source files default to UTF-8 encoding, but the file was written using the OS locale encoding.

## Solution

Add `encoding="utf-8"` to the `open()` call that writes the temporary `_run.py` script:

```python
# Before
with open(tmp_path, "w") as tmp:

# After  
with open(tmp_path, "w", encoding="utf-8") as tmp:
```

This ensures the generated script is always written in UTF-8, consistent with Python's default source encoding expectation on all platforms.

## Testing

- The fix is a one-line change that aligns Python's source encoding requirement with the file write encoding.
- Reproduces on Windows with a Chinese-character string literal in the generated code; after this fix the `SyntaxError` no longer occurs.