### PR TITLE
fix: handle knowledge space id responses

### DIFF
--- a/packages/dbgpt-client/src/dbgpt_client/knowledge.py
+++ b/packages/dbgpt-client/src/dbgpt_client/knowledge.py
@@ -1,13 +1,21 @@
 """Knowledge API client."""
 
 import json
-from typing import List
+from typing import Any, List
 
 from dbgpt._private.pydantic import model_to_dict, model_to_json
 from dbgpt.core.schema.api import Result
 
 from .client import Client, ClientException
 from .schema import DocumentModel, SpaceModel, SyncModel
+
+
+def _space_model_from_create_response(data: Any, request: SpaceModel) -> SpaceModel:
+    if isinstance(data, dict):
+        return SpaceModel(**data)
+    space = model_to_dict(request)
+    space["id"] = data
+    return SpaceModel(**space)
 
 
 async def create_space(client: Client, space_model: SpaceModel) -> SpaceModel:
@@ -25,7 +33,7 @@ async def create_space(client: Client, space_model: SpaceModel) -> SpaceModel:
         res = await client.post("/knowledge/spaces", model_to_dict(space_model))
         result: Result = res.json()
         if result["success"]:
-            return SpaceModel(**result["data"])
+            return _space_model_from_create_response(result["data"], space_model)
         else:
             raise ClientException(status=result["err_code"], reason=result)
     except Exception as e:

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py
@@ -1,0 +1,69 @@
+import pytest
+
+from dbgpt_client.knowledge import create_space
+from dbgpt_client.schema import SpaceModel
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _CreateSpaceClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    async def post(self, path, body):
+        self.requests.append((path, body))
+        return _Response(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_create_space_accepts_primary_key_response():
+    client = _CreateSpaceClient(
+        {"success": True, "err_code": None, "err_msg": None, "data": 2}
+    )
+    request = SpaceModel(
+        name="test_space",
+        vector_type="Chroma",
+        desc="for client space",
+        owner="dbgpt",
+    )
+
+    created = await create_space(client, request)
+
+    assert created.id == 2
+    assert created.name == "test_space"
+    assert created.vector_type == "Chroma"
+    assert created.desc == "for client space"
+    assert created.owner == "dbgpt"
+    assert client.requests[0][0] == "/knowledge/spaces"
+
+
+@pytest.mark.asyncio
+async def test_create_space_preserves_mapping_response():
+    client = _CreateSpaceClient(
+        {
+            "success": True,
+            "err_code": None,
+            "err_msg": None,
+            "data": {
+                "id": 2,
+                "name": "server_space",
+                "vector_type": "Milvus",
+                "desc": "from server",
+                "owner": "dbgpt",
+            },
+        }
+    )
+
+    created = await create_space(client, SpaceModel(name="request_space"))
+
+    assert created.id == 2
+    assert created.name == "server_space"
+    assert created.vector_type == "Milvus"
+    assert created.desc == "from server"


### PR DESCRIPTION
## Description

Fixes #2408.

The knowledge space create API currently returns the created space primary key. The Python client assumed the success payload was always a mapping and tried to construct `SpaceModel(**result["data"])`, which fails when `data` is an integer ID.

This change makes `create_space` accept both response shapes:

- mapping payloads keep the existing behavior and use server-returned fields
- primary-key payloads return a `SpaceModel` built from the request fields with the returned `id`

## Testing

- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-client/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py -q`
- `.venv/bin/ruff check packages/dbgpt-client/src/dbgpt_client/knowledge.py packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py`
- `.venv/bin/ruff format --check packages/dbgpt-client/src/dbgpt_client/knowledge.py packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py`
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-client/src:packages/dbgpt-ext/src .venv/bin/python -m compileall -q packages/dbgpt-client/src/dbgpt_client/knowledge.py packages/dbgpt-client/src/dbgpt_client/tests/test_knowledge.py`
- `git diff --check`
