### PR TITLE
feat: add CLIENT SETNAME to Valkey vector store client

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/valkey_store.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/storage/vector_store/valkey_store.py
@@ -300,12 +300,14 @@ class ValkeyStore(VectorStoreBase):
                 use_tls=config.use_ssl,
                 request_timeout=config.request_timeout,
                 credentials=ServerCredentials(password=config.password),
+                client_name="dbgpt_vector_store_client",
             )
         else:
             client_config = GlideClientConfiguration(
                 addresses=[node],
                 use_tls=config.use_ssl,
                 request_timeout=config.request_timeout,
+                client_name="dbgpt_vector_store_client",
             )
 
         # GlideClient.create() is async — run it in our dedicated loop


### PR DESCRIPTION
## Summary

Adds `client_name="dbgpt_vector_store_client"` to both `GlideClientConfiguration` calls in `ValkeyStore._create_client()`, so the connection is identifiable via `CLIENT LIST` on the server.

## Changes

One-line addition to each of the two `GlideClientConfiguration` constructors (with-password and without-password paths):

```python
client_config = GlideClientConfiguration(
    addresses=[node],
    use_tls=config.use_ssl,
    request_timeout=config.request_timeout,
    client_name="dbgpt_vector_store_client",  # <-- added
)
```

## Motivation

When running `CLIENT LIST` on a Valkey server, connections without a name show up as anonymous. Setting `client_name` sends a `CLIENT SETNAME` command on connection, making the connection identifiable in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

## Risk

Zero-risk — `client_name` is a metadata-only option in valkey-glide that sends a `CLIENT SETNAME` command after connecting. No behavioral changes.

Fixes #3087