### PR TITLE
fix(storage,datasource): per-chunk error tolerance + per-db indexing lock

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/storage/base.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/base.py
@@ -112,6 +112,76 @@ class IndexStoreBase(ABC):
         """Whether name exists."""
         return True
 
+    def _safe_load_group(self, chunk_group: List[Chunk]) -> List[str]:
+        """Load a chunk group with per-chunk fallback on group-level failure.
+
+        Embedding back-ends can fail for individual chunks (e.g. NaN values in
+        FP16 quantized models, or context-length overruns on a few outlier
+        rows). Without this wrapper, a single bad chunk in a 10-chunk group
+        causes ``load_document`` to raise, which propagates up through
+        ``load_document_with_limit`` and aborts the entire indexing job —
+        leaving zero chunks committed even when 99% of inputs are valid.
+
+        Strategy: try the group as a whole; on failure, retry each chunk
+        individually so we lose only the genuinely-bad ones. Returns the ids
+        of successfully-loaded chunks (possibly empty).
+        """
+        try:
+            return self.load_document(chunk_group)
+        except Exception as group_err:
+            if len(chunk_group) <= 1:
+                logger.warning(
+                    "Skipping chunk that failed to load: "
+                    f"chunk_id={getattr(chunk_group[0], 'chunk_id', '?') if chunk_group else '?'} "
+                    f"error={group_err}"
+                )
+                return []
+            logger.warning(
+                f"Group of {len(chunk_group)} chunks failed ({group_err}); "
+                "falling back to per-chunk retry"
+            )
+            ids: List[str] = []
+            for chunk in chunk_group:
+                try:
+                    ids.extend(self.load_document([chunk]))
+                except Exception as chunk_err:
+                    logger.warning(
+                        "Skipping chunk that failed to load: "
+                        f"chunk_id={getattr(chunk, 'chunk_id', '?')} "
+                        f"error={chunk_err}"
+                    )
+            return ids
+
+    async def _safe_aload_group(
+        self, chunk_group: List[Chunk], file_id: Optional[str] = None
+    ) -> List[str]:
+        """Async counterpart of ``_safe_load_group``."""
+        try:
+            return await self.aload_document(chunk_group, file_id)
+        except Exception as group_err:
+            if len(chunk_group) <= 1:
+                logger.warning(
+                    "Skipping chunk that failed to load: "
+                    f"chunk_id={getattr(chunk_group[0], 'chunk_id', '?') if chunk_group else '?'} "
+                    f"error={group_err}"
+                )
+                return []
+            logger.warning(
+                f"Group of {len(chunk_group)} chunks failed ({group_err}); "
+                "falling back to per-chunk retry"
+            )
+            ids: List[str] = []
+            for chunk in chunk_group:
+                try:
+                    ids.extend(await self.aload_document([chunk], file_id))
+                except Exception as chunk_err:
+                    logger.warning(
+                        "Skipping chunk that failed to load: "
+                        f"chunk_id={getattr(chunk, 'chunk_id', '?')} "
+                        f"error={chunk_err}"
+                    )
+            return ids
+
     def load_document_with_limit(
         self,
         chunks: List[Chunk],
@@ -126,7 +196,14 @@ class IndexStoreBase(ABC):
             max_threads(int): Max number of threads to use.
 
         Return:
-            List[str]: Chunk ids.
+            List[str]: Chunk ids of successfully-loaded chunks.
+
+        Note:
+            Individual chunks that fail to load (e.g. due to embedding back-end
+            errors on outlier inputs) are skipped with a warning; this method
+            no longer raises when a partial subset of chunks fails. Callers
+            that need strict all-or-nothing semantics should call
+            ``load_document`` directly.
         """
         max_chunks_once_load = max_chunks_once_load or self._max_chunks_once_load
         max_threads = max_threads or self._max_threads
@@ -141,19 +218,26 @@ class IndexStoreBase(ABC):
         )
         ids = []
         loaded_cnt = 0
+        skipped_cnt = 0
         start_time = time.time()
         with ThreadPoolExecutor(max_workers=max_threads) as executor:
             tasks = []
             for chunk_group in chunk_groups:
-                tasks.append(executor.submit(self.load_document, chunk_group))
-            for future in tasks:
+                tasks.append(executor.submit(self._safe_load_group, chunk_group))
+            for future, chunk_group in zip(tasks, chunk_groups):
                 success_ids = future.result()
                 ids.extend(success_ids)
                 loaded_cnt += len(success_ids)
+                skipped_cnt += len(chunk_group) - len(success_ids)
                 logger.info(f"Loaded {loaded_cnt} chunks, total {len(chunks)} chunks.")
-        logger.info(
-            f"Loaded {len(chunks)} chunks in {time.time() - start_time} seconds"
-        )
+        elapsed = time.time() - start_time
+        if skipped_cnt:
+            logger.warning(
+                f"Loaded {loaded_cnt}/{len(chunks)} chunks in {elapsed:.1f}s; "
+                f"{skipped_cnt} chunk(s) skipped due to load errors."
+            )
+        else:
+            logger.info(f"Loaded {len(chunks)} chunks in {elapsed:.1f} seconds")
         return ids
 
     async def aload_document_with_limit(
@@ -171,7 +255,12 @@ class IndexStoreBase(ABC):
             max_threads(int): Max number of threads to use.
 
         Return:
-            List[str]: Chunk ids.
+            List[str]: Chunk ids of successfully-loaded chunks.
+
+        Note:
+            Individual chunks that fail to load are skipped with a warning;
+            this method no longer raises when a partial subset of chunks
+            fails (matching the sync ``load_document_with_limit`` behavior).
         """
         max_chunks_once_load = max_chunks_once_load or self._max_chunks_once_load
         max_threads = max_threads or self._max_threads
@@ -186,20 +275,32 @@ class IndexStoreBase(ABC):
         )
         tasks = []
         for chunk_group in chunk_groups:
