### PR TITLE
fix(rag): split oversized markdown header chunks

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/react_parser.py
@@ -93,9 +93,7 @@ class ReActOutputParser:
 
     def _find_prefix_matches(self, text: str, escaped_prefix: str) -> List[re.Match]:
         """Find line-start ReAct prefix matches outside markdown code fences."""
-        pattern = re.compile(
-            self._prefix_line_pattern(escaped_prefix), re.MULTILINE
-        )
+        pattern = re.compile(self._prefix_line_pattern(escaped_prefix), re.MULTILINE)
         fence_spans = self._markdown_fence_spans(text)
         return [
             match
@@ -196,9 +194,7 @@ class ReActOutputParser:
         text = self._normalize_react_text(text).strip()
 
         # Find all line-start instances of the thought prefix outside code fences.
-        thought_matches = self._find_prefix_matches(
-            text, self.thought_prefix_escaped
-        )
+        thought_matches = self._find_prefix_matches(text, self.thought_prefix_escaped)
 
         if not thought_matches:
             return []
@@ -272,12 +268,8 @@ class ReActOutputParser:
             self.action_reason_prefix_escaped
         )
         action_line = self._prefix_line_pattern(self.action_prefix_escaped)
-        action_input_line = self._prefix_line_pattern(
-            self.action_input_prefix_escaped
-        )
-        observation_line = self._prefix_line_pattern(
-            self.observation_prefix_escaped
-        )
+        action_input_line = self._prefix_line_pattern(self.action_input_prefix_escaped)
+        observation_line = self._prefix_line_pattern(self.observation_prefix_escaped)
 
         thought_match = re.search(
             rf"{thought_line}(.*?)(?={phase_line}|{action_intention_line}|"

--- a/packages/dbgpt-core/src/dbgpt/agent/util/tests/test_react_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/tests/test_react_parser.py
@@ -55,10 +55,7 @@ Action Input: {"sql": "select distinct major_type from assets"}"""
         assert len(steps) == 1
         assert steps[0].thought == "I need to inspect the database schema."
         assert steps[0].action_intention == "Query the available asset categories."
-        assert (
-            steps[0].action_reason
-            == "The user asked about assets by major type."
-        )
+        assert steps[0].action_reason == "The user asked about assets by major type."
         assert steps[0].action == "query_db"
         assert steps[0].action_input == {
             "sql": "select distinct major_type from assets"
@@ -486,9 +483,7 @@ Action Input: {"result": "网络设备资产共 30 条"}"""
         assert len(all_steps) == 2
         assert len(current_steps) == 1
         assert current_steps[0].action == "query_db"
-        assert current_steps[0].action_input == {
-            "sql": "select count(*) from assets"
-        }
+        assert current_steps[0].action_input == {"sql": "select count(*) from assets"}
 
     def test_react_markers_inside_action_input_code_fence_are_not_steps(self):
         """Do not split Action Input code fences that mention ReAct labels."""

--- a/packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py
+++ b/packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py
@@ -38,6 +38,21 @@ def test_md_header_text_splitter() -> None:
     ]
 
 
+def test_md_header_text_splitter_splits_oversized_code_block() -> None:
+    """Markdown header chunks should still honor the configured chunk size."""
+
+    large_yaml_block = "\n".join(f"key_{i}: value_{i}" for i in range(100))
+    markdown_document = f"# Config\n\n```yaml\n{large_yaml_block}\n```\n"
+    chunk_size = 128
+    markdown_splitter = MarkdownHeaderTextSplitter(chunk_size=chunk_size)
+
+    output = markdown_splitter.split_text(markdown_document)
+
+    assert len(output) > 1
+    assert max(len(chunk.content) for chunk in output) <= chunk_size
+    assert all(chunk.metadata == {"Header1": "Config"} for chunk in output)
+
+
 def test_merge_splits() -> None:
     """Test merging splits with a given separator."""
     splitter = CharacterTextSplitter(separator=" ", chunk_size=9, chunk_overlap=2)

--- a/packages/dbgpt-core/src/dbgpt/rag/text_splitter/text_splitter.py
+++ b/packages/dbgpt-core/src/dbgpt/rag/text_splitter/text_splitter.py
@@ -530,9 +530,10 @@ class MarkdownHeaderTextSplitter(TextSplitter):
                 aggregated_chunks.append(line)
 
         chunks = []
+        fallback_chunk_overlap = min(self._chunk_overlap, self._chunk_size)
         fallback_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self._chunk_size,
-            chunk_overlap=self._chunk_overlap,
+            chunk_overlap=fallback_chunk_overlap,
             length_function=self._length_function,
         )
         for chunk in aggregated_chunks:


### PR DESCRIPTION
## Summary

- Fixes #3030.
- Keeps markdown header-based grouping, but applies a size-bound second pass when an aggregated markdown header chunk exceeds `chunk_size`.
- Preserves header metadata on each generated sub-chunk.
- Avoids introducing an overlap validation regression when a caller sets a small `chunk_size` without overriding the splitter's default overlap.

## Why

Markdown documents can contain large fenced YAML/TOML/config blocks under a single header. The header splitter previously returned that whole section as one chunk, which can exceed embedding provider input limits even when `chunk_size` is configured.

## Tests

- Red test before implementation:
  - `.venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py::test_md_header_text_splitter_splits_oversized_code_block -q`
  - Failed as expected because only one oversized chunk was produced.
- `.venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py::test_md_header_text_splitter_splits_oversized_code_block -q`
- `.venv/bin/python -m pytest packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_markdown.py -q`
- Manual default-path check with `MarkdownKnowledge + ChunkManager + ChunkParameters(chunk_strategy="Automatic", chunk_size=128, chunk_overlap=16)`:
  - Result: `17` chunks, max length `127`, header/source metadata preserved.
- `.venv/bin/python -m ruff check packages/dbgpt-core/src/dbgpt/rag/text_splitter/text_splitter.py packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py`
- `.venv/bin/python -m ruff format --check packages/dbgpt-core/src/dbgpt/rag/text_splitter/text_splitter.py packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py`
- `.venv/bin/python -m compileall -q packages/dbgpt-core/src/dbgpt/rag/text_splitter/text_splitter.py packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py`
- `git diff --check`
