### PR TITLE
fix: accept scalar knowledge resource values

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
@@ -93,9 +93,7 @@ class ReActOutputParser:
 
     def _find_prefix_matches(self, text: str, escaped_prefix: str) -> List[re.Match]:
         """Find line-start ReAct prefix matches outside markdown code fences."""
-        pattern = re.compile(
-            self._prefix_line_pattern(escaped_prefix), re.MULTILINE
-        )
+        pattern = re.compile(self._prefix_line_pattern(escaped_prefix), re.MULTILINE)
         fence_spans = self._markdown_fence_spans(text)
         return [
             match
@@ -196,9 +194,7 @@ class ReActOutputParser:
         text = self._normalize_react_text(text).strip()
 
         # Find all line-start instances of the thought prefix outside code fences.
-        thought_matches = self._find_prefix_matches(
-            text, self.thought_prefix_escaped
-        )
+        thought_matches = self._find_prefix_matches(text, self.thought_prefix_escaped)
 
         if not thought_matches:
             return []
@@ -272,12 +268,8 @@ class ReActOutputParser:
             self.action_reason_prefix_escaped
         )
         action_line = self._prefix_line_pattern(self.action_prefix_escaped)
-        action_input_line = self._prefix_line_pattern(
-            self.action_input_prefix_escaped
-        )
-        observation_line = self._prefix_line_pattern(
-            self.observation_prefix_escaped
-        )
+        action_input_line = self._prefix_line_pattern(self.action_input_prefix_escaped)
+        observation_line = self._prefix_line_pattern(self.observation_prefix_escaped)
 
         thought_match = re.search(
             rf"{thought_line}(.*?)(?={phase_line}|{action_intention_line}|"

--- a/packages/dbgpt-core/src/dbgpt/agent/util/tests/test_react_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/tests/test_react_parser.py
@@ -55,10 +55,7 @@ Action Input: {"sql": "select distinct major_type from assets"}"""
         assert len(steps) == 1
         assert steps[0].thought == "I need to inspect the database schema."
         assert steps[0].action_intention == "Query the available asset categories."
-        assert (
-            steps[0].action_reason
-            == "The user asked about assets by major type."
-        )
+        assert steps[0].action_reason == "The user asked about assets by major type."
         assert steps[0].action == "query_db"
         assert steps[0].action_input == {
             "sql": "select distinct major_type from assets"
@@ -486,9 +483,7 @@ Action Input: {"result": "网络设备资产共 30 条"}"""
         assert len(all_steps) == 2
         assert len(current_steps) == 1
         assert current_steps[0].action == "query_db"
-        assert current_steps[0].action_input == {
-            "sql": "select count(*) from assets"
-        }
+        assert current_steps[0].action_input == {"sql": "select count(*) from assets"}
 
     def test_react_markers_inside_action_input_code_fence_are_not_steps(self):
         """Do not split Action Input code fences that mention ReAct labels."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
@@ -52,7 +52,7 @@ class KnowledgeSpaceLoadResourceParameters(RetrieverResourceParameters):
     def from_dict(
         cls, data: Any, ignore_extra_fields: bool = True
     ) -> "KnowledgeSpaceLoadResourceParameters":
-        """Create a new instance from dict, legacy value, or scalar space input."""
+        """Create a new instance from mapping, legacy value, or scalar space input."""
         if isinstance(data, dict):
             copied_data = data.copy()
         else:

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
@@ -61,17 +61,9 @@ class KnowledgeSpaceLoadResourceParameters(RetrieverResourceParameters):
             copied_data["space_name"] = copied_data.pop("value")
         if copied_data.get("space_name") is not None:
             copied_data["space_name"] = str(copied_data["space_name"])
-        if not copied_data.get("name"):
-            copied_data["name"] = cls._default_resource_name(
-                copied_data.get("space_name")
-            )
+        if copied_data.get("name") is None:
+            copied_data["name"] = "knowledge"
         return super().from_dict(copied_data, ignore_extra_fields=ignore_extra_fields)
-
-    @staticmethod
-    def _default_resource_name(space_name: Optional[str]) -> str:
-        if not space_name:
-            return "knowledge"
-        return f"knowledge_{space_name}"
 
 
 class KnowledgeSpaceRetrieverResource(RetrieverResource):

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
@@ -52,17 +52,26 @@ class KnowledgeSpaceLoadResourceParameters(RetrieverResourceParameters):
     def from_dict(
         cls, data: Any, ignore_extra_fields: bool = True
     ) -> "KnowledgeSpaceLoadResourceParameters":
-        """Create a new instance from a dictionary."""
+        """Create a new instance from dict, legacy value, or scalar space input."""
         if isinstance(data, dict):
             copied_data = data.copy()
         else:
             copied_data = {"space_name": data}
-        copied_data.setdefault("name", "knowledge")
         if "space_name" not in copied_data and "value" in copied_data:
             copied_data["space_name"] = copied_data.pop("value")
         if copied_data.get("space_name") is not None:
             copied_data["space_name"] = str(copied_data["space_name"])
+        if not copied_data.get("name"):
+            copied_data["name"] = cls._default_resource_name(
+                copied_data.get("space_name")
+            )
         return super().from_dict(copied_data, ignore_extra_fields=ignore_extra_fields)
+
+    @staticmethod
+    def _default_resource_name(space_name: Optional[str]) -> str:
+        if not space_name:
+            return "knowledge"
+        return f"knowledge_{space_name}"
 
 
 class KnowledgeSpaceRetrieverResource(RetrieverResource):

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py
@@ -50,12 +50,18 @@ class KnowledgeSpaceLoadResourceParameters(RetrieverResourceParameters):
 
     @classmethod
     def from_dict(
-        cls, data: dict, ignore_extra_fields: bool = True
+        cls, data: Any, ignore_extra_fields: bool = True
     ) -> "KnowledgeSpaceLoadResourceParameters":
         """Create a new instance from a dictionary."""
-        copied_data = data.copy()
+        if isinstance(data, dict):
+            copied_data = data.copy()
+        else:
+            copied_data = {"space_name": data}
+        copied_data.setdefault("name", "knowledge")
         if "space_name" not in copied_data and "value" in copied_data:
             copied_data["space_name"] = copied_data.pop("value")
+        if copied_data.get("space_name") is not None:
+            copied_data["space_name"] = str(copied_data["space_name"])
         return super().from_dict(copied_data, ignore_extra_fields=ignore_extra_fields)
 
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
@@ -4,19 +4,34 @@ from dbgpt_serve.agent.resource.knowledge import KnowledgeSpaceLoadResourceParam
 
 
 @pytest.mark.parametrize(
-    ("data", "expected_space_name"),
+    ("data", "expected_space_name", "expected_name"),
     [
-        (2, "2"),
-        ("2", "2"),
-        ({"value": 2}, "2"),
-        ({"value": "space_name"}, "space_name"),
-        ({"space_name": "space_name"}, "space_name"),
+        (2, "2", "knowledge_2"),
+        ("2", "2", "knowledge_2"),
+        ({"value": 2}, "2", "knowledge_2"),
+        ({"value": "space_name"}, "space_name", "knowledge_space_name"),
+        ({"space_name": "space_name"}, "space_name", "knowledge_space_name"),
+        (
+            {"name": None, "space_name": "space_name"},
+            "space_name",
+            "knowledge_space_name",
+        ),
     ],
 )
 def test_knowledge_resource_parameters_accept_scalar_space_values(
-    data, expected_space_name
+    data, expected_space_name, expected_name
 ):
     params = KnowledgeSpaceLoadResourceParameters.from_dict(data)
 
+    assert params.name == expected_name
     assert params.space_name == expected_space_name
     assert params.top_k == 10
+
+
+def test_knowledge_resource_parameters_preserve_explicit_name():
+    params = KnowledgeSpaceLoadResourceParameters.from_dict(
+        {"name": "custom_resource", "space_name": "space_name"}
+    )
+
+    assert params.name == "custom_resource"
+    assert params.space_name == "space_name"

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
@@ -6,15 +6,15 @@ from dbgpt_serve.agent.resource.knowledge import KnowledgeSpaceLoadResourceParam
 @pytest.mark.parametrize(
     ("data", "expected_space_name", "expected_name"),
     [
-        (2, "2", "knowledge_2"),
-        ("2", "2", "knowledge_2"),
-        ({"value": 2}, "2", "knowledge_2"),
-        ({"value": "space_name"}, "space_name", "knowledge_space_name"),
-        ({"space_name": "space_name"}, "space_name", "knowledge_space_name"),
+        (2, "2", "knowledge"),
+        ("2", "2", "knowledge"),
+        ({"value": 2}, "2", "knowledge"),
+        ({"value": "space_name"}, "space_name", "knowledge"),
+        ({"space_name": "space_name"}, "space_name", "knowledge"),
         (
             {"name": None, "space_name": "space_name"},
             "space_name",
-            "knowledge_space_name",
+            "knowledge",
         ),
     ],
 )

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dbgpt_serve.agent.resource.knowledge import KnowledgeSpaceLoadResourceParameters
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_space_name"),
+    [
+        (2, "2"),
+        ("2", "2"),
+        ({"value": 2}, "2"),
+        ({"value": "space_name"}, "space_name"),
+        ({"space_name": "space_name"}, "space_name"),
+    ],
+)
+def test_knowledge_resource_parameters_accept_scalar_space_values(
+    data, expected_space_name
+):
+    params = KnowledgeSpaceLoadResourceParameters.from_dict(data)
+
+    assert params.space_name == expected_space_name
+    assert params.top_k == 10


### PR DESCRIPTION
## Description

Fixes #2609.

The AWEL Agent Resource Knowledge selector can persist a knowledge space ID as a JSON scalar value, for example `"2"`. During resource construction that value is decoded to an integer and passed to `KnowledgeSpaceLoadResourceParameters.from_dict`, which expected a dict and failed with `'int' object has no attribute 'copy'`.

This change makes the knowledge resource parameter adapter accept scalar space values as well as legacy `{value: ...}` payloads, converts the selected space value to a string, and supplies a safe default resource name when the payload does not include one.

## Testing

- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py -q`
- `.venv/bin/ruff check packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py`
- `.venv/bin/ruff format --check packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py`
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-app/src:packages/dbgpt-serve/src:packages/dbgpt-ext/src .venv/bin/python -m compileall -q packages/dbgpt-serve/src/dbgpt_serve/agent/resource/knowledge.py packages/dbgpt-serve/src/dbgpt_serve/agent/resource/tests/test_knowledge_resource.py`
- `git diff --check`