-            tasks.append(self.aload_document(chunk_group, file_id))
+            tasks.append(self._safe_aload_group(chunk_group, file_id))
 
         results = await self._run_tasks_with_concurrency(tasks, max_threads)
 
         ids = []
         loaded_cnt = 0
-        for idx, success_ids in enumerate(results):
-            if isinstance(success_ids, Exception):
-                raise RuntimeError(
-                    f"Failed to load chunk group {idx + 1}: {str(success_ids)}"
-                ) from success_ids
-            ids.extend(success_ids)
-            loaded_cnt += len(success_ids)
+        skipped_cnt = 0
+        for idx, (result, chunk_group) in enumerate(zip(results, chunk_groups)):
+            if isinstance(result, Exception):
+                # _safe_aload_group already swallows per-chunk errors; an
+                # exception here would be an unexpected internal failure.
+                logger.error(
+                    f"Unexpected exception loading chunk group {idx + 1}: {result}"
+                )
+                skipped_cnt += len(chunk_group)
+                continue
+            ids.extend(result)
+            loaded_cnt += len(result)
+            skipped_cnt += len(chunk_group) - len(result)
             logger.info(f"Loaded {loaded_cnt} chunks, total {len(chunks)} chunks.")
+
+        if skipped_cnt:
+            logger.warning(
+                f"Loaded {loaded_cnt}/{len(chunks)} chunks; "
+                f"{skipped_cnt} chunk(s) skipped due to load errors."
+            )
 
         return ids
 

--- a/packages/dbgpt-core/src/dbgpt/storage/base.py
+++ b/packages/dbgpt-core/src/dbgpt/storage/base.py
@@ -130,10 +130,12 @@ class IndexStoreBase(ABC):
             return self.load_document(chunk_group)
         except Exception as group_err:
             if len(chunk_group) <= 1:
