### PR TITLE
fix: restrict personal skill script execution

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
@@ -334,9 +334,12 @@ class SkillManager(BaseComponent):
         Returns:
             JSON string with execution results.
         """
-        from dbgpt.util.code.server import get_code_server
-
         args = args or {}
+        skill_path = self._get_skill_path(skill_name)
+        if skill_path and self._should_reject_personal_skill_execution(skill_path):
+            return self._personal_skill_execution_denied_result(skill_name)
+
+        from dbgpt.util.code.server import get_code_server
 
         # Get the script
         scripts = self.get_skill_scripts(skill_name)
@@ -541,6 +544,66 @@ class SkillManager(BaseComponent):
         # Fallback: return direct path even if it doesn't exist yet
         return os.path.join(skills_dir, skill_name)
 
+    @staticmethod
+    def _allow_personal_skill_script_execution() -> bool:
+        import os
+
+        return os.getenv(
+            "DBGPT_ALLOW_PERSONAL_SKILL_SCRIPT_EXECUTION", ""
+        ).strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _is_personal_skill_path(skill_path: str) -> bool:
+        import os
+        from pathlib import Path
+
+        from dbgpt.configs.model_config import SKILLS_DIR
+
+        user_dir = Path(SKILLS_DIR).expanduser() / "user"
+        candidate = Path(skill_path).expanduser()
+
+        def _is_relative_to(path: Path, parent: Path) -> bool:
+            try:
+                path.relative_to(parent)
+                return True
+            except ValueError:
+                return False
+
+        lexical_path = Path(os.path.abspath(os.path.normpath(str(candidate))))
+        lexical_user_dir = Path(os.path.abspath(os.path.normpath(str(user_dir))))
+        if _is_relative_to(lexical_path, lexical_user_dir):
+            return True
+
+        try:
+            return _is_relative_to(candidate.resolve(), user_dir.resolve())
+        except OSError:
+            return False
+
+    def _should_reject_personal_skill_execution(self, skill_path: str) -> bool:
+        return (
+            self._is_personal_skill_path(skill_path)
+            and not self._allow_personal_skill_script_execution()
+        )
+
+    @staticmethod
+    def _personal_skill_execution_denied_result(skill_name: str) -> str:
+        return json.dumps(
+            {
+                "chunks": [
+                    {
+                        "output_type": "text",
+                        "content": (
+                            "Refusing to execute scripts from personal skill "
+                            f"'{skill_name}'. Set "
+                            "DBGPT_ALLOW_PERSONAL_SKILL_SCRIPT_EXECUTION=true only "
+                            "in trusted deployments to enable this."
+                        ),
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        )
+
     async def get_skill_resource(
         self,
         skill_name: str,
@@ -629,6 +692,8 @@ class SkillManager(BaseComponent):
 
         # Check if it's a script that needs execution
         if resource_path.startswith("scripts/") and ext.lower() in {".py", ".sh"}:
+            if self._should_reject_personal_skill_execution(skill_path):
+                return self._personal_skill_execution_denied_result(skill_name)
             return await self._execute_script_from_path(full_path, args or {})
 
         # Otherwise, read the file content
@@ -892,6 +957,9 @@ __name__ = "__main__"
                 },
                 ensure_ascii=False,
             )
+
+        if self._should_reject_personal_skill_execution(skill_path):
+            return self._personal_skill_execution_denied_result(skill_name)
 
         script_file_name = script_file_name.lstrip("/\\")
         if script_file_name.startswith("scripts/") or script_file_name.startswith(

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
@@ -545,11 +545,11 @@ class SkillManager(BaseComponent):
         return os.path.join(skills_dir, skill_name)
 
     @staticmethod
-    def _allow_personal_skill_script_execution() -> bool:
+    def _personal_skill_script_execution_disabled() -> bool:
         import os
 
         return os.getenv(
-            "DBGPT_ALLOW_PERSONAL_SKILL_SCRIPT_EXECUTION", ""
+            "DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", ""
         ).strip().lower() in {"1", "true", "yes", "on"}
 
     @staticmethod
@@ -588,7 +588,7 @@ class SkillManager(BaseComponent):
     def _should_reject_personal_skill_execution(self, skill_path: str) -> bool:
         return (
             self._is_personal_skill_path(skill_path)
-            and not self._allow_personal_skill_script_execution()
+            and self._personal_skill_script_execution_disabled()
         )
 
     @staticmethod
@@ -599,10 +599,10 @@ class SkillManager(BaseComponent):
                     {
                         "output_type": "text",
                         "content": (
-                            "Refusing to execute scripts from personal skill "
-                            f"'{skill_name}'. Set "
-                            "DBGPT_ALLOW_PERSONAL_SKILL_SCRIPT_EXECUTION=true only "
-                            "in trusted deployments to enable this."
+                            "Personal skill script execution is disabled for "
+                            f"'{skill_name}'. Unset "
+                            "DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION or set "
+                            "it to false to enable trusted personal skill scripts."
                         ),
                     }
                 ]

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/manage.py
@@ -569,13 +569,19 @@ class SkillManager(BaseComponent):
             except ValueError:
                 return False
 
-        lexical_path = Path(os.path.abspath(os.path.normpath(str(candidate))))
-        lexical_user_dir = Path(os.path.abspath(os.path.normpath(str(user_dir))))
+        def _normalize_for_containment(path: Path) -> Path:
+            return Path(os.path.normcase(os.path.abspath(os.path.normpath(str(path)))))
+
+        lexical_path = _normalize_for_containment(candidate)
+        lexical_user_dir = _normalize_for_containment(user_dir)
         if _is_relative_to(lexical_path, lexical_user_dir):
             return True
 
         try:
-            return _is_relative_to(candidate.resolve(), user_dir.resolve())
+            return _is_relative_to(
+                _normalize_for_containment(candidate.resolve()),
+                _normalize_for_containment(user_dir.resolve()),
+            )
         except OSError:
             return False
 

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
@@ -70,6 +70,76 @@ async def test_execute_skill_script_file_allows_uploaded_personal_skill_by_defau
 
 
 @pytest.mark.asyncio
+async def test_execute_script_allows_uploaded_personal_skill_by_default(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    class FakeCodeResult:
+        output = b"executed"
+        error_message = b""
+
+    class FakeCodeServer:
+        async def exec(self, code, language):
+            marker.write_text("executed", encoding="utf-8")
+            return FakeCodeResult()
+
+    async def fake_get_code_server(system_app):
+        return FakeCodeServer()
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.delenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", raising=False)
+    monkeypatch.setattr("dbgpt.util.code.server.get_code_server", fake_get_code_server)
+
+    result = await SkillManager(None).execute_script(
+        "uploaded-skill",
+        "touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "executed" in result_text
+    assert marker.read_text(encoding="utf-8") == "executed"
+
+
+@pytest.mark.asyncio
+async def test_get_skill_resource_allows_uploaded_personal_skill_scripts_by_default(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    executed = {}
+
+    async def fake_execute_script_from_path(self, script_path, args):
+        executed["script_path"] = script_path
+        executed["args"] = args
+        return json.dumps({"chunks": [{"output_type": "text", "content": "ok"}]})
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.delenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", raising=False)
+    monkeypatch.setattr(
+        SkillManager,
+        "_execute_script_from_path",
+        fake_execute_script_from_path,
+    )
+
+    result = await SkillManager(None).get_skill_resource(
+        "uploaded-skill",
+        "scripts/touch_marker.py",
+        {"marker": "value"},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "ok" in result_text
+    assert executed["script_path"].endswith("scripts/touch_marker.py")
+    assert executed["args"] == {"marker": "value"}
+
+
+@pytest.mark.asyncio
 async def test_execute_script_rejects_uploaded_personal_skill_when_disabled(
     tmp_path, monkeypatch
 ):

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
@@ -1,0 +1,117 @@
+"""Tests for the skill manager."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dbgpt.agent.skill.manage import SkillManager
+from dbgpt.configs import model_config
+
+
+def _write_marker_script(skill_dir: Path) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-skill\ndescription: Test skill\n---\n",
+        encoding="utf-8",
+    )
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "touch_marker.py").write_text(
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                "from pathlib import Path",
+                "",
+                "args = json.loads(sys.argv[1])",
+                "Path(args['marker']).write_text('executed', encoding='utf-8')",
+                "print('executed')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_skill_script_file_rejects_uploaded_personal_skill(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+
+    result = await SkillManager(None).execute_skill_script_file(
+        "uploaded-skill",
+        "touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "personal" in result_text.lower()
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_execute_script_rejects_uploaded_personal_skill(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+
+    result = await SkillManager(None).execute_script(
+        "uploaded-skill",
+        "touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "personal" in result_text.lower()
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_get_skill_resource_rejects_uploaded_personal_skill_scripts(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+
+    result = await SkillManager(None).get_skill_resource(
+        "uploaded-skill",
+        "scripts/touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "personal" in result_text.lower()
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_execute_skill_script_file_allows_builtin_skill(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "builtin-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+
+    result = await SkillManager(None).execute_skill_script_file(
+        "builtin-skill",
+        "touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "executed" in result_text
+    assert marker.read_text(encoding="utf-8") == "executed"

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
@@ -33,6 +33,19 @@ def _write_marker_script(skill_dir: Path) -> None:
     )
 
 
+def test_personal_skill_path_detection_normalizes_case(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    user_skill_dir = skills_dir / "user" / "uploaded-skill"
+    user_skill_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.setattr("os.path.normcase", lambda path: str(path).lower())
+
+    assert SkillManager._is_personal_skill_path(
+        str(skills_dir / "User" / "uploaded-skill")
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_skill_script_file_rejects_uploaded_personal_skill(
     tmp_path, monkeypatch

--- a/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py
@@ -47,7 +47,7 @@ def test_personal_skill_path_detection_normalizes_case(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_skill_script_file_rejects_uploaded_personal_skill(
+async def test_execute_skill_script_file_allows_uploaded_personal_skill_by_default(
     tmp_path, monkeypatch
 ):
     skills_dir = tmp_path / "skills"
@@ -56,6 +56,7 @@ async def test_execute_skill_script_file_rejects_uploaded_personal_skill(
     marker = tmp_path / "marker.txt"
 
     monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.delenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", raising=False)
 
     result = await SkillManager(None).execute_skill_script_file(
         "uploaded-skill",
@@ -64,18 +65,21 @@ async def test_execute_skill_script_file_rejects_uploaded_personal_skill(
     )
 
     result_text = json.dumps(json.loads(result), ensure_ascii=False)
-    assert "personal" in result_text.lower()
-    assert not marker.exists()
+    assert "executed" in result_text
+    assert marker.read_text(encoding="utf-8") == "executed"
 
 
 @pytest.mark.asyncio
-async def test_execute_script_rejects_uploaded_personal_skill(tmp_path, monkeypatch):
+async def test_execute_script_rejects_uploaded_personal_skill_when_disabled(
+    tmp_path, monkeypatch
+):
     skills_dir = tmp_path / "skills"
     skill_dir = skills_dir / "user" / "uploaded-skill"
     _write_marker_script(skill_dir)
     marker = tmp_path / "marker.txt"
 
     monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.setenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", "true")
 
     result = await SkillManager(None).execute_script(
         "uploaded-skill",
@@ -89,7 +93,7 @@ async def test_execute_script_rejects_uploaded_personal_skill(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_get_skill_resource_rejects_uploaded_personal_skill_scripts(
+async def test_get_skill_resource_rejects_uploaded_personal_skill_scripts_when_disabled(
     tmp_path, monkeypatch
 ):
     skills_dir = tmp_path / "skills"
@@ -98,6 +102,7 @@ async def test_get_skill_resource_rejects_uploaded_personal_skill_scripts(
     marker = tmp_path / "marker.txt"
 
     monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.setenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", "true")
 
     result = await SkillManager(None).get_skill_resource(
         "uploaded-skill",
@@ -107,6 +112,29 @@ async def test_get_skill_resource_rejects_uploaded_personal_skill_scripts(
 
     result_text = json.dumps(json.loads(result), ensure_ascii=False)
     assert "personal" in result_text.lower()
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_execute_skill_script_file_rejects_uploaded_personal_skill_when_disabled(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "user" / "uploaded-skill"
+    _write_marker_script(skill_dir)
+    marker = tmp_path / "marker.txt"
+
+    monkeypatch.setattr(model_config, "SKILLS_DIR", str(skills_dir))
+    monkeypatch.setenv("DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION", "true")
+
+    result = await SkillManager(None).execute_skill_script_file(
+        "uploaded-skill",
+        "touch_marker.py",
+        {"marker": str(marker)},
+    )
+
+    result_text = json.dumps(json.loads(result), ensure_ascii=False)
+    assert "disabled" in result_text.lower()
     assert not marker.exists()
 
 


### PR DESCRIPTION
## Summary
- preserve existing personal/uploaded skill script execution by default to keep installed custom skills compatible
- add a deployment opt-out via `DBGPT_DISABLE_PERSONAL_SKILL_SCRIPT_EXECUTION=true` for environments that treat personal skills as untrusted
- keep built-in skill script execution working and cover `execute_skill_script_file`, `execute_script`, and `get_skill_resource` paths

## Why
Uploaded/imported skills are installed under `skills/user`, and DB-GPT documents them as ready to use after installation. Default-denying those scripts would break existing custom skill workflows after upgrade. The guard now keeps the current trust model by default while still giving operators a clear switch to disable personal skill script execution in stricter deployments.

## Testing
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-ext/src .venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py -q`
- `.venv/bin/ruff check packages/dbgpt-core/src/dbgpt/agent/skill/manage.py packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py`
- `.venv/bin/ruff format --check packages/dbgpt-core/src/dbgpt/agent/skill/manage.py packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py`
- `PYTHONPATH=packages/dbgpt-core/src:packages/dbgpt-ext/src .venv/bin/python -m compileall -q packages/dbgpt-core/src/dbgpt/agent/skill/manage.py packages/dbgpt-core/src/dbgpt/agent/skill/tests/test_manage.py`
- `git diff --check`

Closes #3047