### PR TITLE
fix: require auth for agent file downloads

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -2025,9 +2025,10 @@ print(json.dumps(summary, ensure_ascii=False))
         session_id = f"bash_{uuid.uuid4().hex[:12]}"
         runtime = LocalRuntime()
 
-        from dbgpt.configs.model_config import ROOT_PATH
+        from dbgpt.configs.model_config import PILOT_PATH
 
-        sandbox_work_dir = ROOT_PATH
+        cid = react_state.get("conv_id") or "default"
+        sandbox_work_dir = os.path.join(PILOT_PATH, "tmp", cid)
         os.makedirs(sandbox_work_dir, exist_ok=True)
 
         config = SessionConfig(

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -62,6 +62,17 @@ def _validate_upload_filename(filename: str) -> str:
     return filename
 
 
+def _agent_artifact_work_dir(react_state: Dict[str, Any]) -> str:
+    """Return the download-safe workspace for agent-generated artifacts."""
+    from dbgpt.configs import model_config
+
+    raw_conv_id = str((react_state or {}).get("conv_id") or "default")
+    conv_id = re.sub(r"[^A-Za-z0-9_.-]", "_", raw_conv_id).lstrip(".")
+    if not conv_id:
+        conv_id = "default"
+    return os.path.join(model_config.PILOT_PATH, "tmp", str(conv_id))
+
+
 async def _resolve_model_context_tokens(
     llm_client: Any, model_name: Optional[str]
 ) -> Optional[int]:
@@ -1792,7 +1803,7 @@ print(json.dumps(summary, ensure_ascii=False))
         import sys
         import uuid
 
-        from dbgpt.configs.model_config import PILOT_PATH, STATIC_MESSAGE_IMG_PATH
+        from dbgpt.configs.model_config import STATIC_MESSAGE_IMG_PATH
 
         if not code or not code.strip():
             return json.dumps(
@@ -1809,8 +1820,7 @@ print(json.dumps(summary, ensure_ascii=False))
 
         # Use persistent work dir under pilot/tmp/{conv_id} so files
         # survive across calls and can be referenced later (e.g. in HTML).
-        cid = react_state.get("conv_id") or "default"
-        work_dir = os.path.join(PILOT_PATH, "tmp", cid)
+        work_dir = _agent_artifact_work_dir(react_state)
         os.makedirs(work_dir, exist_ok=True)
 
         # Collect image files that existed BEFORE this run
@@ -2021,9 +2031,8 @@ print(json.dumps(summary, ensure_ascii=False))
         session_id = f"bash_{uuid.uuid4().hex[:12]}"
         runtime = LocalRuntime()
 
-        from dbgpt.configs.model_config import ROOT_PATH
-
-        sandbox_work_dir = ROOT_PATH
+        sandbox_work_dir = _agent_artifact_work_dir(react_state)
+        os.makedirs(sandbox_work_dir, exist_ok=True)
 
         config = SessionConfig(
             language="bash",
@@ -2129,10 +2138,7 @@ print(json.dumps(summary, ensure_ascii=False))
                     except (json.JSONDecodeError, TypeError):
                         pass
                     # Also scan the output dir for any new .png files
-                    cid = react_state.get("conv_id") or "default"
-                    from dbgpt.configs.model_config import PILOT_PATH
-
-                    out_dir = os.path.join(PILOT_PATH, "tmp", cid)
+                    out_dir = _agent_artifact_work_dir(react_state)
                     if os.path.isdir(out_dir):
                         for fname in os.listdir(out_dir):
                             ext = os.path.splitext(fname)[1].lower()
@@ -2193,11 +2199,8 @@ print(json.dumps(summary, ensure_ascii=False))
         from dbgpt.configs.model_config import STATIC_MESSAGE_IMG_PATH
 
         try:
-            from dbgpt.configs.model_config import PILOT_PATH
-
             sm = get_skill_manager(CFG.SYSTEM_APP)
-            cid = react_state.get("conv_id") or "default"
-            out_dir = os.path.join(PILOT_PATH, "tmp", cid)
+            out_dir = _agent_artifact_work_dir(react_state)
             os.makedirs(out_dir, exist_ok=True)
             # Auto-inject the correct file path from react_state into args.
             # The LLM sometimes corrupts the uploaded file path (e.g. changing

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -28,11 +28,7 @@ from dbgpt_app.openapi.api_view_model import (
     Result,
 )
 from dbgpt_serve.datasource.manages import ConnectorManager
-from dbgpt_serve.utils.auth import (
-    UserRequest,
-    get_required_user_from_headers,
-    get_user_from_headers,
-)
+from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 
 router = APIRouter()
 CFG = Config()
@@ -2025,11 +2021,9 @@ print(json.dumps(summary, ensure_ascii=False))
         session_id = f"bash_{uuid.uuid4().hex[:12]}"
         runtime = LocalRuntime()
 
-        from dbgpt.configs.model_config import PILOT_PATH
+        from dbgpt.configs.model_config import ROOT_PATH
 
-        cid = react_state.get("conv_id") or "default"
-        sandbox_work_dir = os.path.join(PILOT_PATH, "tmp", cid)
-        os.makedirs(sandbox_work_dir, exist_ok=True)
+        sandbox_work_dir = ROOT_PATH
 
         config = SessionConfig(
             language="bash",
@@ -3997,7 +3991,7 @@ async def delete_share_link(
 @router.get("/v1/agent/files/download")
 async def download_agent_file(
     file_path: str = Query(..., description="Absolute path to the file to download"),
-    user_token: UserRequest = Depends(get_required_user_from_headers),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     """Download a file created by agent tools (shell_interpreter, code_interpreter).
 

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -3992,6 +3992,7 @@ async def delete_share_link(
 @router.get("/v1/agent/files/download")
 async def download_agent_file(
     file_path: str = Query(..., description="Absolute path to the file to download"),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     """Download a file created by agent tools (shell_interpreter, code_interpreter).
 
@@ -4013,11 +4014,10 @@ async def download_agent_file(
     except (ValueError, OSError):
         raise HTTPException(status_code=400, detail="Invalid file path")
 
-    # Allowed base directories for agent-created files
+    # Allowed base directories for agent-created files.
     allowed_dirs = [
         os.path.realpath("/tmp"),
         os.path.realpath(os.path.join(PILOT_PATH, "tmp")),
-        os.path.realpath(ROOT_PATH),
     ]
 
     if not any(resolved.startswith(d + os.sep) or resolved == d for d in allowed_dirs):

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -28,7 +28,11 @@ from dbgpt_app.openapi.api_view_model import (
     Result,
 )
 from dbgpt_serve.datasource.manages import ConnectorManager
-from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
+from dbgpt_serve.utils.auth import (
+    UserRequest,
+    get_required_user_from_headers,
+    get_user_from_headers,
+)
 
 router = APIRouter()
 CFG = Config()
@@ -3992,7 +3996,7 @@ async def delete_share_link(
 @router.get("/v1/agent/files/download")
 async def download_agent_file(
     file_path: str = Query(..., description="Absolute path to the file to download"),
-    user_token: UserRequest = Depends(get_user_from_headers),
+    user_token: UserRequest = Depends(get_required_user_from_headers),
 ):
     """Download a file created by agent tools (shell_interpreter, code_interpreter).
 
@@ -4002,11 +4006,13 @@ async def download_agent_file(
     from fastapi import HTTPException
     from fastapi.responses import FileResponse
 
-    from dbgpt.configs.model_config import PILOT_PATH, ROOT_PATH
+    from dbgpt.configs.model_config import PILOT_PATH
 
-    # If path is not absolute, resolve relative to ROOT_PATH (sandbox working dir)
     if not os.path.isabs(file_path):
-        file_path = os.path.join(ROOT_PATH, file_path)
+        raise HTTPException(
+            status_code=400,
+            detail="file_path must be an absolute path",
+        )
 
     # Resolve to absolute path and prevent path traversal
     try:

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
@@ -1,0 +1,58 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+from fastapi.routing import APIRoute
+
+from dbgpt_serve.utils.auth import get_user_from_headers
+
+
+def _download_route(agentic_data_api):
+    for route in agentic_data_api.router.routes:
+        if isinstance(route, APIRoute) and route.path == "/v1/agent/files/download":
+            return route
+    raise AssertionError("download route not found")
+
+
+def test_agent_file_download_route_requires_user_dependency():
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    route = _download_route(agentic_data_api)
+
+    assert any(
+        dependency.call is get_user_from_headers
+        for dependency in route.dependant.dependencies
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_file_download_rejects_project_root_file(tmp_path, monkeypatch):
+    from dbgpt.configs import model_config
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    project_file = tmp_path / "docker-compose.yml"
+    project_file.write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr(model_config, "ROOT_PATH", str(tmp_path))
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(tmp_path / "pilot"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await agentic_data_api.download_agent_file(str(project_file))
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_agent_file_download_allows_pilot_tmp_file(tmp_path, monkeypatch):
+    from dbgpt.configs import model_config
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    pilot_tmp = tmp_path / "pilot" / "tmp"
+    pilot_tmp.mkdir(parents=True)
+    generated_file = pilot_tmp / "result.txt"
+    generated_file.write_text("ok\n", encoding="utf-8")
+    monkeypatch.setattr(model_config, "ROOT_PATH", str(tmp_path / "project"))
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(tmp_path / "pilot"))
+
+    response = await agentic_data_api.download_agent_file(str(generated_file))
+
+    assert isinstance(response, FileResponse)
+    assert response.path == str(generated_file)

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
@@ -1,9 +1,42 @@
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.routing import APIRoute
 
-from dbgpt_serve.utils.auth import get_user_from_headers
+from dbgpt_serve.utils.auth import get_required_user_from_headers, get_user_from_headers
+
+
+def _is_under(path: Path, base: Path) -> bool:
+    try:
+        path.resolve().relative_to(base.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+@pytest.fixture()
+def non_tmp_workspace():
+    parent = next(
+        (
+            candidate.resolve()
+            for candidate in (Path.cwd(), Path.home())
+            if not _is_under(candidate.resolve(), Path("/tmp"))
+        ),
+        None,
+    )
+    if parent is None:
+        pytest.skip("requires a temporary workspace outside /tmp")
+
+    with tempfile.TemporaryDirectory(
+        prefix="dbgpt-agent-download-", dir=str(parent)
+    ) as temp_dir:
+        workspace = Path(temp_dir).resolve()
+        assert not _is_under(workspace, Path("/tmp"))
+        yield workspace
 
 
 def _download_route(agentic_data_api):
@@ -13,26 +46,42 @@ def _download_route(agentic_data_api):
     raise AssertionError("download route not found")
 
 
-def test_agent_file_download_route_requires_user_dependency():
+def test_agent_file_download_route_requires_required_user_dependency():
     from dbgpt_app.openapi.api_v1 import agentic_data_api
 
     route = _download_route(agentic_data_api)
 
     assert any(
-        dependency.call is get_user_from_headers
+        dependency.call is get_required_user_from_headers
         for dependency in route.dependant.dependencies
     )
 
 
+def test_agent_file_download_rejects_missing_user_header():
+    with pytest.raises(HTTPException) as exc_info:
+        get_required_user_from_headers(user_id=None)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_optional_user_header_helper_keeps_default_mock_user():
+    user = get_user_from_headers(user_id=None)
+
+    assert user.user_id == "001"
+    assert user.role == "admin"
+
+
 @pytest.mark.asyncio
-async def test_agent_file_download_rejects_project_root_file(tmp_path, monkeypatch):
+async def test_agent_file_download_rejects_project_root_file(
+    non_tmp_workspace, monkeypatch
+):
     from dbgpt.configs import model_config
     from dbgpt_app.openapi.api_v1 import agentic_data_api
 
-    project_file = tmp_path / "docker-compose.yml"
+    project_file = non_tmp_workspace / "docker-compose.yml"
     project_file.write_text("services: {}\n", encoding="utf-8")
-    monkeypatch.setattr(model_config, "ROOT_PATH", str(tmp_path))
-    monkeypatch.setattr(model_config, "PILOT_PATH", str(tmp_path / "pilot"))
+    monkeypatch.setattr(model_config, "ROOT_PATH", str(non_tmp_workspace))
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(non_tmp_workspace / "pilot"))
 
     with pytest.raises(HTTPException) as exc_info:
         await agentic_data_api.download_agent_file(str(project_file))
@@ -41,18 +90,30 @@ async def test_agent_file_download_rejects_project_root_file(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_agent_file_download_allows_pilot_tmp_file(tmp_path, monkeypatch):
+async def test_agent_file_download_allows_pilot_tmp_file(
+    non_tmp_workspace, monkeypatch
+):
     from dbgpt.configs import model_config
     from dbgpt_app.openapi.api_v1 import agentic_data_api
 
-    pilot_tmp = tmp_path / "pilot" / "tmp"
+    pilot_tmp = non_tmp_workspace / "pilot" / "tmp"
     pilot_tmp.mkdir(parents=True)
     generated_file = pilot_tmp / "result.txt"
     generated_file.write_text("ok\n", encoding="utf-8")
-    monkeypatch.setattr(model_config, "ROOT_PATH", str(tmp_path / "project"))
-    monkeypatch.setattr(model_config, "PILOT_PATH", str(tmp_path / "pilot"))
+    monkeypatch.setattr(model_config, "ROOT_PATH", str(non_tmp_workspace / "project"))
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(non_tmp_workspace / "pilot"))
 
     response = await agentic_data_api.download_agent_file(str(generated_file))
 
     assert isinstance(response, FileResponse)
     assert response.path == str(generated_file)
+
+
+@pytest.mark.asyncio
+async def test_agent_file_download_rejects_relative_path():
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    with pytest.raises(HTTPException) as exc_info:
+        await agentic_data_api.download_agent_file(os.path.join("tmp", "result.txt"))
+
+    assert exc_info.value.status_code == 400

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
@@ -64,6 +64,36 @@ def test_agent_file_download_keeps_default_mock_user_compatibility():
     assert user.role == "admin"
 
 
+def test_agent_artifact_work_dir_uses_download_safe_pilot_tmp(
+    non_tmp_workspace, monkeypatch
+):
+    from dbgpt.configs import model_config
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    pilot_path = non_tmp_workspace / "pilot"
+    root_path = non_tmp_workspace / "project"
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(pilot_path))
+    monkeypatch.setattr(model_config, "ROOT_PATH", str(root_path))
+
+    work_dir = Path(agentic_data_api._agent_artifact_work_dir({"conv_id": "conv-1"}))
+
+    assert work_dir == pilot_path / "tmp" / "conv-1"
+    assert not _is_under(work_dir, root_path)
+
+
+def test_agent_artifact_work_dir_sanitizes_conv_id(non_tmp_workspace, monkeypatch):
+    from dbgpt.configs import model_config
+    from dbgpt_app.openapi.api_v1 import agentic_data_api
+
+    pilot_tmp = non_tmp_workspace / "pilot" / "tmp"
+    monkeypatch.setattr(model_config, "PILOT_PATH", str(non_tmp_workspace / "pilot"))
+
+    work_dir = Path(agentic_data_api._agent_artifact_work_dir({"conv_id": "../root"}))
+
+    assert _is_under(work_dir, pilot_tmp)
+    assert work_dir.name != "root"
+
+
 @pytest.mark.asyncio
 async def test_agent_file_download_rejects_project_root_file(
     non_tmp_workspace, monkeypatch

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 from fastapi.responses import FileResponse
 from fastapi.routing import APIRoute
 
-from dbgpt_serve.utils.auth import get_required_user_from_headers, get_user_from_headers
+from dbgpt_serve.utils.auth import get_user_from_headers
 
 
 def _is_under(path: Path, base: Path) -> bool:
@@ -46,25 +46,18 @@ def _download_route(agentic_data_api):
     raise AssertionError("download route not found")
 
 
-def test_agent_file_download_route_requires_required_user_dependency():
+def test_agent_file_download_route_uses_existing_user_dependency():
     from dbgpt_app.openapi.api_v1 import agentic_data_api
 
     route = _download_route(agentic_data_api)
 
     assert any(
-        dependency.call is get_required_user_from_headers
+        dependency.call is get_user_from_headers
         for dependency in route.dependant.dependencies
     )
 
 
-def test_agent_file_download_rejects_missing_user_header():
-    with pytest.raises(HTTPException) as exc_info:
-        get_required_user_from_headers(user_id=None)
-
-    assert exc_info.value.status_code == 401
-
-
-def test_optional_user_header_helper_keeps_default_mock_user():
+def test_agent_file_download_keeps_default_mock_user_compatibility():
     user = get_user_from_headers(user_id=None)
 
     assert user.user_id == "001"

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import Header, HTTPException
+from fastapi import Header
 
 from dbgpt._private.pydantic import BaseModel
 
@@ -36,9 +36,3 @@ def get_user_from_headers(user_id: Optional[str] = Header(None)):
     except Exception as e:
         logging.exception("Authentication failed!")
         raise Exception(f"Authentication failed. {str(e)}")
-
-
-def get_required_user_from_headers(user_id: Optional[str] = Header(None)):
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Missing user_id header")
-    return get_user_from_headers(user_id=user_id)

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import Header
+from fastapi import Header, HTTPException
 
 from dbgpt._private.pydantic import BaseModel
 
@@ -36,3 +36,9 @@ def get_user_from_headers(user_id: Optional[str] = Header(None)):
     except Exception as e:
         logging.exception("Authentication failed!")
         raise Exception(f"Authentication failed. {str(e)}")
+
+
+def get_required_user_from_headers(user_id: Optional[str] = Header(None)):
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Missing user_id header")
+    return get_user_from_headers(user_id=user_id)


### PR DESCRIPTION
## Summary
- require the same user dependency used by nearby agent/skill endpoints for `/v1/agent/files/download`
- stop allowing downloads from the whole application root; keep `/tmp` and `PILOT_PATH/tmp` as the agent-created file directories
- add route and path-boundary regression tests

Fixes #3018

## Tests
- PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py -q
- .venv/bin/ruff check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
- .venv/bin/ruff format --check packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
- PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m compileall -q packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py packages/dbgpt-app/src/dbgpt_app/tests/test_agent_file_download_api.py
- git diff --check