### PR TITLE
fix: restrict execute_code filenames to work_dir

### DIFF
--- a/docs/docs/changelog/Released_V0.8.0.md
+++ b/docs/docs/changelog/Released_V0.8.0.md
@@ -138,6 +138,7 @@ The official documentation has been completely revamped and now officially suppo
 
 - Add MiniMax Provider support ([#2989](https://github.com/eosphoros-ai/DB-GPT/pull/2989))
 - Fix React parser handling of vis-thinking blocks ([#2996](https://github.com/eosphoros-ai/DB-GPT/pull/2996))
+- Tighten `execute_code` filename handling so absolute paths, path traversal, and symlink escapes are rejected. This security hardening may affect callers that previously relied on files outside the configured working directory.
 - README and documentation updates ([#2991](https://github.com/eosphoros-ai/DB-GPT/pull/2991))
 
 ## How to Upgrade

--- a/packages/dbgpt-core/src/dbgpt/util/code_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/code_utils.py
@@ -154,6 +154,7 @@ def _cmd(lang):
 
 
 def _resolve_work_dir_filepath(work_dir: str, filename: str) -> str:
+    """Resolve a relative filename while keeping it inside work_dir."""
     work_dir_path = pathlib.Path(work_dir).resolve()
     filename_path = pathlib.Path(filename)
     if filename_path.is_absolute():
@@ -189,7 +190,9 @@ def execute_code(
             stored when `code` is None. If None, a file with a randomly generated name
             will be created. The randomly generated file will be deleted after
             execution. The file name must be a relative path. Relative paths are
-            relative to the working directory.
+            resolved against the working directory and must stay inside it after
+            resolving path components and symlinks. Absolute paths, path traversal,
+            and symlinks that point outside the working directory are rejected.
         work_dir (Optional, str): The working directory for the code execution.
             If None, a default working directory will be used.
             The default working directory is the "extensions" directory under

--- a/packages/dbgpt-core/src/dbgpt/util/code_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/code_utils.py
@@ -153,6 +153,20 @@ def _cmd(lang):
     raise NotImplementedError(f"{lang} not recognized in code execution")
 
 
+def _resolve_work_dir_filepath(work_dir: str, filename: str) -> str:
+    work_dir_path = pathlib.Path(work_dir).resolve()
+    filename_path = pathlib.Path(filename)
+    if filename_path.is_absolute():
+        raise ValueError("filename must be a relative path inside work_dir")
+
+    filepath = (work_dir_path / filename_path).resolve()
+    try:
+        filepath.relative_to(work_dir_path)
+    except ValueError as exc:
+        raise ValueError("filename must stay inside work_dir") from exc
+    return str(filepath)
+
+
 def execute_code(
     code: Optional[str] = None,
     timeout: Optional[int] = None,
@@ -246,7 +260,7 @@ def execute_code(
         filename = f"tmp_code_{code_hash}.{'py' if lang.startswith('python') else lang}"
     if work_dir is None:
         work_dir = WORKING_DIR
-    filepath = os.path.join(work_dir, filename)
+    filepath = _resolve_work_dir_filepath(work_dir, filename)
     file_dir = os.path.dirname(filepath)
     os.makedirs(file_dir, exist_ok=True)
     if code is not None:

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from dbgpt.util.code_utils import execute_code
+
+
+def test_execute_code_rejects_filename_outside_work_dir(tmp_path: Path):
+    work_dir = tmp_path / "workspace"
+    outside_file = tmp_path / "outside.py"
+
+    with pytest.raises(ValueError, match="work_dir"):
+        execute_code(
+            "print('escaped')",
+            filename="../outside.py",
+            work_dir=str(work_dir),
+            use_docker=False,
+        )
+
+    assert not outside_file.exists()
+
+
+def test_execute_code_rejects_absolute_filename(tmp_path: Path):
+    work_dir = tmp_path / "workspace"
+    outside_file = tmp_path / "outside.py"
+
+    with pytest.raises(ValueError, match="relative path"):
+        execute_code(
+            "print('escaped')",
+            filename=str(outside_file),
+            work_dir=str(work_dir),
+            use_docker=False,
+        )
+
+    assert not outside_file.exists()
+
+
+def test_execute_code_allows_nested_filename_inside_work_dir(tmp_path: Path):
+    work_dir = tmp_path / "workspace"
+
+    exitcode, logs, image = execute_code(
+        "print('inside')",
+        filename="nested/script.py",
+        work_dir=str(work_dir),
+        use_docker=False,
+    )
+
+    assert exitcode == 0
+    assert logs == "inside\n"
+    assert image is None
+    assert (work_dir / "nested" / "script.py").exists()

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py
@@ -49,3 +49,25 @@ def test_execute_code_allows_nested_filename_inside_work_dir(tmp_path: Path):
     assert logs == "inside\n"
     assert image is None
     assert (work_dir / "nested" / "script.py").exists()
+
+
+def test_execute_code_rejects_symlink_escape_from_work_dir(tmp_path: Path):
+    work_dir = tmp_path / "workspace"
+    outside_dir = tmp_path / "outside"
+    work_dir.mkdir()
+    outside_dir.mkdir()
+
+    try:
+        (work_dir / "linked").symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    with pytest.raises(ValueError, match="work_dir"):
+        execute_code(
+            "print('escaped')",
+            filename="linked/escaped.py",
+            work_dir=str(work_dir),
+            use_docker=False,
+        )
+
+    assert not (outside_dir / "escaped.py").exists()


### PR DESCRIPTION
## Summary

- Constrain `execute_code` filenames to resolved paths inside `work_dir` before writing or executing generated code.
- Reject absolute filenames and relative paths that escape `work_dir`.
- Add regression coverage for path traversal, absolute paths, and safe nested relative filenames.

## Root Cause / 根因

`CodeAction` can pass a model-generated `# filename:` header into `execute_code`. The previous implementation joined `work_dir` and `filename` directly, so a normalized path like `../outside.py` could point outside the intended workspace before file creation.

## Validation / 测试

- RED test before fix: `PYTHONPATH=packages/dbgpt-core/src .venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py -q` failed with `DID NOT RAISE ValueError`.
- `PYTHONPATH=packages/dbgpt-core/src .venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py -q` -> `3 passed`.
- `PYTHONPATH=packages/dbgpt-core/src .venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/util/tests -q` -> `168 passed`.
- `.venv/bin/ruff check packages/dbgpt-core/src/dbgpt/util/code_utils.py packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py` -> passed.
- `.venv/bin/ruff format --check packages/dbgpt-core/src/dbgpt/util/code_utils.py packages/dbgpt-core/src/dbgpt/util/tests/test_code_utils.py` -> passed.
- `git diff --check` -> passed.
- Manual smoke test confirmed `../outside.py` is blocked and no outside file is created.

Fixes #3025.
Fixes #3048.
