### PR TITLE
fix: fix the unsandboxed jinja2 rce problem.

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/core/base_agent.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/core/base_agent.py
@@ -10,7 +10,7 @@ from concurrent.futures import Executor, ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast, final
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from dbgpt._private.pydantic import ConfigDict, Field
 from dbgpt.core import LLMClient, ModelMessageRoleType, PromptTemplate
@@ -1255,7 +1255,13 @@ class ConversableAgent(Role, Agent):
             if self.bind_prompt.template_format == "f-string":
                 system_prompt = self.bind_prompt.format(**prompt_param)
             elif self.bind_prompt.template_format == "jinja2":
-                system_prompt = Template(self.bind_prompt.template).render(prompt_param)
+                # Render in a sandbox: bind_prompt.template may contain
+                # user-controlled content (e.g. a selected skill's instructions),
+                # so a plain jinja2.Template would allow SSTI -> RCE.
+                _env = SandboxedEnvironment()
+                system_prompt = _env.from_string(self.bind_prompt.template).render(
+                    prompt_param
+                )
             else:
                 logger.warning("Bind prompt template not exsit or  format not support!")
         if not system_prompt:

--- a/packages/dbgpt-core/src/dbgpt/agent/core/role.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/core/role.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
 
-from jinja2 import Environment, Template, meta
+from jinja2 import Environment, meta
 from jinja2.sandbox import SandboxedEnvironment
 
 from dbgpt._private.pydantic import BaseModel, ConfigDict, Field
@@ -118,7 +118,9 @@ class Role(ABC, BaseModel):
         """Get agent prompt template."""
         self.language = language
         system_prompt = self.current_profile.get_system_prompt_template()
-        template = Template(system_prompt)
+        # Render via the sandboxed environment to prevent SSTI from any
+        # user-controlled content that reaches the system prompt template.
+        template = self.template_env.from_string(system_prompt)
 
         env = Environment()
         parsed_content = env.parse(system_prompt)

--- a/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/prompt.py
@@ -23,16 +23,18 @@ T = TypeVar("T", bound="BasePromptTemplate")
 
 
 def _jinja2_formatter(template: str, **kwargs: Any) -> str:
-    """Format a template using jinja2."""
+    """Format a template using jinja2 in a secure sandbox."""
     try:
-        from jinja2 import Template
+        from jinja2.sandbox import SandboxedEnvironment
     except ImportError:
         raise ImportError(
             "jinja2 not installed, which is needed to use the jinja2_formatter. "
             "Please install it with `pip install jinja2`."
         )
 
-    return Template(template).render(**kwargs)
+    env = SandboxedEnvironment()
+    
+    return env.from_string(template).render(**kwargs)
 
 
 _DEFAULT_FORMATTER_MAPPING: Dict[str, Callable] = {


### PR DESCRIPTION
# Description

### Summary of Changes

This PR fixes a critical Server-Side Template Injection (SSTI) vulnerability in the Jinja2 template formatter (`_jinja2_formatter`).

Previously, `_jinja2_formatter` utilized the standard unrestricted `jinja2.Template`, which allowed template context escape via Python magic methods (e.g., `cycler.__init__.__globals__`) and resulted in arbitrary Remote Code Execution (RCE).

This change replaces the standard environment with **`jinja2.sandbox.SandboxedEnvironment`** to intercept and block access to sensitive/hidden python attributes, ensuring secure template rendering without breaking backward compatibility for legitimate use cases.

### Related Issue

Fixes #3110 

### Dependencies

No new dependencies are required. `jinja2` is already a project dependency.

# How Has This Been Tested?

### Test Configuration

* **OS:** MacOS (M5) running Docker Compose Container
* **Python Version:** >= 3.11
* **DB-GPT Branch:** main

### Replication & Verification Steps

1. Uploaded a malicious `SKILL.md` containing the SSTI payload:
```twig
{{ cycler.__init__.__globals__.os.popen('echo "DBGPT_SSTI_OK" > /tmp/dbgpt_ssti_ok').read() }}

```


2. Triggered the React Agent via the `/api/v1/chat/react-agent` endpoint.
3. **Before this PR:** The payload executed successfully, creating the file `/tmp/dbgpt_ssti_ok` inside the container (Remote Code Execution).
4. **After this PR:** The application throws a `jinja2.exceptions.SecurityError` when attempting to access forbidden attributes, successfully blocking the attack. Normal Jinja2 templates still render perfectly.

# Snapshots:


# Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have already rebased the commits and make the commit message conform to the project standard.
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] Any dependent changes have been merged and published in downstream modules
