### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/minimax.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/minimax.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     ClientType = Union[AsyncAzureOpenAI, AsyncOpenAI]
 
-_DEFAULT_MODEL = "MiniMax-M2.7"
+_DEFAULT_MODEL = "MiniMax-M3"
 
 
 @auto_register_resource(
@@ -161,11 +161,22 @@ register_proxy_model_adapter(
     MiniMaxLLMClient,
     supported_models=[
         ModelMetadata(
+            model="MiniMax-M3",
+            context_length=204800,
+            max_output_length=192000,
+            description=(
+                "MiniMax-M3 by MiniMax. Latest flagship model with enhanced "
+                "reasoning, coding and tool use."
+            ),
+            link="https://platform.minimax.io/docs/api-reference/text-openai-api",
+            function_calling=True,
+        ),
+        ModelMetadata(
             model="MiniMax-M2.7",
             context_length=204800,
             max_output_length=192000,
             description=(
-                "MiniMax-M2.7 by MiniMax. Latest flagship model with enhanced "
+                "MiniMax-M2.7 by MiniMax. Previous flagship model with enhanced "
                 "reasoning and coding."
             ),
             link="https://platform.minimax.io/docs/api-reference/text-openai-api",
@@ -178,25 +189,6 @@ register_proxy_model_adapter(
             description=(
                 "MiniMax-M2.7-highspeed by MiniMax. High-speed version of M2.7 "
                 "for low-latency scenarios."
-            ),
-            link="https://platform.minimax.io/docs/api-reference/text-openai-api",
-            function_calling=True,
-        ),
-        ModelMetadata(
-            model="MiniMax-M2.5",
-            context_length=204800,
-            max_output_length=192000,
-            description=("MiniMax-M2.5 by MiniMax. Peak Performance. Ultimate Value."),
-            link="https://platform.minimax.io/docs/api-reference/text-openai-api",
-            function_calling=True,
-        ),
-        ModelMetadata(
-            model="MiniMax-M2.5-highspeed",
-            context_length=204800,
-            max_output_length=192000,
-            description=(
-                "MiniMax-M2.5-highspeed by MiniMax. Same performance, faster and "
-                "more agile."
             ),
             link="https://platform.minimax.io/docs/api-reference/text-openai-api",
             function_calling=True,

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/tests/test_minimax.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/tests/test_minimax.py
@@ -13,18 +13,18 @@ from dbgpt.model.proxy.llms.minimax import (
 class TestMiniMaxDefaults:
     """Test MiniMax default model configuration."""
 
-    def test_default_model_is_m27(self):
-        assert _DEFAULT_MODEL == "MiniMax-M2.7"
+    def test_default_model_is_m3(self):
+        assert _DEFAULT_MODEL == "MiniMax-M3"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
     def test_client_default_model(self):
         client = MiniMaxLLMClient()
-        assert client.default_model == "MiniMax-M2.7"
+        assert client.default_model == "MiniMax-M3"
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
     def test_client_custom_model(self):
-        client = MiniMaxLLMClient(model="MiniMax-M2.5")
-        assert client.default_model == "MiniMax-M2.5"
+        client = MiniMaxLLMClient(model="MiniMax-M2.7")
+        assert client.default_model == "MiniMax-M2.7"
 
     def test_deploy_params_provider(self):
         assert MiniMaxDeployModelParameters.provider == "proxy/minimax"
@@ -33,8 +33,14 @@ class TestMiniMaxDefaults:
 class TestMiniMaxModelList:
     """Test MiniMax model registration."""
 
-    def test_model_list_contains_m27(self):
+    def test_model_list_contains_m3(self):
         # Import triggers registration
+        from dbgpt.model.adapter.base import get_model_adapter
+
+        adapter = get_model_adapter("proxy/minimax", "MiniMax-M3")
+        assert adapter is not None
+
+    def test_model_list_contains_m27(self):
         from dbgpt.model.adapter.base import get_model_adapter
 
         adapter = get_model_adapter("proxy/minimax", "MiniMax-M2.7")
@@ -44,18 +50,6 @@ class TestMiniMaxModelList:
         from dbgpt.model.adapter.base import get_model_adapter
 
         adapter = get_model_adapter("proxy/minimax", "MiniMax-M2.7-highspeed")
-        assert adapter is not None
-
-    def test_model_list_contains_m25(self):
-        from dbgpt.model.adapter.base import get_model_adapter
-
-        adapter = get_model_adapter("proxy/minimax", "MiniMax-M2.5")
-        assert adapter is not None
-
-    def test_model_list_contains_m25_highspeed(self):
-        from dbgpt.model.adapter.base import get_model_adapter
-
-        adapter = get_model_adapter("proxy/minimax", "MiniMax-M2.5-highspeed")
         assert adapter is not None
 
 
@@ -68,7 +62,7 @@ class TestMiniMaxTemperatureClamping:
 
         client = MiniMaxLLMClient()
         request = ModelRequest(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[ModelMessage(role="user", content="hi")],
             temperature=0.5,
         )
@@ -81,7 +75,7 @@ class TestMiniMaxTemperatureClamping:
 
         client = MiniMaxLLMClient()
         request = ModelRequest(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[ModelMessage(role="user", content="hi")],
             temperature=2.0,
         )

--- a/web/utils/constants.ts
+++ b/web/utils/constants.ts
@@ -38,7 +38,7 @@ export const MODEL_ICON_INFO: Record<string, ModelIconInfo> = {
   minimax: {
     label: 'MiniMax',
     icon: '/models/minimax.png',
-    patterns: ['minimax', 'm2.7', 'm2.5', 'm2.1', 'm2'],
+    patterns: ['minimax', 'm3', 'm2.7'],
   },
   doubao: {
     label: 'Doubao',


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as default.

## Changes
- Add `MiniMax-M3` to the model selection list
- Set `MiniMax-M3` as the new default model
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` from the list
- Add `m3` to web UI icon matching patterns (drop legacy `m2.5/m2.1/m2`)
- Update related unit tests

## Why
MiniMax-M3 is the new flagship model with enhanced reasoning, coding and tool-use capabilities, available through the same OpenAI-compatible endpoint already used by the existing MiniMax provider.

## Testing
- Unit tests updated and passing (defaults, model registration, temperature clamping)
- Verified `_DEFAULT_MODEL` resolves to `MiniMax-M3`
- Verified backward compatibility with explicit `MiniMax-M2.7` selection