### PR TITLE
fix(chat_db_qa): tell LLM the table list is a TOP-K subset, not the full DB

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/scene/chat_db/professional_qa/prompt.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/chat_db/professional_qa/prompt.py
@@ -18,6 +18,13 @@ available to answer this question." Feel free to fudge information.
 Use the following tables generate sql if have any table info:
 {table_info}
 
+NOTE: the table list above contains only the TOP-K most relevant tables \
+retrieved from a vector store; it is NOT the complete list of tables in \
+the database. If the user asks for a total count of tables, a list of all \
+tables, a schema overview, or any other metadata that requires knowing the \
+whole database, generate a SQL query against INFORMATION_SCHEMA (or the \
+dialect-specific system catalog) instead of answering from the list above.
+
 user question:
 {input}
 think step by step.
@@ -27,8 +34,13 @@ _DEFAULT_TEMPLATE_ZH = """
 根据要求和问题，提供专业的答案。如果无法从提供的内容中获取答案，请说：\
 “知识库中提供的信息不足以回答此问题。” 禁止随意捏造信息。
 
-使用以下表结构信息: 
+使用以下表结构信息:
 {table_info}
+
+注意：以上表清单只是从向量库检索到的 TOP-K 最相关表，并非数据库中所有表的\
+完整清单。当用户询问表的总数、所有表的列表、schema 结构总览，或其他需要\
+了解整个数据库元信息的问题时，请改用对 INFORMATION_SCHEMA（或方言对应的\
+系统目录）的 SQL 查询，而不是仅根据以上显示的表清单作答。
 
 问题:
 {input}

--- a/packages/dbgpt-app/src/dbgpt_app/scene/chat_db/professional_qa/prompt.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/chat_db/professional_qa/prompt.py
@@ -18,12 +18,15 @@ available to answer this question." Feel free to fudge information.
 Use the following tables generate sql if have any table info:
 {table_info}
 
-NOTE: the table list above contains only the TOP-K most relevant tables \
-retrieved from a vector store; it is NOT the complete list of tables in \
-the database. If the user asks for a total count of tables, a list of all \
-tables, a schema overview, or any other metadata that requires knowing the \
-whole database, generate a SQL query against INFORMATION_SCHEMA (or the \
-dialect-specific system catalog) instead of answering from the list above.
+NOTE: this is a QA-only scene; you cannot execute SQL here. The table list \
+above contains only the TOP-K most relevant tables retrieved from a vector \
+store; it is NOT the complete list of tables in the database. If the user \
+asks for a total count of tables, a list of all tables, a schema overview, \
+or any other metadata that requires knowing the whole database, do NOT \
+answer with a count or list derived from the partial table list above. \
+Instead, acknowledge the limitation and show the SQL query against \
+INFORMATION_SCHEMA (or the dialect-specific system catalog) that the user \
+can run in a SQL-executing scene to obtain the answer.
 
 user question:
 {input}
@@ -37,10 +40,12 @@ _DEFAULT_TEMPLATE_ZH = """
 使用以下表结构信息:
 {table_info}
 
-注意：以上表清单只是从向量库检索到的 TOP-K 最相关表，并非数据库中所有表的\
-完整清单。当用户询问表的总数、所有表的列表、schema 结构总览，或其他需要\
-了解整个数据库元信息的问题时，请改用对 INFORMATION_SCHEMA（或方言对应的\
-系统目录）的 SQL 查询，而不是仅根据以上显示的表清单作答。
+注意：这是只问答（QA）场景，无法在此处执行 SQL。以上表清单只是从向量库\
+检索到的 TOP-K 最相关表，并非数据库中所有表的完整清单。当用户询问表的\
+总数、所有表的列表、schema 结构总览，或其他需要了解整个数据库元信息的\
+问题时，请勿根据以上部分表清单直接给出数量或列表。请说明此限制，并展示\
+可在「可执行 SQL」场景中运行、针对 INFORMATION_SCHEMA（或方言对应的系统\
+目录）的 SQL 查询，以便用户取得正确答案。
 
 问题:
 {input}


### PR DESCRIPTION
## Problem

The `chat_with_db_qa` scene retrieves the top-K most relevant tables from the vector store (via `DBSchemaRetriever`) and inlines their `CREATE TABLE` statements into the `{table_info}` placeholder of the system prompt. The current template does not tell the LLM that this is a *subset* of the database.

When a user asks a meta question like *"How many tables are in this database?"*, the LLM has nothing in the prompt that suggests the table list is partial, so it counts the tables shown and answers with that number — even when the real database is much larger.

Concrete repro on an MSSQL database with 166 user tables (top-K=10):

> User: 多少 TABLE? (How many tables?)
> Assistant: 表数量：10 张

The list of 10 tables that follows is the top-K retrieval output, not the database total.

## Fix

Add a short instruction to both the EN and ZH `chat_with_db_qa` templates telling the LLM that the inlined table list is a top-K subset and that whole-database meta questions should be answered by generating a SQL query against `INFORMATION_SCHEMA` (or the dialect-specific system catalog).

The change is prompt-only — no code, no tests, no schema impact.

## Tested

- AAEON internal DB-GPT deployment, MSSQL with 166 tables.
  - Before: "多少 TABLE?" → "10 张" (wrong).
  - After: "多少 TABLE?" → LLM emits `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE'`, executes via the connector, returns the correct 166.
- Sanity-checked normal SQL-generation queries ("show me top 5 customers by revenue last month") to confirm the new note doesn't push the LLM into INFORMATION_SCHEMA queries when it has the right table in the top-K list.

## Related

Continues the AAEON-internal stabilization work alongside #3039 (merged), #3040, #3042.
