### PR TITLE
feat(qdrant): make distance metric configurable

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
@@ -89,6 +89,17 @@ def _chunk_id_to_uuid(chunk_id: str) -> str:
             optional=True,
             default=6334,
         ),
+        Parameter.build_from(
+            _("Distance"),
+            "distance",
+            str,
+            description=_(
+                "Distance metric used to compare vectors. One of: "
+                "Cosine, Euclid, Dot, Manhattan."
+            ),
+            optional=True,
+            default="Cosine",
+        ),
     ],
 )
 @dataclass
@@ -124,6 +135,15 @@ class QdrantVectorConfig(VectorStoreConfig):
     grpc_port: int = field(
         default_factory=lambda: int(os.getenv("QDRANT_GRPC_PORT", "6334")),
         metadata={"help": _("The gRPC port of Qdrant store.")},
+    )
+    distance: str = field(
+        default_factory=lambda: os.getenv("QDRANT_DISTANCE", "Cosine"),
+        metadata={
+            "help": _(
+                "Distance metric used to compare vectors. One of: "
+                "Cosine, Euclid, Dot, Manhattan."
+            )
+        },
     )
 
     def create_store(self, **kwargs) -> "QdrantStore":
@@ -189,7 +209,7 @@ class QdrantStore(VectorStoreBase):
 
     def create_collection(self, collection_name: str, **kwargs) -> None:
         """Create a Qdrant collection."""
-        from qdrant_client.models import Distance, VectorParams
+        from qdrant_client.models import VectorParams
 
         if self._client.collection_exists(collection_name):
             return
@@ -197,8 +217,29 @@ class QdrantStore(VectorStoreBase):
         dim = len(self.embeddings.embed_query("probe"))
         self._client.create_collection(
             collection_name=collection_name,
-            vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+            vectors_config=VectorParams(
+                size=dim,
+                distance=self._resolve_distance(self._vector_store_config.distance),
+            ),
         )
+
+    @staticmethod
+    def _resolve_distance(name: str) -> "Distance":  # type: ignore[name-defined]
+        from qdrant_client.models import Distance
+
+        mapping = {
+            "cosine": Distance.COSINE,
+            "euclid": Distance.EUCLID,
+            "dot": Distance.DOT,
+            "manhattan": Distance.MANHATTAN,
+        }
+        try:
+            return mapping[name.strip().lower()]
+        except (AttributeError, KeyError):
+            raise ValueError(
+                f"Unsupported Qdrant distance metric: {name!r}. "
+                f"Expected one of: {sorted(mapping)}"
+            )
 
     def load_document(self, chunks: List[Chunk]) -> List[str]:
         """Load document in vector database."""

--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/qdrant_store.py
@@ -6,7 +6,10 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from qdrant_client.models import Distance
 
 from dbgpt.core import Chunk, Embeddings
 from dbgpt.core.awel.flow import Parameter, ResourceCategory, register_resource
@@ -224,7 +227,7 @@ class QdrantStore(VectorStoreBase):
         )
 
     @staticmethod
-    def _resolve_distance(name: str) -> "Distance":  # type: ignore[name-defined]
+    def _resolve_distance(name: str) -> "Distance":
         from qdrant_client.models import Distance
 
         mapping = {


### PR DESCRIPTION
# Description

- distance metric on QdrantStore was hardcoded to Distance.COSINE inside create_collection
- users who wanted Euclid, Dot, or Manhattan had to subclass the store or patch the source
- a new _resolve_distance staticmethod on QdrantStore maps the string to the qdrant-client Distance enum

# How Has This Been Tested?

ran qdrant 1.17.1 locally via `docker run -p 6333:6333 qdrant/qdrant`, then exercised the patched `_resolve_distance` loaded straight from the source file 
- good names work, tried Cosine, Euclid, Dot, Manhattan, also weird casing and spaces around them. all picked the right metric
- bad names fail clean, tried empty string, "l2", None, a number. all raised an error that tells the user what the valid choices are.
- real qdrant, for each metric, made a collection, read it back, confirmed the distance was what i set. also double-checked it from the rest api.
# Snapshots:


<img width="1550" height="391" alt="image" src="https://github.com/user-attachments/assets/508b333c-1151-4a41-a580-13dfb80c4c6c" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
