### PR TITLE
fix: add authentication dependency to knowledge module endpoints

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/knowledge/api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/knowledge/api.py
@@ -56,6 +56,7 @@ from dbgpt_serve.rag.api.schemas import (
 # from dbgpt_serve.rag.connector import VectorStoreConnector
 from dbgpt_serve.rag.service.service import Service
 from dbgpt_serve.rag.storage_manager import StorageManager
+from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,10 @@ def get_fs() -> FileStorageClient:
 
 
 @router.post("/knowledge/space/add")
-async def space_add(request: KnowledgeSpaceRequest):
+async def space_add(
+    request: KnowledgeSpaceRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/space/add params: {request}")
     try:
         await blocking_func_to_async(
@@ -127,7 +131,9 @@ def space_delete(request: KnowledgeSpaceRequest):
 
 
 @router.post("/knowledge/retrieve_strategy_list")
-async def retrieve_strategy_list():
+async def retrieve_strategy_list(
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     try:
         res = await blocking_func_to_async(
             get_executor(), knowledge_space_service.get_retrieve_strategy_list
@@ -153,6 +159,7 @@ async def arguments(space_id: str):
 async def recall_test(
     space_name: str,
     request: DocumentRecallTestRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"/knowledge/{space_name}/recall_test params: {request}")
     try:
@@ -204,7 +211,11 @@ def recall_retrievers(
 
 
 @router.post("/knowledge/{space_id}/argument/save")
-async def arguments_save(space_id: str, argument_request: SpaceArgumentRequest):
+async def arguments_save(
+    space_id: str,
+    argument_request: SpaceArgumentRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     print("/knowledge/space/argument/save params:")
     try:
         res = await blocking_func_to_async(
@@ -342,7 +353,11 @@ async def space_config() -> Result[KnowledgeConfigResponse]:
 
 
 @router.post("/knowledge/{space_name}/document/list")
-def document_list(space_name: str, query_request: DocumentQueryRequest):
+def document_list(
+    space_name: str,
+    query_request: DocumentQueryRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/document/list params: {space_name}, {query_request}")
     try:
         return Result.succ(


### PR DESCRIPTION
# Add authentication dependency to knowledge module endpoints (5 of 19)

## Summary

This PR adds `Depends(get_user_from_headers)` to 5 endpoints in
`packages/dbgpt-app/src/dbgpt_app/knowledge/api.py` that currently lack
authentication.

This is a partial fix for the systematic authentication omission documented
in:
- This PR's companion issue (linked above)
- Issue #3036 (per-endpoint surface analysis)

## Background

The `knowledge` module's `APIRouter()` is declared at line 63 without
`dependencies`, and individual endpoints do not declare
`Depends(get_user_from_headers)`. This results in unauthenticated access
to operations that should require authentication.

The same authentication pattern (`Depends(get_user_from_headers)`) is
already used 48 times in 14 other files in this codebase
(`api_v1.py`, `python_upload_api.py`, `agentic_data_api.py`,
`examples_api.py`, etc.), so this PR simply applies the project's
existing convention to the affected endpoints.

## Scope of this PR

This PR addresses 5 of the 19 affected endpoints, prioritizing:
- Diverse endpoint families (space/add, document/list, recall_test,
  argument/save, retrieve_strategy_list)
- Endpoints not already named in Issue #3036
- A range of CVSS impact levels (5.3-8.5)

| Endpoint | Line | CVSS |
|---|---|---|
| `/knowledge/space/add` | 83 | 8.5 |
| `/knowledge/{space_name}/document/list` | 344 | 7.5 |
| `/knowledge/{space_name}/recall_test` | 152 | 7.5 |
| `/knowledge/{space_id}/argument/save` | 206 | 7.5 |
| `/knowledge/retrieve_strategy_list` | 129 | 5.3 |

The remaining 14 endpoints in the same module require similar treatment
but are out of scope for this PR. They are documented in the companion
issue. I am happy to extend this PR to cover all 19 endpoints if
maintainers prefer a single comprehensive fix.

## Changes

For each affected endpoint, this PR:
1. Adds the import `from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers`
   (the canonical import path used by `api_v1.py` and 3 other files in this codebase)
2. Adds `user_token: UserRequest = Depends(get_user_from_headers)` to the
   endpoint signature

Example diff:

```python
# BEFORE
@router.post("/knowledge/space/add")
async def space_add(request: KnowledgeSpaceRequest):
    ...

# AFTER
@router.post("/knowledge/space/add")
async def space_add(
    request: KnowledgeSpaceRequest,
    user_token: UserRequest = Depends(get_user_from_headers),
):
    ...
```

## Testing

Verified against a default DB-GPT installation (`docker compose up`):
- Before fix: `curl -X POST http://localhost:5670/knowledge/space/add -d '{}'`
  returns HTTP 200 (auth bypass)
- After fix: same request returns an authentication challenge
  (the standard behavior of `get_user_from_headers` when `user-id` header
  is absent)

## Relationship to CVE-2024-10906

CVE-2024-10906 reports CSRF in DB-GPT due to permissive CORS
(`Access-Control-Allow-Origin: *`). This PR partially addresses the
impact described there by adding authentication dependencies that
prevent unauthenticated invocation of the 5 fixed endpoints. The
remaining endpoints (14 in this module + others outside this module)
still need authentication for full coverage.

## Notes for maintainers

- This PR follows the project's existing convention
  (`Depends(get_user_from_headers)`) rather than introducing new patterns.
- The companion issue documents all 19 affected endpoints in this module
  for reference.
- I'm happy to extend this PR to cover all 19 endpoints if maintainers
  prefer a complete fix in a single PR.

---

**Companion issue:** https://github.com/eosphoros-ai/DB-GPT/issues/3037
