### PR TITLE
fix(milvus): make MilvusStore compatible with milvus 2.5+

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -490,6 +490,12 @@ class MilvusStore(VectorStoreBase):
         """similar_search in vector database."""
         self.col = Collection(self.collection_name)
         schema = self.col.schema
+        # Reset before re-populating from schema. Without this, repeated calls
+        # accumulate every field name once per call, so the
+        # ``output_fields.remove(self.sparse_vector)`` guard in ``_search``
+        # only strips one occurrence and the duplicate trips milvus 2.5+
+        # with "not allowed to retrieve raw data of field sparse_vector".
+        self.fields = []
         for x in schema.fields:
             self.fields.append(x.name)
             if x.auto_id:
@@ -541,6 +547,10 @@ class MilvusStore(VectorStoreBase):
 
         self.col = Collection(self.collection_name)
         schema = self.col.schema
+        # See similar_search above for why the reset is necessary (avoids
+        # accumulating duplicate sparse_vector entries that bypass the
+        # output_fields.remove() guard and trip milvus 2.5+).
+        self.fields = []
         for x in schema.fields:
             self.fields.append(x.name)
             if x.auto_id:
@@ -777,12 +787,22 @@ class MilvusStore(VectorStoreBase):
     ) -> List[Chunk]:
         if self.is_support_full_text_search():
             milvus_filters = self.convert_metadata_filters(filters) if filters else None
+            # Milvus 2.5+ forbids returning sparse-vector raw data in search
+            # results ("not allowed to retrieve raw data of field
+            # sparse_vector"), so we cannot ask for "*". Build an explicit
+            # field list that excludes both vector fields. We only need
+            # content + metadata + pk for chunk construction below; this
+            # mirrors the pattern in similar_search_with_scores' _search().
+            output_fields = [
+                f for f in self.fields
+                if f != self.sparse_vector and f != self.vector_field
+            ]
             results = self._milvus_client.search(
                 collection_name=self.collection_name,
                 data=[text],
                 anns_field=self.sparse_vector,
                 limit=topk,
-                output_fields=["*"],
+                output_fields=output_fields,
                 filter=milvus_filters,
             )
             chunk_results = [

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py
@@ -794,7 +794,8 @@ class MilvusStore(VectorStoreBase):
             # content + metadata + pk for chunk construction below; this
             # mirrors the pattern in similar_search_with_scores' _search().
             output_fields = [
-                f for f in self.fields
+                f
+                for f in self.fields
                 if f != self.sparse_vector and f != self.vector_field
             ]
             results = self._milvus_client.search(


### PR DESCRIPTION
## Problem

`MilvusStore` is incompatible with milvus 2.5+ (and milvus-lite ≥ 2.5) because:

1. **`full_text_search` requests `output_fields=["*"]`.** Milvus 2.5 rejects this with:
   ```
   not allowed to retrieve raw data of field sparse_vector
   ```
   The sparse `BM25` vector is internally generated and cannot be returned as
   raw data, so `*` always trips the validator.

2. **`self.fields` is a mutable instance attribute appended to from `schema.fields` on every call.** On the *second* invocation of `similar_search`/`similar_search_with_scores` against a collection that has full-text search enabled, `self.fields` contains every field name twice. The guard in `_search`:
   ```python
   if self.sparse_vector in output_fields:
       output_fields.remove(self.sparse_vector)
   ```
   only removes the *first* occurrence, so the duplicate `sparse_vector` reaches milvus and produces the same error as #1.

Both errors surface as `MilvusException: not allowed to retrieve raw data of field sparse_vector` and break Chat-DB / Chat-Knowledge / DB-Schema retrieval entirely on milvus 2.5+.

## Reproduce

```python
from dbgpt_ext.storage.vector_store.milvus_store import MilvusStore, MilvusVectorConfig

cfg = MilvusVectorConfig(
    uri="http://127.0.0.1", port="19530", name="repro_25",
    enable_full_text_search=True,
)
store = cfg.create_store(embedding_fn=embeddings)
store.load_document(chunks)

# Bug A - full_text_search:
store.full_text_search("hello", topk=3)
# MilvusException: not allowed to retrieve raw data of field sparse_vector

# Bug B - accumulated self.fields:
store.similar_search_with_scores("a", 3, 0.0)  # works
store.similar_search_with_scores("b", 3, 0.0)  # boom - same error
```

Observed against `milvus 2.5.x` standalone and `milvus-lite >= 2.5`. Works on milvus 2.4.x because 2.4 silently accepts the duplicated sparse_vector field.

## Fix

Three minimal changes in `packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/milvus_store.py`:

1. `similar_search`: reset `self.fields = []` before re-populating from `schema.fields`.
2. `similar_search_with_scores`: same reset (mirrors #1).
3. `full_text_search`: replace `output_fields=["*"]` with an explicit list that excludes `self.sparse_vector` and `self.vector_field`; we only need content/metadata/pk for chunk construction, matching the pattern already used by `_search()`.

No public API or schema change. No new dependency.

## Tested

- Manual repro of both bugs against `milvus 2.5.x` standalone (Docker `milvusdb/milvus:v2.5.0-beta` and a 2.5.x release) - fails before patch, passes after.
- DB-GPT Chat-DB end-to-end against an MSSQL datasource with ~860 tables (`AAEONBPM`) indexed into Milvus - repeated queries succeed; previously the second query SIGSEGV'd / errored after the first.
- Re-ran on milvus 2.4.x to confirm no regression.

Related: continues the milvus-2.5 compatibility work; complements #3040 (which addressed an indexing race + per-chunk error tolerance triggered while migrating off chromadb to milvus).