+                first_id = (
+                    getattr(chunk_group[0], "chunk_id", "?") if chunk_group else "?"
+                )
                 logger.warning(
                     "Skipping chunk that failed to load: "
-                    f"chunk_id={getattr(chunk_group[0], 'chunk_id', '?') if chunk_group else '?'} "
-                    f"error={group_err}"
+                    f"chunk_id={first_id} error={group_err}"
                 )
                 return []
             logger.warning(
@@ -160,10 +162,12 @@ class IndexStoreBase(ABC):
             return await self.aload_document(chunk_group, file_id)
         except Exception as group_err:
             if len(chunk_group) <= 1:
+                first_id = (
+                    getattr(chunk_group[0], "chunk_id", "?") if chunk_group else "?"
+                )
                 logger.warning(
                     "Skipping chunk that failed to load: "
-                    f"chunk_id={getattr(chunk_group[0], 'chunk_id', '?') if chunk_group else '?'} "
-                    f"error={group_err}"
+                    f"chunk_id={first_id} error={group_err}"
                 )
                 return []
             logger.warning(

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/db_summary_client.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/db_summary_client.py
@@ -1,8 +1,9 @@
 """DBSummaryClient class."""
 
 import logging
+import threading
 import traceback
-from typing import Tuple
+from typing import Dict, Tuple
 
 from dbgpt.component import SystemApp
 from dbgpt.core import Embeddings
@@ -16,6 +17,26 @@ from dbgpt_serve.datasource.manages import ConnectorManager
 from dbgpt_serve.rag.storage_manager import StorageManager
 
 logger = logging.getLogger(__name__)
+
+
+# Per-database mutexes to prevent concurrent indexing of the same db_name from
+# trampling each other (e.g. startup auto-summary racing with a manual /refresh
+# call). When two indexing flows run for the same db, one path's
+# delete_db_profile() can drop a chroma collection while the other path still
+# has 1000s of writes queued against its UUID, producing
+# ``Collection <uuid> does not exist`` errors for every chunk.
+_DB_INDEX_LOCKS: Dict[str, threading.Lock] = {}
+_DB_INDEX_LOCKS_GUARD = threading.Lock()
+
+
+def _get_db_index_lock(dbname: str) -> threading.Lock:
+    """Return (creating if needed) the per-db indexing mutex."""
+    with _DB_INDEX_LOCKS_GUARD:
+        lock = _DB_INDEX_LOCKS.get(dbname)
+        if lock is None:
+            lock = threading.Lock()
+            _DB_INDEX_LOCKS[dbname] = lock
+        return lock
 
 
 class DBSummaryClient:
@@ -46,7 +67,19 @@ class DBSummaryClient:
         return embedding_factory.create()
 
     def db_summary_embedding(self, dbname, db_type):
-        """Put db profile and table profile summary into vector store."""
+        """Put db profile and table profile summary into vector store.
+
+        Serializes per-db so that concurrent triggers (startup auto-summary,
+        ``/refresh`` API, retries on failure) cannot race and delete each
+        other's in-flight chroma collections.
+        """
+        lock = _get_db_index_lock(dbname)
+        if not lock.acquire(blocking=False):
+            logger.info(
+                f"{dbname} summary already in progress; "
+                "skipping concurrent trigger to avoid race with in-flight writes."
+            )
+            return
         try:
             db_summary_client = self.create_summary_client(dbname, db_type)
 
@@ -59,6 +92,8 @@ class DBSummaryClient:
                 f"{dbname}, {db_type} summary error!{str(e)}, detail: {message}"
             )
             raise
+        finally:
+            lock.release()
 
     def get_db_summary(self, dbname, query, topk):
         """Get user query related tables info."""
@@ -130,17 +165,25 @@ class DBSummaryClient:
         logger.info("initialize db summary profile success...")
 
     def delete_db_profile(self, dbname):
-        """Delete db profile."""
-        table_vector_store_name = dbname + "_profile"
-        field_vector_store_name = dbname + "_profile_field"
+        """Delete db profile.
 
-        table_vector_connector, field_vector_connector = (
-            self._get_vector_connector_by_db(dbname)
-        )
+        Held under the per-db indexing lock so a delete cannot race with a
+        concurrent embedding flow (which would otherwise see chroma drop the
+        collection mid-write and fail every subsequent chunk with
+        ``Collection <uuid> does not exist``).
+        """
+        lock = _get_db_index_lock(dbname)
+        with lock:
+            table_vector_store_name = dbname + "_profile"
+            field_vector_store_name = dbname + "_profile_field"
 
-        table_vector_connector.delete_vector_name(table_vector_store_name)
-        field_vector_connector.delete_vector_name(field_vector_store_name)
-        logger.info(f"delete db profile {dbname} success")
+            table_vector_connector, field_vector_connector = (
+                self._get_vector_connector_by_db(dbname)
+            )
+
+            table_vector_connector.delete_vector_name(table_vector_store_name)
+            field_vector_connector.delete_vector_name(field_vector_store_name)
+            logger.info(f"delete db profile {dbname} success")
 
     @staticmethod
     def create_summary_client(dbname: str, db_type: str):


### PR DESCRIPTION
## Problem

Two related deadlock-class bugs surface on large datasources (~1000+ tables) where embedding back-end transient errors and concurrent re-indexing triggers can leave a database with a permanently-empty schema RAG store.

### Bug 1: a single bad chunk aborts the whole batch

`IndexStoreBase.load_document_with_limit()` (sync) and `aload_document_with_limit()` (async) both call `future.result()` / re-raise on the first exception, so any single chunk_group that fails to embed kills the entire indexing job.

**Reproducer**: index a SQL Server database with 1000+ tables using Ollama's `bge-m3:f16` (FP16 embedding model). About 1% of inputs deterministically trigger NaN values in the model output, which Ollama's Go JSON encoder rejects with HTTP 500. With the default `max_chunks_once_load=10`, one bad chunk loses 10 chunks; the first failing group aborts the entire indexing job.

```
File ".../dbgpt/storage/base.py", in load_document_with_limit
    success_ids = future.result()  # raises -> abort
ValueError: **Ollama Response Error**: failed to encode response: json:
    unsupported value: NaN (status code: 500)
```

### Bug 2: refresh API races with in-flight indexing

`DBSummaryClient.delete_db_profile()` and `db_summary_embedding()` are unsynchronized. When a manual `/refresh` call lands while the startup auto-summary is still embedding, `delete_db_profile` drops the chroma collection that the in-flight `init_db_profile` flow has thousands of writes queued against. Every subsequent chunk fails with:

```
chromadb.errors.InvalidCollectionException:
    Collection <uuid> does not exist.
```

After Bug 1 is fixed, this manifests as Bug 2: thousands of "Skipping chunk that failed to load" warnings and zero successful writes for the target db.

## Fix

### Bug 1 — `dbgpt/storage/base.py`

Introduce `_safe_load_group` / `_safe_aload_group` wrappers that:
- Try the chunk group as a whole.
- On failure, retry each chunk individually so only the genuinely-bad chunks are skipped (with WARNING logs naming each `chunk_id`).
- The public `load_document_with_limit` / `aload_document_with_limit` methods now return the ids of successfully-loaded chunks and log a summary count when any are skipped.

Callers that need strict all-or-nothing semantics can still call `load_document` directly. The change is backward compatible for the happy path.

### Bug 2 — `dbgpt_serve/datasource/service/db_summary_client.py`

Per-database `threading.Lock` (held in a module-level dict). Both:
- `db_summary_embedding` — non-blocking acquire; concurrent triggers are skipped (logged as `already in progress; skipping concurrent trigger`), not queued.
- `delete_db_profile` — blocking acquire; delete cannot race with insert.

The same lock guards delete and insert for a given dbname, so refresh API → delete + summary cannot interleave with startup auto-summary.

## Tested

**Setup**: AAEON SQL Server BPM database with 888 tables (post-filter), Ollama `bge-m3:f16` for embeddings, single-worker DB-GPT.

**Before**: 
- BPMDB (166 tables) succeeded with 307 chunks.
- AAEONBPM (888 tables, 7326 chunks) — startup auto-summary started indexing, refresh API call deleted in-flight collection, every chunk failed with `Collection <uuid> does not exist`, 0 chunks committed, Chat DB unusable.

**After**:
- Both BPMDB and AAEONBPM index to completion at ~5 chunks/sec via Ollama bge-m3.
- Per-chunk NaN failures land as warnings (`Skipping chunk that failed to load: chunk_id=… error=… NaN (status code: 500)`) without blocking the rest of the dataset.
- Concurrent refresh during indexing logs `already in progress; skipping concurrent trigger` and no-ops, leaving in-flight job intact.
- Chat DB returns sensible table-name retrievals from the full schema.

## Notes

- No new dependencies. Uses only `threading` (already imported elsewhere in dbgpt-serve).
- The lock is per-process; if DB-GPT later runs multiple worker processes, this would need to be replaced with a distributed lock (e.g. Redis). Single-worker is the current default.
- Exception types preserved as-is so logs still surface root causes.
