### PR TITLE
fix: validate skill upload filenames

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import uuid
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -43,6 +43,23 @@ DEFAULT_SKILLS_DIR = SKILLS_DIR
 AUTO_DATA_MARKER_PATTERN = re.compile(
     r"###([A-Z0-9_]+)_START###\s*(.*?)\s*###\1_END###", re.DOTALL
 )
+
+
+def _validate_upload_filename(filename: str) -> str:
+    if "\x00" in filename:
+        raise ValueError("filename must not contain null bytes")
+
+    posix_path = PurePosixPath(filename)
+    windows_path = PureWindowsPath(filename)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or len(posix_path.parts) != 1
+        or len(windows_path.parts) != 1
+        or filename in {"", ".", ".."}
+    ):
+        raise ValueError("filename must be a plain file name")
+    return filename
 
 
 async def _resolve_model_context_tokens(
@@ -482,7 +499,11 @@ async def skill_upload(
     user_dir = skills_dir / "user"
     user_dir.mkdir(parents=True, exist_ok=True)
 
-    filename = file.filename
+    try:
+        filename = _validate_upload_filename(file.filename)
+    except ValueError as exc:
+        return Result.failed(code="E4002", msg=str(exc))
+
     suffix = Path(filename).suffix.lower()
     stem = Path(filename).stem
 

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py
@@ -1,0 +1,89 @@
+import pytest
+
+from dbgpt_serve.utils.auth import UserRequest
+
+
+class FakeUploadFile:
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self.content_type = "text/x-python"
+        self._content = content
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+def _configure_skill_paths(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    upload_dir = tmp_path / "pilot" / "tmp"
+    skills_dir = tmp_path / "skills"
+    monkeypatch.setattr(
+        agentic_data_api, "resolve_root_path", lambda _: str(upload_dir)
+    )
+    monkeypatch.setattr(agentic_data_api, "DEFAULT_SKILLS_DIR", str(skills_dir))
+    return agentic_data_api, upload_dir, skills_dir
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_rejects_traversal_filename(tmp_path, monkeypatch):
+    agentic_data_api, _, skills_dir = _configure_skill_paths(tmp_path, monkeypatch)
+
+    result = await agentic_data_api.skill_upload(
+        FakeUploadFile("../../outside.py", b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not (tmp_path / "outside.py").exists()
+    assert not (skills_dir / "outside.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_rejects_absolute_filename(tmp_path, monkeypatch):
+    agentic_data_api, _, _ = _configure_skill_paths(tmp_path, monkeypatch)
+    outside_path = tmp_path / "outside.py"
+
+    result = await agentic_data_api.skill_upload(
+        FakeUploadFile(str(outside_path), b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not outside_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_rejects_windows_path_separator(tmp_path, monkeypatch):
+    agentic_data_api, upload_dir, skills_dir = _configure_skill_paths(
+        tmp_path, monkeypatch
+    )
+
+    result = await agentic_data_api.skill_upload(
+        FakeUploadFile(r"..\outside.py", b"print('escaped')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is False
+    assert not (upload_dir / r"..\outside.py").exists()
+    assert not (skills_dir / "user" / "outside.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_accepts_plain_filename(tmp_path, monkeypatch):
+    agentic_data_api, upload_dir, skills_dir = _configure_skill_paths(
+        tmp_path, monkeypatch
+    )
+
+    result = await agentic_data_api.skill_upload(
+        FakeUploadFile("hello.py", b"print('hello')"),
+        UserRequest(user_id="alice"),
+    )
+
+    assert result.success is True
+    assert result.data["file_path"] == "user/hello"
+    assert result.data["tmp_path"] == str(upload_dir / "hello.py")
+    assert (upload_dir / "hello.py").read_bytes() == b"print('hello')"
+    assert (
+        skills_dir / "user" / "hello" / "hello.py"
+    ).read_bytes() == b"print('hello')"


### PR DESCRIPTION
## Summary
- validate uploaded skill filenames before writing temporary or installed files
- reject absolute paths, traversal paths, Windows path separators, null bytes, and special dot names
- keep plain skill file uploads working

Fixes #3026

## Tests
- PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py -q
- PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_import_github_url_parsing.py packages/dbgpt-app/src/dbgpt_app/tests/test_import_github_extract.py -q
- .venv/bin/ruff check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py
- .venv/bin/ruff format --check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py
- PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m compileall -q packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_skill_upload_api.py
- git diff --cached --check