### PR TITLE
fix(rag): honor configured Tongyi embedding model name (Fixes #3029)

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/embeddings/tongyi.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/embeddings/tongyi.py
@@ -32,7 +32,7 @@ class TongyiEmbeddingDeployModelParameters(EmbeddingDeployModelParameters):
     @property
     def real_provider_model_name(self) -> str:
         """Get the real provider model name."""
-        return self.backend or self.name
+        return self.name or self.backend
 
 
 class TongYiEmbeddings(BaseModel, Embeddings):


### PR DESCRIPTION
## Summary
- prioritize name over backend when resolving Tongyi embedding provider model
- prevents configured text-embedding-v3 from being overridden by backend default

## Change
- 1-line change in packages/dbgpt-ext/src/dbgpt_ext/rag/embeddings/tongyi.py

Fixes #3029