### PR TITLE
fix(datasource): override get_fields() for MSSQL with SQL Server-correct INFORMATION_SCHEMA

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_mssql.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_mssql.py
@@ -1,7 +1,7 @@
 """MSSQL connector."""
 
 from dataclasses import dataclass, field
-from typing import Iterable, Type
+from typing import Iterable, List, Tuple, Type
 
 from sqlalchemy import text
 
@@ -77,6 +77,67 @@ class MSSQLConnector(RDBMSConnector):
                     table_colums.append(field_info[0])
                 results.append(f"{table_name}({','.join(table_colums)});")
             return results
+
+    def get_fields(self, table_name, db_name=None) -> List[Tuple]:
+        """Get column fields about specified table.
+
+        SQL Server's INFORMATION_SCHEMA does NOT have COLUMN_TYPE or
+        COLUMN_COMMENT (those are MySQL-only). Override the base
+        ``RDBMSConnector.get_fields`` MySQL-shaped query with a SQL Server
+        variant that returns the same 5-tuple shape:
+        ``(column_name, data_type, default, is_nullable, comment)``.
+
+        Column comments come from ``sys.extended_properties`` with name
+        ``MS_Description`` (the standard MS convention).
+
+        ``table_name`` may include a schema prefix like ``dbo.MyTable``;
+        if absent, defaults to ``dbo``. The ``db_name`` argument is ignored
+        because the active connection is already scoped to a database, and
+        upstream callers in editor APIs sometimes pass the catalog name in
+        a position where INFORMATION_SCHEMA expects the schema.
+        """
+        if "." in table_name:
+            schema_name, pure_table_name = table_name.split(".", 1)
+        else:
+            schema_name = "dbo"
+            pure_table_name = table_name
+
+        with self.session_scope() as session:
+            query = """
+            SELECT
+                c.COLUMN_NAME,
+                c.DATA_TYPE,
+                c.COLUMN_DEFAULT,
+                c.IS_NULLABLE,
+                CAST(ep.value AS NVARCHAR(MAX)) AS COLUMN_COMMENT
+            FROM INFORMATION_SCHEMA.COLUMNS c
+            LEFT JOIN sys.extended_properties ep
+                ON ep.major_id = OBJECT_ID(
+                       QUOTENAME(c.TABLE_SCHEMA) + '.' + QUOTENAME(c.TABLE_NAME))
+                AND ep.minor_id = COLUMNPROPERTY(
+                       OBJECT_ID(QUOTENAME(c.TABLE_SCHEMA) + '.'
+                                 + QUOTENAME(c.TABLE_NAME)),
+                       c.COLUMN_NAME, 'ColumnId')
+                AND ep.class = 1
+                AND ep.name = 'MS_Description'
+            WHERE c.TABLE_SCHEMA = :schema
+              AND c.TABLE_NAME   = :table
+            ORDER BY c.ORDINAL_POSITION
+            """
+            cursor = session.execute(
+                text(query), {"schema": schema_name, "table": pure_table_name}
+            )
+            fields = cursor.fetchall()
+            return [
+                (
+                    self._decode_if_bytes(f[0]),
+                    self._decode_if_bytes(f[1]),
+                    self._decode_if_bytes(f[2]) if f[2] is not None else None,
+                    self._decode_if_bytes(f[3]),
+                    self._decode_if_bytes(f[4]) if f[4] is not None else "",
+                )
+                for f in fields
+            ]
 
     def get_users(self):
         with self.session_scope() as session:


### PR DESCRIPTION
## Problem

`MSSQLConnector` (in `dbgpt_ext.datasource.rdbms.conn_mssql`) inherits `RDBMSConnector.get_fields()` from `dbgpt-core`, which emits MySQL-only column names (`COLUMN_TYPE`, `COLUMN_COMMENT`) from `INFORMATION_SCHEMA.COLUMNS`. On SQL Server those columns do not exist, so any caller that asks for column metadata fails. Most visibly, `/api/v1/editor/db/tables` returns a 500 with:

```
(pymssql.exceptions.ProgrammingError) (207, b"Invalid column name 'COLUMN_TYPE'.")
[SQL: SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAULT, IS_NULLABLE,
      COLUMN_COMMENT  from information_schema.COLUMNS
      where table_name='dbo.<some_table>' AND table_schema='<DB_NAME>']
```

## Reproduce

1. Add a working MSSQL datasource (e.g. via `POST /api/v2/serve/datasources`).
2. `GET /api/v1/editor/db/tables?db_name=<DB>&page_index=1&page_size=10`.
3. Server returns `err_code: E0003` with the `Invalid column name 'COLUMN_TYPE'` message above.

## Fix

Override `get_fields()` in `MSSQLConnector` with a SQL Server-correct query that:

- Selects `DATA_TYPE` (the SQL Server equivalent of MySQL's `COLUMN_TYPE`).
- LEFT JOINs `sys.extended_properties` (name = `MS_Description`) to retrieve column comments, since SQL Server has no `INFORMATION_SCHEMA.COLUMN_COMMENT`.
- Parses an optional `schema.table` prefix into separate schema/table args, defaulting schema to `dbo`.
- Ignores `db_name` (the catalog), because the connection is already scoped to a database; upstream editor APIs sometimes pass the catalog where `INFORMATION_SCHEMA` expects the schema.

Returns the same 5-tuple shape `(column_name, data_type, default, is_nullable, comment)` as the base implementation, so all existing call sites work unchanged.

## Test

Tested against **SQL Server 2016 SP2** with **pymssql 2.3.13**:

- `GET /api/v1/editor/db/tables?db_name=BPMDB&page_index=1&page_size=10` now returns the full schema tree (table → columns with `int`/`nvarchar`/etc.) instead of a 500.
- `chat_with_db_execute` against the same datasource continues to return correct answers (was already working through a different code path).
- `db_summary` schema embedding continues to work.

## Notes

- No new dependencies. Uses only `INFORMATION_SCHEMA.COLUMNS` and `sys.extended_properties`, both standard SQL Server views.
- Comments default to empty string when no `MS_Description` extended property is set, matching the previous "no comment" behavior on databases that don't use that convention.
- Doesn't change behavior for any other database backend; only `MSSQLConnector.get_fields` is added.
