### PR TITLE
fix(web): refresh ReAct task state

### DIFF
--- a/web/components/layout/side-bar.tsx
+++ b/web/components/layout/side-bar.tsx
@@ -5,6 +5,7 @@ import { DarkSvg, ModelSvg, SunnySvg } from '@/components/icons';
 import UserBar from '@/new-components/layout/UserBar';
 import type { IChatDialogueSchema } from '@/types/chat';
 import { STORAGE_LANG_KEY, STORAGE_THEME_KEY } from '@/utils/constants/index';
+import { dispatchReactAgentNewTask, subscribeReactAgentDialoguesChanged } from '@/utils/react-agent-events';
 import Icon, {
   ApartmentOutlined,
   AppstoreOutlined,
@@ -103,6 +104,13 @@ function SideBar() {
       console.error('Failed to delete dialogue', error);
     }
   }, []);
+
+  const handleNewTask = useCallback(() => {
+    dispatchReactAgentNewTask();
+    if (pathname !== '/' || router.asPath !== '/') {
+      router.push('/', undefined, { shallow: true });
+    }
+  }, [pathname, router]);
 
   const formatRelativeTime = useCallback((dateStr?: string) => {
     if (!dateStr) return '';
@@ -285,6 +293,20 @@ function SideBar() {
     fetchDialogueList();
   }, [fetchDialogueList]);
 
+  useEffect(() => {
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+    const refreshDialogues = () => {
+      fetchDialogueList();
+      if (refreshTimer) clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(fetchDialogueList, 800);
+    };
+    const unsubscribe = subscribeReactAgentDialoguesChanged(refreshDialogues);
+    return () => {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      unsubscribe();
+    };
+  }, [fetchDialogueList]);
+
   // ============ COLLAPSED SIDEBAR ============
   if (!isMenuExpand) {
     return (
@@ -374,12 +396,14 @@ function SideBar() {
       </div>
 
       {/* New Task Button */}
-      <Link href='/'>
-        <div className='flex items-center justify-center gap-2 px-4 py-2.5 mb-4 bg-black dark:bg-white dark:text-black text-white rounded-xl text-sm font-medium hover:opacity-90 transition-opacity cursor-pointer'>
-          <PlusOutlined className='text-xs' />
-          <span>{t('new_task')}</span>
-        </div>
-      </Link>
+      <button
+        type='button'
+        onClick={handleNewTask}
+        className='flex w-full items-center justify-center gap-2 px-4 py-2.5 mb-4 bg-black dark:bg-white dark:text-black text-white rounded-xl text-sm font-medium hover:opacity-90 transition-opacity cursor-pointer border-0'
+      >
+        <PlusOutlined className='text-xs' />
+        <span>{t('new_task')}</span>
+      </button>
 
       {/* Functions */}
       <div className='flex flex-col gap-1'>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -571,6 +571,8 @@ const Playground: NextPage = () => {
   // Track step IDs that belong to a terminate action so we can suppress them
   const terminatedStepIdsRef = useRef<Set<string>>(new Set());
   const preloadedFilePathRef = useRef<string | null>(null);
+  const streamControllerRef = useRef<AbortController | null>(null);
+  const activeRequestIdRef = useRef(0);
 
   const [historyLoading, setHistoryLoading] = useState(false);
   const [contextStatus, setContextStatus] = useState<{
@@ -583,9 +585,13 @@ const Playground: NextPage = () => {
   const [taskPlan, setTaskPlan] = useState<TaskItem[]>([]);
 
   const resetConversationState = useCallback(() => {
+    activeRequestIdRef.current += 1;
+    streamControllerRef.current?.abort();
+    streamControllerRef.current = null;
     setMessages([]);
     setConversationId(null);
     setQuery('');
+    setLoading(false);
     setExecutionMap({});
     setActiveMessageId(null);
     setActiveViewMsgId(null);
@@ -1481,6 +1487,9 @@ const Playground: NextPage = () => {
     if (!conversationId) {
       setConversationId(currentConvId);
     }
+    const requestId = activeRequestIdRef.current + 1;
+    activeRequestIdRef.current = requestId;
+    const isActiveRequest = () => requestId === activeRequestIdRef.current;
 
     // Calculate current order
     const currentOrder = Math.floor(messages.length / 2) + 1;
@@ -1523,6 +1532,7 @@ const Playground: NextPage = () => {
     setActiveViewMsgId(responseId); // Auto-switch right panel to new round
 
     const controller = new AbortController();
+    streamControllerRef.current = controller;
     terminatedStepIdsRef.current.clear();
     setExecutionMap(prev => ({
       ...prev,
@@ -1562,6 +1572,8 @@ const Playground: NextPage = () => {
         signal: controller.signal,
       });
 
+      if (!isActiveRequest()) return;
+
       if (!response.body) {
         throw new Error('No response body');
       }
@@ -1571,6 +1583,7 @@ const Playground: NextPage = () => {
       let buffer = '';
 
       const processEvent = (raw: string) => {
+        if (!isActiveRequest()) return;
         if (!raw.startsWith('data:')) return;
         const data = raw.slice(5).trim();
         if (!data) return;
@@ -1863,6 +1876,10 @@ const Playground: NextPage = () => {
             const summaryText = cleanFinalContent(payload.content);
             const streamInterval = setInterval(() => {
               setStreamingSummary(prev => {
+                if (!isActiveRequest()) {
+                  clearInterval(streamInterval);
+                  return prev;
+                }
                 if (prev.length >= summaryText.length) {
                   clearInterval(streamInterval);
                   setSummaryComplete(true);
@@ -1947,16 +1964,19 @@ const Playground: NextPage = () => {
       // eslint-disable-next-line no-constant-condition
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
+        if (done || !isActiveRequest()) break;
         buffer += decoder.decode(value, { stream: true });
         const parts = buffer.split('\n\n');
         buffer = parts.pop() || '';
         parts.forEach(processEvent);
       }
+      if (!isActiveRequest()) return;
       setLoading(false);
       dispatchReactAgentDialoguesChanged();
     } catch (err: any) {
+      if (!isActiveRequest()) return;
       setLoading(false);
+      if (err?.name === 'AbortError') return;
       message.error(err?.message || 'Failed to get response');
       setMessages(prev => {
         const newMessages = [...prev];
@@ -1967,6 +1987,10 @@ const Playground: NextPage = () => {
         }
         return newMessages;
       });
+    } finally {
+      if (isActiveRequest()) {
+        streamControllerRef.current = null;
+      }
     }
   };
 

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -16,6 +16,7 @@ import ManusRightPanel, {
 import { MessagePart, ToolPart, ToolStatus } from '@/new-components/chat/content/OpenCodeSessionTurn';
 import TaskPlanCard, { TaskItem } from '@/new-components/chat/content/TaskPlanCard';
 import axios from '@/utils/ctx-axios';
+import { dispatchReactAgentDialoguesChanged, subscribeReactAgentNewTask } from '@/utils/react-agent-events';
 import { sendSpacePostRequest } from '@/utils/request';
 import {
   ArrowUpOutlined,
@@ -63,7 +64,7 @@ import {
 import { NextPage } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const generateUUID = () => {
@@ -581,6 +582,33 @@ const Playground: NextPage = () => {
   } | null>(null);
   const [taskPlan, setTaskPlan] = useState<TaskItem[]>([]);
 
+  const resetConversationState = useCallback(() => {
+    setMessages([]);
+    setConversationId(null);
+    setQuery('');
+    setExecutionMap({});
+    setActiveMessageId(null);
+    setActiveViewMsgId(null);
+    setUploadedFilePath(null);
+    setFilePreview(null);
+    setFilePreviewError(null);
+    setChartPreview(null);
+    setArtifacts([]);
+    setCreatedSkillNames({});
+    setRightPanelTab('preview');
+    setRightPanelView('execution');
+    setRightPanelCollapsed(false);
+    setStreamingSummary('');
+    setSummaryComplete(false);
+    setTaskPlan([]);
+    setContextStatus(null);
+    setSelectedStepId(null);
+    setPreviewArtifact(null);
+    lastArtifactKeyRef.current = '';
+    terminatedStepIdsRef.current.clear();
+    preloadedFilePathRef.current = null;
+  }, []);
+
   // Fetch Data Sources
   const { data: dataSources, loading: _loadingSources } = useRequest(async () => {
     try {
@@ -694,22 +722,13 @@ const Playground: NextPage = () => {
       loadConversation(convId);
     } else if (!convId && conversationId) {
       // URL 中 id 消失（如点击 new_task / 探索广场），清空当前会话状态
-      setMessages([]);
-      setConversationId(null);
-      setQuery('');
-      setExecutionMap({});
-      setActiveMessageId(null);
-      setActiveViewMsgId(null);
-      setUploadedFilePath(null);
-      setFilePreview(null);
-      setFilePreviewError(null);
-      setArtifacts([]);
-      setRightPanelTab('preview');
-      setStreamingSummary('');
-      setSummaryComplete(false);
-      setTaskPlan([]);
+      resetConversationState();
     }
-  }, [router.query.id]);
+    // Only react to URL id changes. Adding conversationId would reset a new '/' chat immediately after it starts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query.id, resetConversationState]);
+
+  useEffect(() => subscribeReactAgentNewTask(resetConversationState), [resetConversationState]);
 
   useEffect(() => {
     const lastView = [...messages].reverse().find(msg => msg.role === 'view');
@@ -1935,6 +1954,7 @@ const Playground: NextPage = () => {
         parts.forEach(processEvent);
       }
       setLoading(false);
+      dispatchReactAgentDialoguesChanged();
     } catch (err: any) {
       setLoading(false);
       message.error(err?.message || 'Failed to get response');
@@ -2017,19 +2037,7 @@ const Playground: NextPage = () => {
 
   // Clear chat history
   const handleClearChat = () => {
-    setMessages([]);
-    setConversationId(null);
-    setQuery('');
-    setExecutionMap({});
-    setActiveMessageId(null);
-    setActiveViewMsgId(null);
-    setUploadedFilePath(null);
-    setFilePreview(null);
-    setFilePreviewError(null);
-    setArtifacts([]);
-    setRightPanelTab('preview');
-    setStreamingSummary('');
-    setSummaryComplete(false);
+    resetConversationState();
     router.push('/', undefined, { shallow: true });
   };
 

--- a/web/utils/react-agent-events.ts
+++ b/web/utils/react-agent-events.ts
@@ -1,0 +1,33 @@
+const REACT_AGENT_NEW_TASK_EVENT = 'dbgpt:react-agent:new-task';
+const REACT_AGENT_DIALOGUES_CHANGED_EVENT = 'dbgpt:react-agent:dialogues-changed';
+
+type Unsubscribe = () => void;
+
+function dispatchBrowserEvent(eventName: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(eventName));
+}
+
+function subscribeBrowserEvent(eventName: string, handler: () => void): Unsubscribe {
+  if (typeof window === 'undefined') return () => {};
+
+  const listener = () => handler();
+  window.addEventListener(eventName, listener);
+  return () => window.removeEventListener(eventName, listener);
+}
+
+export function dispatchReactAgentNewTask() {
+  dispatchBrowserEvent(REACT_AGENT_NEW_TASK_EVENT);
+}
+
+export function subscribeReactAgentNewTask(handler: () => void): Unsubscribe {
+  return subscribeBrowserEvent(REACT_AGENT_NEW_TASK_EVENT, handler);
+}
+
+export function dispatchReactAgentDialoguesChanged() {
+  dispatchBrowserEvent(REACT_AGENT_DIALOGUES_CHANGED_EVENT);
+}
+
+export function subscribeReactAgentDialoguesChanged(handler: () => void): Unsubscribe {
+  return subscribeBrowserEvent(REACT_AGENT_DIALOGUES_CHANGED_EVENT, handler);
+}


### PR DESCRIPTION
## Summary
- replace the ReAct sidebar New Task link with an explicit reset action so it works even when already on /
- notify the sidebar after a ReAct conversation stream completes and refresh the task list, including a delayed retry for backend persistence
- centralize ReAct conversation reset state to keep route reset and manual clear behavior consistent

Fixes #3075

## Tests
- node integration check for ReAct sidebar reset/refresh wiring
- node behavior check for react-agent event helper subscribe/dispatch/unsubscribe
- npx eslint components/layout/side-bar.tsx pages/index.tsx utils/react-agent-events.ts
- npx prettier --check components/layout/side-bar.tsx pages/index.tsx utils/react-agent-events.ts
- npx tsc --pretty false --noEmit --target es6 --lib dom,esnext --strict --module esnext --moduleResolution node --skipLibCheck utils/react-agent-events.ts
- npm run build (compiled successfully, then failed on existing unrelated Prettier issue in components/chat/chat-content/ReferencesContent.tsx)

## Notes
- Full npm ci is currently blocked because package-lock.json is out of sync with package.json; yarn --frozen-lockfile is also blocked by the current yarn.lock state. I installed local dependencies with package-lock writes disabled only for verification.