### PR TITLE
feat: Adds support for vector search with Qdrant

### DIFF
--- a/packages/dbgpt-ext/pyproject.toml
+++ b/packages/dbgpt-ext/pyproject.toml
@@ -78,6 +78,7 @@ storage_chromadb = [
     "chromadb>=0.4.22"
     ]
 storage_elasticsearch = ["elasticsearch"]
+storage_qdrant = ["qdrant-client>=1.17.1; python_version < '3.13'"]
 storage_obvector = ["pyobvector"]
 
 file_oss = [

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/__init__.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/__init__.py
@@ -57,6 +57,15 @@ def _import_elastic() -> Tuple[Type, Type]:
     return ElasticStore, ElasticsearchStoreConfig
 
 
+def _import_qdrant() -> Tuple[Type, Type]:
+    from dbgpt_ext.storage.vector_store.qdrant_store import (
+        QdrantStore,
+        QdrantVectorConfig,
+    )
+
+    return QdrantStore, QdrantVectorConfig
+
+
 def _import_builtin_knowledge_graph() -> Tuple[Type, Type]:
     from dbgpt_ext.storage.knowledge_graph.knowledge_graph import (
         BuiltinKnowledgeGraph,
@@ -101,6 +110,8 @@ def _select_rag_storage(name: str) -> Tuple[Type, Type]:
         return _import_oceanbase()
     elif name == "ElasticSearch":
         return _import_elastic()
+    elif name == "Qdrant":
+        return _import_qdrant()
     elif name == "KnowledgeGraph":
         return _import_builtin_knowledge_graph()
     elif name == "CommunitySummaryKnowledgeGraph":
@@ -149,6 +160,7 @@ __vector_store__ = [
     "OceanBase",
     "PGVector",
     "ElasticSearch",
+    "Qdrant",
 ]
 
 __knowledge_graph__ = ["KnowledgeGraph", "CommunitySummaryKnowledgeGraph", "OpenSPG"]

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
@@ -1,0 +1,352 @@
+"""Qdrant vector store."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from dbgpt.core import Chunk, Embeddings
+from dbgpt.core.awel.flow import Parameter, ResourceCategory, register_resource
+from dbgpt.storage.vector_store.base import (
+    _COMMON_PARAMETERS,
+    _VECTOR_STORE_COMMON_PARAMETERS,
+    VectorStoreBase,
+    VectorStoreConfig,
+)
+from dbgpt.storage.vector_store.filters import (
+    FilterCondition,
+    FilterOperator,
+    MetadataFilters,
+)
+from dbgpt.util.i18n_utils import _
+
+logger = logging.getLogger(__name__)
+
+
+def _chunk_id_to_uuid(chunk_id: str) -> str:
+    """
+    Qdrant only allows UUIDs or +ve integers to be used as point IDs.
+    Ref: https://qdrant.tech/documentation/manage-data/points/#point-ids
+    """
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, chunk_id))
+
+
+@register_resource(
+    _("Qdrant Config"),
+    "qdrant_vector_config",
+    category=ResourceCategory.VECTOR_STORE,
+    description=_("Qdrant vector store config."),
+    parameters=[
+        *_COMMON_PARAMETERS,
+        Parameter.build_from(
+            _("Host"),
+            "host",
+            str,
+            description=_("The host of Qdrant store."),
+            optional=True,
+            default="localhost",
+        ),
+        Parameter.build_from(
+            _("Port"),
+            "port",
+            int,
+            description=_("The HTTP port of Qdrant store."),
+            optional=True,
+            default=6333,
+        ),
+        Parameter.build_from(
+            _("API Key"),
+            "api_key",
+            str,
+            description=_("The API key for Qdrant Cloud or secured Qdrant instances."),
+            optional=True,
+            default=None,
+        ),
+        Parameter.build_from(
+            _("Use HTTPS"),
+            "https",
+            bool,
+            description=_("Whether to use HTTPS for the Qdrant connection."),
+            optional=True,
+            default=False,
+        ),
+        Parameter.build_from(
+            _("Prefer gRPC"),
+            "prefer_grpc",
+            bool,
+            description=_(
+                "Whether to prefer gRPC over HTTP for data plane operations."
+            ),
+            optional=True,
+            default=False,
+        ),
+    ],
+)
+@dataclass
+class QdrantVectorConfig(VectorStoreConfig):
+    """Qdrant vector store config."""
+
+    __type__ = "qdrant"
+
+    host: str = field(
+        default_factory=lambda: os.getenv("QDRANT_HOST", "localhost"),
+        metadata={"help": _("The host of Qdrant store.")},
+    )
+    port: int = field(
+        default_factory=lambda: int(os.getenv("QDRANT_PORT", "6333")),
+        metadata={"help": _("The HTTP port of Qdrant store.")},
+    )
+    api_key: Optional[str] = field(
+        default_factory=lambda: os.getenv("QDRANT_API_KEY"),
+        metadata={
+            "help": _("The API key for Qdrant Cloud or secured Qdrant instances.")
+        },
+    )
+    https: bool = field(
+        default=False,
+        metadata={"help": _("Whether to use HTTPS for the Qdrant connection.")},
+    )
+    prefer_grpc: bool = field(
+        default=False,
+        metadata={
+            "help": _("Whether to prefer gRPC over HTTP for data plane operations.")
+        },
+    )
+
+    def create_store(self, **kwargs) -> "QdrantStore":
+        """Create QdrantStore."""
+        return QdrantStore(vector_store_config=self, **kwargs)
+
+
+@register_resource(
+    _("Qdrant Vector Store"),
+    "qdrant_vector_store",
+    category=ResourceCategory.VECTOR_STORE,
+    description=_("Qdrant vector store."),
+    parameters=[
+        Parameter.build_from(
+            _("Qdrant Config"),
+            "vector_store_config",
+            QdrantVectorConfig,
+            description=_("the qdrant config of vector store."),
+            optional=True,
+            default=None,
+        ),
+        *_VECTOR_STORE_COMMON_PARAMETERS,
+    ],
+)
+class QdrantStore(VectorStoreBase):
+    """Qdrant vector store."""
+
+    def __init__(
+        self,
+        vector_store_config: QdrantVectorConfig,
+        name: Optional[str],
+        embedding_fn: Optional[Embeddings] = None,
+        max_chunks_once_load: Optional[int] = None,
+        max_threads: Optional[int] = None,
+    ) -> None:
+        try:
+            from qdrant_client import QdrantClient
+        except ImportError:
+            raise ImportError("Please install qdrant-client: pip install qdrant-client")
+        super().__init__(
+            max_chunks_once_load=max_chunks_once_load, max_threads=max_threads
+        )
+        if embedding_fn is None:
+            raise ValueError("embedding_fn is required for QdrantStore")
+
+        self._vector_store_config = vector_store_config
+        self.embeddings = embedding_fn
+        self.collection_name = name
+
+        self._client = QdrantClient(
+            host=vector_store_config.host,
+            port=vector_store_config.port,
+            api_key=vector_store_config.api_key,
+            https=vector_store_config.https,
+            prefer_grpc=vector_store_config.prefer_grpc,
+        )
+        self.create_collection(self.collection_name)
+
+    def get_config(self) -> QdrantVectorConfig:
+        """Get the vector store config."""
+        return self._vector_store_config
+
+    def create_collection(self, collection_name: str, **kwargs) -> None:
+        """Create a Qdrant collection."""
+        from qdrant_client.models import Distance, VectorParams
+
+        if self._client.collection_exists(collection_name):
+            return
+
+        dim = len(self.embeddings.embed_query("probe"))
+        self._client.create_collection(
+            collection_name=collection_name,
+            vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+        )
+
+    def load_document(self, chunks: List[Chunk]) -> List[str]:
+        """Load document in vector database."""
+        from qdrant_client.models import PointStruct
+
+        texts = [chunk.content for chunk in chunks]
+        vectors = self.embeddings.embed_documents(texts)
+        points = [
+            PointStruct(
+                id=_chunk_id_to_uuid(chunk.chunk_id),
+                vector=vector,
+                payload={
+                    "content": chunk.content,
+                    "metadata": chunk.metadata,
+                    "chunk_id": chunk.chunk_id,
+                },
+            )
+            for chunk, vector in zip(chunks, vectors)
+        ]
+        self._client.upsert(collection_name=self.collection_name, points=points)
+        return [chunk.chunk_id for chunk in chunks]
+
+    def _query(
+        self,
+        text: str,
+        topk: int,
+        filters: Optional[MetadataFilters] = None,
+        score_threshold: Optional[float] = None,
+    ) -> List[Chunk]:
+        query_vector = self.embeddings.embed_query(text)
+        qdrant_filter = self.convert_metadata_filters(filters) if filters else None
+        response = self._client.query_points(
+            collection_name=self.collection_name,
+            query=query_vector,
+            limit=topk,
+            query_filter=qdrant_filter,
+            with_payload=True,
+            score_threshold=score_threshold,
+        )
+        return [
+            Chunk(
+                content=r.payload.get("content", ""),
+                metadata=r.payload.get("metadata", {}),
+                score=r.score,
+                chunk_id=r.payload.get("chunk_id", ""),
+            )
+            for r in response.points
+        ]
+
+    def similar_search(
+        self, text: str, topk: int, filters: Optional[MetadataFilters] = None
+    ) -> List[Chunk]:
+        """Search similar documents."""
+        return self._query(text, topk, filters)
+
+    def similar_search_with_scores(
+        self,
+        text: str,
+        topk: int,
+        score_threshold: float,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[Chunk]:
+        """Search similar documents with scores."""
+        chunks = self._query(text, topk, filters, score_threshold)
+        return self.filter_by_score_threshold(chunks, score_threshold)
+
+    def vector_name_exists(self) -> bool:
+        """Whether vector name exists."""
+        try:
+            if not self._client.collection_exists(self.collection_name):
+                return False
+
+            return self._client.count(self.collection_name).count > 0
+        except Exception as e:
+            logger.error(f"vector_name_exists error, {str(e)}")
+            return False
+
+    def delete_vector_name(self, vector_name: str):
+        """Delete vector name."""
+        logger.info(f"qdrant vector_name:{vector_name} begin delete...")
+        self._client.delete_collection(self.collection_name)
+        return True
+
+    def delete_by_ids(self, ids: str, batch_size: int = 1000) -> List[str]:
+        """Delete vector by ids."""
+        from qdrant_client.models import PointIdsList
+
+        id_list = [i.strip() for i in ids.split(",") if i.strip()]
+        point_ids = [_chunk_id_to_uuid(cid) for cid in id_list]
+        for i in range(0, len(point_ids), batch_size):
+            batch = point_ids[i : i + batch_size]
+            self._client.delete(
+                collection_name=self.collection_name,
+                points_selector=PointIdsList(points=batch),
+            )
+        return id_list
+
+    def truncate(self) -> List[str]:
+        """Truncate data."""
+        logger.info(f"begin truncate qdrant collection:{self.collection_name}")
+        all_ids = []
+        next_offset = None
+        while True:
+            records, next_offset = self._client.scroll(
+                collection_name=self.collection_name,
+                limit=1000,
+                offset=next_offset,
+                with_payload=False,
+                with_vectors=False,
+            )
+            all_ids.extend(str(r.id) for r in records)
+            if next_offset is None:
+                break
+
+        if all_ids:
+            self._client.delete(
+                collection_name=self.collection_name,
+                points_selector=all_ids,
+            )
+        return all_ids
+
+    def convert_metadata_filters(self, filters: MetadataFilters) -> Any:
+        """Convert metadata filters to Qdrant filters."""
+        from qdrant_client.models import (
+            FieldCondition,
+            Filter,
+            MatchAny,
+            MatchValue,
+            Range,
+        )
+
+        positive = []
+        negative = []
+
+        for f in filters.filters:
+            key = f"metadata.{f.key}"
+            op = f.operator
+            val = f.value
+
+            if op == FilterOperator.EQ:
+                positive.append(FieldCondition(key=key, match=MatchValue(value=val)))
+            elif op == FilterOperator.GT:
+                positive.append(FieldCondition(key=key, range=Range(gt=val)))
+            elif op == FilterOperator.GTE:
+                positive.append(FieldCondition(key=key, range=Range(gte=val)))
+            elif op == FilterOperator.LT:
+                positive.append(FieldCondition(key=key, range=Range(lt=val)))
+            elif op == FilterOperator.LTE:
+                positive.append(FieldCondition(key=key, range=Range(lte=val)))
+            elif op == FilterOperator.NE:
+                negative.append(FieldCondition(key=key, match=MatchValue(value=val)))
+            elif op == FilterOperator.IN:
+                positive.append(FieldCondition(key=key, match=MatchAny(any=val)))
+            elif op == FilterOperator.NIN:
+                negative.append(FieldCondition(key=key, match=MatchAny(any=val)))
+            else:
+                raise ValueError(f"Qdrant Where operator {op} not supported")
+
+        if filters.condition == FilterCondition.AND:
+            return Filter(must=positive or None, must_not=negative or None)
+        else:
+            return Filter(should=positive or None, must_not=negative or None)

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
@@ -77,9 +77,7 @@ def _chunk_id_to_uuid(chunk_id: str) -> str:
             _("Prefer gRPC"),
             "prefer_grpc",
             bool,
-            description=_(
-                "Whether to prefer gRPC for data plane operations."
-            ),
+            description=_("Whether to prefer gRPC for data plane operations."),
             optional=True,
             default=False,
         ),

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
@@ -45,7 +45,7 @@ def _chunk_id_to_uuid(chunk_id: str) -> str:
             _("Host"),
             "host",
             str,
-            description=_("The host of Qdrant store."),
+            description=_("The host of the Qdrant instance."),
             optional=True,
             default="localhost",
         ),
@@ -53,7 +53,7 @@ def _chunk_id_to_uuid(chunk_id: str) -> str:
             _("Port"),
             "port",
             int,
-            description=_("The HTTP port of Qdrant store."),
+            description=_("The REST port of the Qdrant instance."),
             optional=True,
             default=6333,
         ),
@@ -78,10 +78,18 @@ def _chunk_id_to_uuid(chunk_id: str) -> str:
             "prefer_grpc",
             bool,
             description=_(
-                "Whether to prefer gRPC over HTTP for data plane operations."
+                "Whether to prefer gRPC for data plane operations."
             ),
             optional=True,
             default=False,
+        ),
+        Parameter.build_from(
+            _("gRPC Port"),
+            "grpc_port",
+            int,
+            description=_("The gRPC port of the Qdrant instance."),
+            optional=True,
+            default=6334,
         ),
     ],
 )
@@ -114,6 +122,10 @@ class QdrantVectorConfig(VectorStoreConfig):
         metadata={
             "help": _("Whether to prefer gRPC over HTTP for data plane operations.")
         },
+    )
+    grpc_port: int = field(
+        default_factory=lambda: int(os.getenv("QDRANT_GRPC_PORT", "6334")),
+        metadata={"help": _("The gRPC port of Qdrant store.")},
     )
 
     def create_store(self, **kwargs) -> "QdrantStore":
@@ -166,6 +178,7 @@ class QdrantStore(VectorStoreBase):
         self._client = QdrantClient(
             host=vector_store_config.host,
             port=vector_store_config.port,
+            grpc_port=vector_store_config.grpc_port,
             api_key=vector_store_config.api_key,
             https=vector_store_config.https,
             prefer_grpc=vector_store_config.prefer_grpc,


### PR DESCRIPTION
## Note

The lockfile update has ballooned the diff to 7000 lines. The code is about 400 lines. 

## Description

This PR adds support for using [Qdrant](https://qdrant.tech/) as a vector search provider in DB GPT.

Qdrant is an open-source vector search engine for high-performance and massive scale.

### Testing

I've unit tested this integration against a local Qdrant instance.

### Setup

You can run Qdrant with 

```bash
docker run -p 6333:6333 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard

You can also use `-p 6334:6334` for more performance using Qdrant's gRPC API.

Ref: https://qdrant.tech/documentation/interfaces/#api-reference