### PR TITLE
Harden DB-GPT service endpoints

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/knowledge/api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/knowledge/api.py
@@ -97,7 +97,10 @@ async def space_add(
 
 
 @router.post("/knowledge/space/list")
-async def space_list(request: KnowledgeSpaceRequest):
+async def space_list(
+    request: KnowledgeSpaceRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/space/list params: {request}")
     try:
         res = await blocking_func_to_async(
@@ -110,7 +113,10 @@ async def space_list(request: KnowledgeSpaceRequest):
 
 
 @router.post("/knowledge/space/delete")
-def space_delete(request: KnowledgeSpaceRequest):
+def space_delete(
+    request: KnowledgeSpaceRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/space/delete params: {request}")
     try:
         # delete Files in 'pilot/data/
@@ -144,7 +150,10 @@ async def retrieve_strategy_list(
 
 
 @router.post("/knowledge/{space_id}/arguments")
-async def arguments(space_id: str):
+async def arguments(
+    space_id: str,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/knowledge/{space_id}/arguments params: {space_id}")
     try:
         res = await blocking_func_to_async(
@@ -173,6 +182,7 @@ async def recall_test(
 @router.get("/knowledge/{space_id}/recall_retrievers")
 def recall_retrievers(
     space_id: str,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"/knowledge/{space_id}/recall_retrievers params:")
     try:
@@ -230,7 +240,11 @@ async def arguments_save(
 
 
 @router.post("/knowledge/{space_name}/document/add")
-async def document_add(space_name: str, request: KnowledgeDocumentRequest):
+async def document_add(
+    space_name: str,
+    request: KnowledgeDocumentRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/document/add params: {space_name}, {request}")
     try:
         res = await blocking_func_to_async(
@@ -250,6 +264,7 @@ def document_edit(
     space_name: str,
     request: KnowledgeDocumentRequest,
     service: Service = Depends(get_rag_service),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"/document/edit params: {space_name}, {request}")
     space = service.get({"name": space_name})
@@ -369,7 +384,11 @@ def document_list(
 
 
 @router.post("/knowledge/{space_name}/graphvis")
-def graph_vis(space_name: str, query_request: GraphVisRequest):
+def graph_vis(
+    space_name: str,
+    query_request: GraphVisRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"/document/list params: {space_name}, {query_request}")
     try:
         return Result.succ(
@@ -382,7 +401,11 @@ def graph_vis(space_name: str, query_request: GraphVisRequest):
 
 
 @router.post("/knowledge/{space_name}/document/delete")
-def document_delete(space_name: str, query_request: DocumentQueryRequest):
+def document_delete(
+    space_name: str,
+    query_request: DocumentQueryRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     print(f"/document/list params: {space_name}, {query_request}")
     try:
         return Result.succ(
@@ -399,6 +422,7 @@ async def document_upload(
     doc_type: str = Form(...),
     doc_file: UploadFile = File(...),
     fs: FileStorageClient = Depends(get_fs),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     print(f"/document/upload params: {space_name}")
     try:
@@ -467,6 +491,7 @@ async def document_sync(
     space_name: str,
     request: DocumentSyncRequest,
     service: Service = Depends(get_rag_service),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"Received params: {space_name}, {request}")
     try:
@@ -496,6 +521,7 @@ async def batch_document_sync(
     space_name: str,
     request: List[KnowledgeSyncRequest],
     service: Service = Depends(get_rag_service),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"Received params: {space_name}, {request}")
     try:
@@ -517,6 +543,7 @@ def chunk_list(
     space_name: str,
     query_request: ChunkQueryRequest,
     service: Service = Depends(get_rag_service),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     print(f"/chunk/list params: {space_name}, {query_request}")
     try:
@@ -545,6 +572,7 @@ def chunk_edit(
     space_name: str,
     edit_request: ChunkEditRequest,
     service: Service = Depends(get_rag_service),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     print(f"/chunk/edit params: {space_name}, {edit_request}")
     try:
@@ -556,7 +584,11 @@ def chunk_edit(
 
 
 @router.post("/knowledge/{vector_name}/query")
-def similarity_query(space_name: str, query_request: KnowledgeQueryRequest):
+def similarity_query(
+    space_name: str,
+    query_request: KnowledgeQueryRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     print(f"Received params: {space_name}, {query_request}")
     storage_manager = StorageManager.get_instance(CFG.SYSTEM_APP)
     vector_store_connector = storage_manager.create_vector_store(index_name=space_name)
@@ -572,7 +604,10 @@ def similarity_query(space_name: str, query_request: KnowledgeQueryRequest):
 
 
 @router.post("/knowledge/document/summary")
-async def document_summary(request: DocumentSummaryRequest):
+async def document_summary(
+    request: DocumentSummaryRequest,
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     print(f"/document/summary params: {request}")
     try:
         with root_tracer.start_span(

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -3992,6 +3992,7 @@ async def delete_share_link(
 @router.get("/v1/agent/files/download")
 async def download_agent_file(
     file_path: str = Query(..., description="Absolute path to the file to download"),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     """Download a file created by agent tools (shell_interpreter, code_interpreter).
 
@@ -4001,11 +4002,11 @@ async def download_agent_file(
     from fastapi import HTTPException
     from fastapi.responses import FileResponse
 
-    from dbgpt.configs.model_config import PILOT_PATH, ROOT_PATH
+    from dbgpt.configs.model_config import PILOT_PATH
 
-    # If path is not absolute, resolve relative to ROOT_PATH (sandbox working dir)
+    # If path is not absolute, resolve it under the controlled agent temp directory.
     if not os.path.isabs(file_path):
-        file_path = os.path.join(ROOT_PATH, file_path)
+        file_path = os.path.join(PILOT_PATH, "tmp", file_path)
 
     # Resolve to absolute path and prevent path traversal
     try:
@@ -4017,7 +4018,6 @@ async def download_agent_file(
     allowed_dirs = [
         os.path.realpath("/tmp"),
         os.path.realpath(os.path.join(PILOT_PATH, "tmp")),
-        os.path.realpath(ROOT_PATH),
     ]
 
     if not any(resolved.startswith(d + os.sep) or resolved == d for d in allowed_dirs):

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/editor/api_editor_v1.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/editor/api_editor_v1.py
@@ -36,6 +36,36 @@ CHAT_FACTORY = ChatFactory()
 logger = logging.getLogger(__name__)
 
 
+def _strip_sql_comments(sql: str) -> str:
+    result = []
+    index = 0
+    length = len(sql)
+
+    while index < length:
+        if sql.startswith("/*", index):
+            end = sql.find("*/", index + 2)
+            if end == -1:
+                result.append(" ")
+                break
+            result.append(" ")
+            index = end + 2
+            continue
+
+        if sql.startswith("--", index):
+            end = sql.find("\n", index + 2)
+            if end == -1:
+                result.append(" ")
+                break
+            result.append(" ")
+            index = end
+            continue
+
+        result.append(sql[index])
+        index += 1
+
+    return "".join(result)
+
+
 def get_conversation_serve() -> ConversationServe:
     return ConversationServe.get_instance(CFG.SYSTEM_APP)
 
@@ -102,8 +132,7 @@ def sanitize_sql(sql: str, db_type: str = None) -> Tuple[bool, str, dict]:
         Tuple of (is_safe, reason, params)
     """
     # Normalize SQL (remove comments and excess whitespace)
-    sql = re.sub(r"/\*.*?\*/", " ", sql)
-    sql = re.sub(r"--.*?$", " ", sql, flags=re.MULTILINE)
+    sql = _strip_sql_comments(sql)
     sql = re.sub(r"\s+", " ", sql).strip()
 
     # Block multiple statements
@@ -191,7 +220,7 @@ async def editor_sql_run(run_param: dict = Body()):
     # Sanitize and parameterize the SQL query
     is_safe, result, params = sanitize_sql(sql, db_type)
     if not is_safe:
-        logger.warning(f"Blocked dangerous SQL: {sql}")
+        logger.warning("Blocked dangerous SQL with length %s", len(sql))
         return Result.failed(msg=f"Operation not allowed: {result}")
 
     try:
@@ -272,7 +301,7 @@ async def chart_run(run_param: dict = Body()):
     # Sanitize and parameterize the SQL query
     is_safe, result, params = sanitize_sql(sql, db_type)
     if not is_safe:
-        logger.warning(f"Blocked dangerous SQL: {sql}")
+        logger.warning("Blocked dangerous SQL with length %s", len(sql))
         return Result.failed(msg=f"Operation not allowed: {result}")
 
     try:

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
@@ -1,5 +1,4 @@
 import json
-import re
 import time
 import uuid
 from typing import AsyncIterator, Optional
@@ -232,6 +231,24 @@ async def no_stream_wrapper(
         )
 
 
+def _extract_sse_json_payload(output: str) -> Optional[dict]:
+    data_index = output.find("data:")
+    if data_index < 0:
+        return None
+
+    payload = output[data_index + len("data:") :].lstrip()
+    if not payload or payload[0] != "{":
+        return None
+
+    try:
+        parsed, _ = json.JSONDecoder().raw_decode(payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
 async def chat_app_stream_wrapper(request: ChatCompletionRequestBody = None):
     """chat app stream
     Args:
@@ -245,10 +262,8 @@ async def chat_app_stream_wrapper(request: ChatCompletionRequestBody = None):
         user_code=request.user_name,
         sys_code=request.sys_code,
     ):
-        match = re.search(r"data:\s*({.*})", output)
-        if match:
-            json_str = match.group(1)
-            vis = json.loads(json_str)
+        vis = _extract_sse_json_payload(output)
+        if vis:
             vis_content = vis.get("vis", None)
             if vis_content != "[DONE]":
                 choice_data = ChatCompletionResponseStreamChoice(

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/tests/test_api_v2.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/tests/test_api_v2.py
@@ -1,0 +1,172 @@
+import importlib.util
+import sys
+import time
+import types
+from pathlib import Path
+
+
+def _install_stub(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load_api_v2_module():
+    stub_names = [
+        "fastapi",
+        "fastapi.security",
+        "dbgpt._private.pydantic",
+        "dbgpt.component",
+        "dbgpt.core.schema.api",
+        "dbgpt.model.cluster.apiserver.api",
+        "dbgpt.util.executor_utils",
+        "dbgpt.util.tracer",
+        "dbgpt_app.openapi.api_v1.api_v1",
+        "dbgpt_app.scene",
+        "dbgpt_client.schema",
+        "dbgpt_serve.agent.agents.controller",
+        "dbgpt_serve.flow.api.endpoints",
+    ]
+    original_modules = {name: sys.modules.get(name) for name in stub_names}
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class _APIRouter:
+        def post(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class _HTTPException(Exception):
+        def __init__(self, status_code=None, detail=None):
+            self.status_code = status_code
+            self.detail = detail
+
+    class _ChatMode:
+        CHAT_APP = _Dummy(value="chat_app")
+        CHAT_AWEL_FLOW = _Dummy(value="chat_flow")
+        CHAT_NORMAL = _Dummy(value="chat_normal")
+        CHAT_KNOWLEDGE = _Dummy(value="chat_knowledge")
+        CHAT_DATA = _Dummy(value="chat_data")
+        CHAT_DB_QA = _Dummy(value="chat_db")
+        CHAT_DASHBOARD = _Dummy(value="chat_dashboard")
+
+    class _Tracer:
+        def start_span(self, *args, **kwargs):
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    _install_stub(
+        "fastapi",
+        APIRouter=_APIRouter,
+        Body=lambda *args, **kwargs: None,
+        Depends=lambda *args, **kwargs: None,
+        HTTPException=_HTTPException,
+    )
+    _install_stub(
+        "fastapi.security",
+        HTTPAuthorizationCredentials=object,
+        HTTPBearer=lambda *args, **kwargs: None,
+    )
+    _install_stub(
+        "dbgpt._private.pydantic",
+        model_to_dict=lambda value: {},
+        model_to_json=lambda value, **kwargs: "{}",
+    )
+    _install_stub("dbgpt.component", SystemApp=object, logger=_Dummy(info=lambda *a, **k: None))
+    _install_stub(
+        "dbgpt.core.schema.api",
+        ChatCompletionResponse=_Dummy,
+        ChatCompletionResponseChoice=_Dummy,
+        ChatCompletionResponseStreamChoice=_Dummy,
+        ChatCompletionStreamResponse=_Dummy,
+        ChatMessage=_Dummy,
+        DeltaMessage=_Dummy,
+        ErrorResponse=_Dummy,
+        UsageInfo=_Dummy,
+    )
+    _install_stub("dbgpt.model.cluster.apiserver.api", APISettings=_Dummy)
+    _install_stub("dbgpt.util.executor_utils", blocking_func_to_async=None)
+    _install_stub("dbgpt.util.tracer", SpanType=_Dummy(CHAT="chat"), root_tracer=_Tracer())
+    _install_stub(
+        "dbgpt_app.openapi.api_v1.api_v1",
+        CHAT_FACTORY=_Dummy(),
+        __new_conversation=lambda *a, **k: _Dummy(conv_uid="conv"),
+        get_chat_flow=lambda: None,
+        get_executor=lambda: None,
+        stream_generator=lambda *a, **k: None,
+    )
+    _install_stub(
+        "dbgpt_app.scene",
+        BaseChat=object,
+        ChatParam=_Dummy,
+        ChatScene=_Dummy(
+            ChatNormal=_Dummy(value=lambda: "chat_normal"),
+            is_valid_mode=lambda mode: True,
+            of_mode=lambda mode: mode,
+        ),
+    )
+    _install_stub(
+        "dbgpt_client.schema",
+        ChatCompletionRequestBody=_Dummy,
+        ChatMode=_ChatMode,
+    )
+    _install_stub(
+        "dbgpt_serve.agent.agents.controller",
+        multi_agents=_Dummy(app_agent_chat=lambda **kwargs: None),
+    )
+    _install_stub(
+        "dbgpt_serve.flow.api.endpoints",
+        get_service=lambda: _Dummy(config=_Dummy(api_keys=""), system_app=None),
+    )
+
+    module_path = Path(__file__).resolve().parents[1] / "api_v2.py"
+    spec = importlib.util.spec_from_file_location("api_v2_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, original in original_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+    return module
+
+
+api_v2 = _load_api_v2_module()
+
+
+def test_extract_sse_json_payload_parses_data_object():
+    payload = api_v2._extract_sse_json_payload('data: {"vis":"hello"}\n\n')
+
+    assert payload == {"vis": "hello"}
+
+
+def test_extract_sse_json_payload_ignores_non_json_data():
+    payload = api_v2._extract_sse_json_payload("data: [DONE]\n\n")
+
+    assert payload is None
+
+
+def test_extract_sse_json_payload_handles_malformed_large_input_quickly():
+    output = ("data:{{" * 80000) + "X"
+
+    started = time.perf_counter()
+    payload = api_v2._extract_sse_json_payload(output)
+    elapsed = time.perf_counter() - started
+
+    assert payload is None
+    assert elapsed < 1.0

--- a/packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/resource/tool/autogpt/plugins_util.py
@@ -11,6 +11,7 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from auto_gpt_plugin_template import AutoGPTPluginTemplate
@@ -144,7 +145,8 @@ def update_from_git(
 
     os.makedirs(download_path, exist_ok=True)
     if github_repo:
-        if github_repo.index("github.com") <= 0:
+        parsed = urlparse(github_repo)
+        if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
             raise ValueError("Not a correct Github repository address！" + github_repo)
         github_repo = github_repo.replace(".git", "")
         url = github_repo + "/archive/refs/heads/" + branch_name + ".zip"

--- a/packages/dbgpt-core/src/dbgpt/util/file_client.py
+++ b/packages/dbgpt-core/src/dbgpt/util/file_client.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import aiofiles
 from fastapi import File, UploadFile
@@ -6,10 +7,31 @@ from fastapi import File, UploadFile
 from dbgpt.configs.model_config import KNOWLEDGE_UPLOAD_ROOT_PATH
 
 
+def _resolve_conv_file_path(conv_uid: str, file_key: str) -> Path:
+    if not conv_uid:
+        raise ValueError("conv_uid is required")
+    if not file_key:
+        raise ValueError("file_key is required")
+    if "\x00" in str(file_key):
+        raise ValueError("file_key must not contain null bytes")
+
+    upload_dir = (Path(KNOWLEDGE_UPLOAD_ROOT_PATH) / str(conv_uid)).resolve()
+    candidate = Path(file_key)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        resolved = (upload_dir / candidate).resolve()
+    try:
+        resolved.relative_to(upload_dir)
+    except ValueError as exc:
+        raise ValueError("file_key must stay inside conversation upload directory") from exc
+    return resolved
+
+
 class FileClient:
     def read_file(self, conv_uid, file_key, is_oss: bool = False):
-        # File path
-        with open(file_key, "rb") as file:
+        file_path = _resolve_conv_file_path(conv_uid, file_key)
+        with open(file_path, "rb") as file:
             content = file.read()
         return content
 
@@ -23,13 +45,13 @@ class FileClient:
         # Save the uploaded file
         upload_dir = os.path.join(KNOWLEDGE_UPLOAD_ROOT_PATH, file_key)
         os.makedirs(upload_dir, exist_ok=True)
-        upload_path = os.path.join(upload_dir, doc_file.filename)
+        upload_path = _resolve_conv_file_path(conv_uid, doc_file.filename)
         async with aiofiles.open(upload_path, "wb") as f:
             await f.write(await doc_file.read())
 
-        return False, upload_path
+        return False, str(upload_path)
 
     async def delete_file(self, conv_uid, file_key, is_oss: bool = False):
-        # File path
-        if os.path.exists(file_key):
-            os.remove(file_key)
+        file_path = _resolve_conv_file_path(conv_uid, file_key)
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_file_client.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_file_client.py
@@ -1,0 +1,63 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from dbgpt.util import file_client
+from dbgpt.util.file_client import FileClient
+
+
+def test_read_file_rejects_absolute_path_outside_upload_root(monkeypatch, tmp_path):
+    upload_root = tmp_path / "uploads"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    monkeypatch.setattr(file_client, "KNOWLEDGE_UPLOAD_ROOT_PATH", str(upload_root))
+
+    with pytest.raises(ValueError):
+        FileClient().read_file("conv_a", str(outside))
+
+
+def test_read_file_rejects_relative_traversal(monkeypatch, tmp_path):
+    upload_root = tmp_path / "uploads"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    monkeypatch.setattr(file_client, "KNOWLEDGE_UPLOAD_ROOT_PATH", str(upload_root))
+
+    with pytest.raises(ValueError):
+        FileClient().read_file("conv_a", "../outside.txt")
+
+
+def test_read_file_allows_conversation_file(monkeypatch, tmp_path):
+    upload_root = tmp_path / "uploads"
+    conv_dir = upload_root / "conv_a"
+    conv_dir.mkdir(parents=True)
+    target = conv_dir / "allowed.txt"
+    target.write_text("allowed", encoding="utf-8")
+    monkeypatch.setattr(file_client, "KNOWLEDGE_UPLOAD_ROOT_PATH", str(upload_root))
+
+    assert FileClient().read_file("conv_a", "allowed.txt") == b"allowed"
+
+
+def test_delete_file_rejects_absolute_path_outside_upload_root(monkeypatch, tmp_path):
+    upload_root = tmp_path / "uploads"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    monkeypatch.setattr(file_client, "KNOWLEDGE_UPLOAD_ROOT_PATH", str(upload_root))
+
+    with pytest.raises(ValueError):
+        asyncio.run(FileClient().delete_file("conv_a", str(outside)))
+
+    assert outside.exists()
+
+
+def test_delete_file_allows_conversation_file(monkeypatch, tmp_path):
+    upload_root = tmp_path / "uploads"
+    conv_dir = upload_root / "conv_a"
+    conv_dir.mkdir(parents=True)
+    target = conv_dir / "allowed.txt"
+    target.write_text("allowed", encoding="utf-8")
+    monkeypatch.setattr(file_client, "KNOWLEDGE_UPLOAD_ROOT_PATH", str(upload_root))
+
+    asyncio.run(FileClient().delete_file("conv_a", str(target)))
+
+    assert not target.exists()

--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py
@@ -57,7 +57,7 @@ class PDFKnowledge(Knowledge):
             if content_type == "text":
                 # use regex to match the first level title
                 first_level_match = re.match(
-                    r"§(\d+)+([\u4e00-\u9fa5]+)", inside_content.strip()
+                    r"§(\d+)([\u4e00-\u9fa5]+)", inside_content.strip()
                 )
                 second_level_match = re.match(
                     r"(\d+\.\d+)([\u4e00-\u9fa5]+)", inside_content.strip()

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/hub/controller.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/hub/controller.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC
 from typing import List
 
-from fastapi import APIRouter, Body, File, UploadFile
+from fastapi import APIRouter, Body, Depends, File, UploadFile
 
 from dbgpt.agent.resource.tool.autogpt.plugins_util import scan_plugins
 from dbgpt.agent.resource.tool.pack import AutoGPTPluginToolPack
@@ -16,6 +16,7 @@ from dbgpt_serve.agent.model import (
     PluginHubFilter,
     PluginHubParam,
 )
+from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 
 from .db.my_plugin_db import MyPluginEntity
 from .db.plugin_hub_db import PluginHubEntity
@@ -45,7 +46,10 @@ module_plugin = ModulePlugin()
 
 
 @router.post("/v1/agent/hub/update", response_model=Result[str])
-async def plugin_hub_update(update_param: PluginHubParam = Body()):
+async def plugin_hub_update(
+    update_param: PluginHubParam = Body(),
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
     logger.info(f"plugin_hub_update:{update_param.__dict__}")
     try:
         branch = (

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
@@ -180,18 +180,37 @@ class ConnectConfigDao(BaseDao):
                 session = self.get_raw_session()
                 if not db_path:
                     update_statement = text(
-                        f"UPDATE connect_config set db_type='{db_type}', "
-                        f"db_host='{db_host}', db_port={db_port}, db_user='{db_user}', "
-                        f"db_pwd='{db_pwd}', comment='{comment}' where "
-                        f"db_name='{db_name}'"
+                        """
+                        UPDATE connect_config
+                        SET db_type=:db_type, db_host=:db_host, db_port=:db_port,
+                            db_user=:db_user, db_pwd=:db_pwd, comment=:comment
+                        WHERE db_name=:db_name
+                        """
                     )
+                    params = {
+                        "db_name": db_name,
+                        "db_type": db_type,
+                        "db_host": db_host,
+                        "db_port": db_port,
+                        "db_user": db_user,
+                        "db_pwd": db_pwd,
+                        "comment": comment,
+                    }
                 else:
                     update_statement = text(
-                        f"UPDATE connect_config set db_type='{db_type}', "
-                        f"db_path='{db_path}', comment='{comment}' where "
-                        f"db_name='{db_name}'"
+                        """
+                        UPDATE connect_config
+                        SET db_type=:db_type, db_path=:db_path, comment=:comment
+                        WHERE db_name=:db_name
+                        """
                     )
-                session.execute(update_statement)
+                    params = {
+                        "db_name": db_name,
+                        "db_type": db_type,
+                        "db_path": db_path,
+                        "comment": comment,
+                    }
+                session.execute(update_statement, params)
                 session.commit()
                 session.close()
             except Exception as e:
@@ -233,24 +252,40 @@ class ConnectConfigDao(BaseDao):
     def get_db_list(self, db_name: Optional[str] = None, user_id: Optional[str] = None):
         """Get db list."""
         session = self.get_raw_session()
+        conditions = []
+        params = {}
         if db_name and user_id:
-            sql = f"SELECT * FROM connect_config where (user_id='{user_id}' or user_id='' or user_id IS NULL) and db_name='{db_name}'"  # noqa
+            conditions.append(
+                "(user_id=:user_id OR user_id='' OR user_id IS NULL)"
+            )
+            conditions.append("db_name=:db_name")
+            params["user_id"] = user_id
+            params["db_name"] = db_name
         elif user_id:
-            sql = f"SELECT * FROM connect_config where user_id='{user_id}' or user_id='' or user_id IS NULL"  # noqa
+            conditions.append(
+                "(user_id=:user_id OR user_id='' OR user_id IS NULL)"
+            )
+            params["user_id"] = user_id
         elif db_name:
-            sql = f"SELECT * FROM connect_config where  db_name='{db_name}'"  # noqa
-        else:
-            sql = f"SELECT * FROM connect_config"  # noqa
+            conditions.append("db_name=:db_name")
+            params["db_name"] = db_name
 
-        result = session.execute(text(sql))
-        fields = [field[0] for field in result.cursor.description]  # type: ignore
-        data = []
-        for row in result.cursor.fetchall():  # type: ignore
-            row_dict = {}
-            for i, field in enumerate(fields):
-                row_dict[field] = row[i]
-            data.append(row_dict)
-        return data
+        sql = "SELECT * FROM connect_config"
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
+
+        try:
+            result = session.execute(text(sql), params)
+            fields = [field[0] for field in result.cursor.description]  # type: ignore
+            data = []
+            for row in result.cursor.fetchall():  # type: ignore
+                row_dict = {}
+                for i, field in enumerate(fields):
+                    row_dict[field] = row[i]
+                data.append(row_dict)
+            return data
+        finally:
+            session.close()
 
     def delete_db(self, db_name):
         """Delete db connect info."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connect_config_db.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from dbgpt.storage.metadata import db
+
+
+def _load_connect_config_db_module():
+    schemas = types.ModuleType("dbgpt_serve.datasource.api.schemas")
+
+    class DatasourceServeRequest:
+        pass
+
+    class DatasourceServeResponse:
+        pass
+
+    schemas.DatasourceServeRequest = DatasourceServeRequest
+    schemas.DatasourceServeResponse = DatasourceServeResponse
+    sys.modules["dbgpt_serve.datasource.api.schemas"] = schemas
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "manages"
+        / "connect_config_db.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "connect_config_db_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+connect_config_db = _load_connect_config_db_module()
+ConnectConfigDao = connect_config_db.ConnectConfigDao
+
+
+def _new_dao():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    return ConnectConfigDao()
+
+
+def test_get_db_list_treats_user_id_as_data():
+    dao = _new_dao()
+    dao.add_file_db("private_db", "sqlite", "/tmp/private.sqlite", user_id="victim")
+    dao.add_file_db("public_db", "sqlite", "/tmp/public.sqlite", user_id="")
+
+    rows = dao.get_db_list(user_id="alice' OR 1=1 --")
+
+    assert [row["db_name"] for row in rows] == ["public_db"]
+
+
+def test_get_db_list_treats_db_name_as_data():
+    dao = _new_dao()
+    dao.add_file_db("private_db", "sqlite", "/tmp/private.sqlite", user_id="victim")
+    dao.add_file_db("public_db", "sqlite", "/tmp/public.sqlite", user_id="")
+
+    rows = dao.get_db_list(db_name="x' OR 1=1 --", user_id="alice")
+
+    assert rows == []
+
+
+def test_update_db_info_treats_db_name_as_data():
+    dao = _new_dao()
+    malicious_name = "owned' OR 1=1 --"
+    dao.add_file_db("victim_db", "sqlite", "/tmp/victim.sqlite", comment="secret")
+    dao.add_file_db(
+        malicious_name, "sqlite", "/tmp/owned.sqlite", comment="owned"
+    )
+
+    assert dao.update_db_info(
+        malicious_name, "sqlite", "/tmp/new.sqlite", comment="pwned"
+    )
+
+    comments = {row["db_name"]: row["comment"] for row in dao.get_db_list()}
+    assert comments["victim_db"] == "secret"
+    assert comments[malicious_name] == "pwned"

--- a/packages/dbgpt-serve/src/dbgpt_serve/prompt/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/prompt/api/endpoints.py
@@ -2,7 +2,7 @@ import logging
 from functools import cache
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.responses import StreamingResponse
 
@@ -54,7 +54,6 @@ def _parse_api_keys(api_keys: str) -> List[str]:
 
 async def check_api_key(
     auth: Optional[HTTPAuthorizationCredentials] = Depends(get_bearer_token),
-    request: Request = None,
     service: Service = Depends(get_service),
 ) -> Optional[str]:
     """Check the api key
@@ -73,7 +72,23 @@ async def check_api_key(
         assert res.status_code == 200
 
     """
-    if request.url.path.startswith("/api/v1"):
+    if service.config.api_keys:
+        api_keys = _parse_api_keys(service.config.api_keys)
+        if auth is None or (token := auth.credentials) not in api_keys:
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "error": {
+                        "message": "",
+                        "type": "invalid_request_error",
+                        "param": None,
+                        "code": "invalid_api_key",
+                    }
+                },
+            )
+        return token
+    else:
+        # api_keys not set; allow all
         return None
 
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/prompt/tests/test_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/prompt/tests/test_endpoints.py
@@ -25,6 +25,10 @@ def client_init_caller(app: FastAPI, system_app: SystemApp, config: BaseServeCon
     init_endpoints(system_app, config)
 
 
+def _auth_client():
+    return {"app_caller": client_init_caller, "client_api_key": "mock_api_key_123"}
+
+
 async def _create_and_validate(
     client: AsyncClient, sys_code: str, content: str, expect_id: int = 1, **kwargs
 ):
@@ -44,7 +48,7 @@ async def _create_and_validate(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "client", [{"app_caller": client_init_caller}], indirect=["client"]
+    "client", [_auth_client()], indirect=["client"]
 )
 async def test_api_create(client: AsyncClient):
     await _create_and_validate(client, "test", "test")
@@ -52,7 +56,7 @@ async def test_api_create(client: AsyncClient):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "client", [{"app_caller": client_init_caller}], indirect=["client"]
+    "client", [_auth_client()], indirect=["client"]
 )
 async def test_api_update(client: AsyncClient):
     await _create_and_validate(client, "test", "test")
@@ -71,7 +75,7 @@ async def test_api_update(client: AsyncClient):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "client", [{"app_caller": client_init_caller}], indirect=["client"]
+    "client", [_auth_client()], indirect=["client"]
 )
 async def test_api_query(client: AsyncClient):
     for i in range(10):
@@ -93,7 +97,7 @@ async def test_api_query(client: AsyncClient):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "client", [{"app_caller": client_init_caller}], indirect=["client"]
+    "client", [_auth_client()], indirect=["client"]
 )
 async def test_api_query_by_page(client: AsyncClient):
     for i in range(10):
@@ -114,3 +118,24 @@ async def test_api_query_by_page(client: AsyncClient):
     assert page_result.page == 1
     assert page_result.page_size == 5
     assert len(page_result.items) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client",
+    [{"app_caller": client_init_caller, "client_api_key": "wrong_key"}],
+    indirect=["client"],
+)
+async def test_api_auth_rejects_invalid_key(client: AsyncClient):
+    response = await client.get("/test_auth")
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {
+            "error": {
+                "message": "",
+                "type": "invalid_request_error",
+                "param": None,
+                "code": "invalid_api_key",
+            }
+        }
+    }

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import Header
+from fastapi import Header, HTTPException
 
 from dbgpt._private.pydantic import BaseModel
 
@@ -22,9 +22,65 @@ class UserRequest(BaseModel):
     nick_name_like: Optional[str] = None
 
 
-def get_user_from_headers(user_id: Optional[str] = Header(None)):
+def _parse_api_keys(api_keys) -> list[str]:
+    if not api_keys:
+        return []
+    if isinstance(api_keys, str):
+        return [key.strip() for key in api_keys.split(",") if key.strip()]
+    if isinstance(api_keys, (list, tuple, set)):
+        return [str(key).strip() for key in api_keys if str(key).strip()]
+    return []
+
+
+def _get_configured_api_keys() -> list[str]:
     try:
-        # Mock User Info
+        from dbgpt._private.config import Config
+
+        system_app = Config().SYSTEM_APP
+        if not system_app or not getattr(system_app, "config", None):
+            return []
+        return _parse_api_keys(system_app.config.get("dbgpt.app.global.api_keys"))
+    except Exception:
+        logger.debug("Failed to load configured API keys", exc_info=True)
+        return []
+
+
+def _extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+def _raise_invalid_api_key() -> None:
+    raise HTTPException(
+        status_code=401,
+        detail={
+            "error": {
+                "message": "",
+                "type": "invalid_request_error",
+                "param": None,
+                "code": "invalid_api_key",
+            }
+        },
+    )
+
+
+def get_user_from_headers(
+    user_id: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+):
+    try:
+        api_keys = _get_configured_api_keys()
+        if api_keys:
+            token = _extract_bearer_token(authorization)
+            if token not in api_keys:
+                _raise_invalid_api_key()
+
+        # Compatibility user info. Real deployments should map authenticated
+        # tokens to stable user identities instead of trusting plain headers.
         if user_id:
             return UserRequest(
                 user_id=user_id, role="admin", nick_name=user_id, real_name=user_id
@@ -33,6 +89,8 @@ def get_user_from_headers(user_id: Optional[str] = Header(None)):
             return UserRequest(
                 user_id="001", role="admin", nick_name="dbgpt", real_name="dbgpt"
             )
+    except HTTPException:
+        raise
     except Exception as e:
         logging.exception("Authentication failed!")
         raise Exception(f"Authentication failed. {str(e)}")

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/tests/test_auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/tests/test_auth.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi import HTTPException
+
+from dbgpt_serve.utils import auth
+
+
+def test_get_user_from_headers_allows_compat_when_no_api_keys(monkeypatch):
+    monkeypatch.setattr(auth, "_get_configured_api_keys", lambda: [])
+
+    user = auth.get_user_from_headers(user_id=None, authorization=None)
+
+    assert user.user_id == "001"
+    assert user.role == "admin"
+
+
+def test_get_user_from_headers_rejects_missing_bearer_when_api_keys_configured(
+    monkeypatch,
+):
+    monkeypatch.setattr(auth, "_get_configured_api_keys", lambda: ["secret"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.get_user_from_headers(user_id=None, authorization=None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["error"]["code"] == "invalid_api_key"
+
+
+def test_get_user_from_headers_rejects_wrong_bearer_when_api_keys_configured(
+    monkeypatch,
+):
+    monkeypatch.setattr(auth, "_get_configured_api_keys", lambda: ["secret"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.get_user_from_headers(user_id=None, authorization="Bearer wrong")
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["error"]["code"] == "invalid_api_key"
+
+
+def test_get_user_from_headers_accepts_valid_bearer_when_api_keys_configured(
+    monkeypatch,
+):
+    monkeypatch.setattr(auth, "_get_configured_api_keys", lambda: ["secret"])
+
+    user = auth.get_user_from_headers(user_id="alice", authorization="Bearer secret")
+
+    assert user.user_id == "alice"
+    assert user.role == "admin"


### PR DESCRIPTION
## Summary

This PR applies defensive hardening across several DB-GPT service endpoints and helpers:

- Tightens agent file download path handling and route protection.
- Restricts plugin hub updates to expected repository URLs.
- Replaces regex-heavy SQL comment stripping with a linear scanner.
- Adds route-level user dependencies to sensitive knowledge APIs.
- Simplifies PDF title matching to avoid pathological regex behavior.
- Enforces configured API keys consistently for Prompt APIs and v1 user dependencies.
- Parameterizes datasource configuration SQL and adds regression coverage.
- Scopes legacy resource file paths to conversation upload directories.
- Replaces v2 chat app stream regex parsing with linear JSON extraction.

## Validation

- Added focused regression tests for authentication helper behavior.
- Added focused regression tests for datasource configuration DAO filtering and updates.
- Added focused regression tests for resource file path scoping.
- Added focused regression tests for v2 chat app stream parsing.
- Ran syntax checks for touched Python modules.
- Ran focused pytest coverage for the new and updated tests.

## Notes

This public PR intentionally keeps the description high level. It does not include vulnerability reproduction details.