### PR TITLE
fix: constrain python upload filenames

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, UploadFile
 
@@ -10,6 +11,20 @@ from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 router = APIRouter()
 CFG = Config()
 logger = logging.getLogger(__name__)
+
+
+def _resolve_upload_path(upload_dir: str, filename: str) -> str:
+    upload_dir_path = Path(upload_dir).resolve()
+    filename_path = Path(filename)
+    if filename_path.is_absolute():
+        raise ValueError("filename must be a relative path inside upload directory")
+
+    file_path = (upload_dir_path / filename_path).resolve()
+    try:
+        file_path.relative_to(upload_dir_path)
+    except ValueError as exc:
+        raise ValueError("filename must stay inside upload directory") from exc
+    return str(file_path)
 
 
 @router.post("/v1/python/file/upload", response_model=Result[str])
@@ -39,7 +54,7 @@ async def python_file_upload(
         upload_dir = os.path.join(base_dir, "python_uploads", user_id)
         os.makedirs(upload_dir, exist_ok=True)
 
-        file_path = os.path.join(upload_dir, file.filename)
+        file_path = _resolve_upload_path(upload_dir, file.filename)
 
         # Read file content and write to disk
         content = await file.read()

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+import pytest
+
+from dbgpt_serve.utils.auth import UserRequest
+
+
+class FakeUploadFile:
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self.content_type = "text/x-python"
+        self._content = content
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_traversal_filename(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    result = await python_upload_api.python_file_upload(
+        FakeUploadFile("../../outside.py", b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not (tmp_path / "outside.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_absolute_filename(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    result = await python_upload_api.python_file_upload(
+        FakeUploadFile(str(tmp_path / "outside.py"), b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not (tmp_path / "outside.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_allows_plain_filename_inside_user_dir(
+    tmp_path, monkeypatch
+):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    result = await python_upload_api.python_file_upload(
+        FakeUploadFile("inside.py", b"print('inside')"),
+        UserRequest(user_id="alice"),
+    )
+
+    expected_path = tmp_path / "python_uploads" / "alice" / "inside.py"
+    assert result.success is True
+    assert result.data == str(expected_path)
+    assert expected_path.read_bytes() == b"print('inside')"
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_symlink_escape(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    upload_dir = tmp_path / "python_uploads" / "alice"
+    outside_dir = tmp_path / "outside"
+    upload_dir.mkdir(parents=True)
+    outside_dir.mkdir()
+    try:
+        (upload_dir / "linked").symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    result = await python_upload_api.python_file_upload(
+        FakeUploadFile("linked/escaped.py", b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not (outside_dir / "escaped.py").exists()


### PR DESCRIPTION
## Summary

- Resolve uploaded Python filenames against the per-user upload directory before writing files.
- Reject absolute filenames and relative/symlink paths that escape `python_uploads/<user_id>`.
- Add focused async regression tests for traversal, absolute path, symlink escape, and a normal filename upload.

## Root Cause / 根因

`python_file_upload` built the destination path with `os.path.join(upload_dir, file.filename)` and wrote it directly. A filename such as `../../outside.py` normalized outside the authenticated user's upload directory, so the endpoint could write outside `python_uploads/<user_id>`.

## Validation / 测试

- RED test before fix: `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src .venv/bin/python -m pytest packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py -q` failed because the traversal upload returned `success=True` and wrote outside the user directory.
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src .venv/bin/python -m pytest packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py -q` -> `4 passed`.
- `.venv/bin/ruff check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py` -> passed.
- `.venv/bin/ruff format --check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py` -> passed.
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src .venv/bin/python -m compileall -q packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py` -> passed.
- `git diff --check` -> passed.

Fixes #3027.
