### PR TITLE
fix: gracefully handle module scanning failures in _scan_awel_flow (closes #2280)

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/cli/_module.py
+++ b/packages/dbgpt-core/src/dbgpt/util/cli/_module.py
@@ -30,14 +30,19 @@ def _scan_awel_flow(modules: Optional[List[str]] = None):
     if not modules:
         modules = ["dbgpt", "dbgpt_client", "dbgpt_ext", "dbgpt_serve", "dbgpt_app"]
     for module in modules:
-        config = ScannerConfig(
-            module_path=module,
-            base_class=object,
-            recursive=True,
-            class_filter=lambda cls: _is_flow_operator(cls) or _is_flow_resource(cls),
-            skip_files=["test_*.py", "*_test.py"],
-        )
-        scanner.scan_and_register(config)
+        try:
+            config = ScannerConfig(
+                module_path=module,
+                base_class=object,
+                recursive=True,
+                class_filter=lambda cls: _is_flow_operator(cls) or _is_flow_resource(cls),
+                skip_files=["test_*.py", "*_test.py"],
+            )
+            scanner.scan_and_register(config)
+        except Exception as e:
+            import logging
+            logging.warning(f"Skipping module '{module}' due to error: {e}")
+            continue
     flow_cls = scanner.get_registered_items()
     compat_metadata = []
     for cls_name, cls in flow_cls.items():


### PR DESCRIPTION
## What
When scanning modules for AWEL flow operators/resources, a failure in one module (e.g., missing database tables, import errors) crashes the entire process. This was reported in #2280 where a missing `gpts_app_collection` table caused a crash.

## Fix
Wrap the scanning loop in a try-except to catch and log exceptions, then continue scanning remaining modules. This prevents a single module failure from blocking the whole startup.

Closes #2280