### PR TITLE
fix: prevent path traversal in plugin install via branch_name sanitiz…

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py
@@ -133,6 +133,18 @@ def scan_plugins(
     return loaded_plugins
 
 
+def _sanitize_branch_name(branch_name: str) -> str:
+    """Sanitize branch_name to prevent path traversal attacks."""
+    sanitized = branch_name.replace("\\", "/")
+    sanitized = "/".join(
+        part for part in sanitized.split("/") if part not in (".", "..")
+    )
+    sanitized = sanitized.strip("/")
+    if not sanitized:
+        raise ValueError(f"Invalid branch name: {branch_name}")
+    return sanitized
+
+
 def update_from_git(
     download_path: str,
     github_repo: str = "",
@@ -142,6 +154,7 @@ def update_from_git(
     """Update plugins from a git repository."""
     import requests
 
+    branch_name = _sanitize_branch_name(branch_name)
     os.makedirs(download_path, exist_ok=True)
     if github_repo:
         if github_repo.index("github.com") <= 0:
@@ -174,6 +187,9 @@ def update_from_git(
             file_name = (
                 f"{plugins_path_path}/{plugin_repo_name}-{branch_name}-{time_str}.zip"
             )
+            base_real = os.path.realpath(str(plugins_path_path))
+            if not os.path.realpath(file_name).startswith(base_real + os.sep):
+                raise ValueError(f"Path traversal detected: {file_name}")
             print(file_name)
             with open(file_name, "wb") as f:
                 f.write(response.content)


### PR DESCRIPTION
### Summary

- Sanitize `branch_name` parameter in `update_from_git()` to strip `..` and `.` path components before use in file path construction
- Add post-construction containment check verifying the resolved path stays within the plugins directory
- Prevents arbitrary file write via crafted `download_param.branch_name` in `POST /api/v1/agent/hub/update`

### Problem

`packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py:175` constructs a file path using unsanitized user input:

```python
file_name = f"{plugins_path_path}/{plugin_repo_name}-{branch_name}-{time_str}.zip"
with open(file_name, "wb") as f:
    f.write(response.content)
```

`branch_name` originates from the `download_param` JSON field in the API request body. A malicious value like `main/../../etc/cron.d/pwn` allows writing attacker-controlled content outside the intended plugins directory.

### Fix

Two layers of defense:

1. **Input sanitization** (`_sanitize_branch_name`): strips `..`, `.`, and backslash-based traversal from branch name before it enters any path logic.

2. **Output containment check**: after constructing the final path, resolves it to an absolute path and verifies it remains under the plugins base directory. Raises `ValueError` if the resolved path escapes.

### Changed files

- `packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py`

### Test plan

- [ ] Verify normal plugin install still works with standard branch names (`main`, `dev`, `feature/foo`)
- [ ] Verify `branch_name` containing `../` raises `ValueError`
- [ ] Verify `branch_name` containing absolute path components raises `ValueError`
- [ ] Existing unit tests pass
 
The issue linked is #3083 