### PR TITLE
fix(web): pass model to newDialogue for knowledge chat

### DIFF
--- a/web/components/knowledge/space-card.tsx
+++ b/web/components/knowledge/space-card.tsx
@@ -1,9 +1,11 @@
 import { apiInterceptors, delSpace, newDialogue } from '@/client/api';
+import { ChatContext } from '@/app/chat-context';
 import { ISpace } from '@/types/knowledge';
 import { ClockCircleOutlined, DeleteFilled, MessageFilled, UserOutlined, WarningOutlined } from '@ant-design/icons';
 import { Badge, ConfigProvider, Modal, Popover } from 'antd';
 import moment from 'moment';
 import { useRouter } from 'next/router';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import GptCard from '../common/gpt-card';
 import DocPanel from './doc-panel';
@@ -20,6 +22,7 @@ export default function SpaceCard(props: IProps) {
   const router = useRouter();
   const { t } = useTranslation();
   const { space, getSpaces } = props;
+  const { model } = useContext(ChatContext);
 
   const showDeleteConfirm = () => {
     confirm({
@@ -44,6 +47,7 @@ export default function SpaceCard(props: IProps) {
     const [_, data] = await apiInterceptors(
       newDialogue({
         chat_mode: 'chat_knowledge',
+        model,
       }),
     );
     if (data?.conv_uid) {

--- a/web/pages/construct/knowledge/index.tsx
+++ b/web/pages/construct/knowledge/index.tsx
@@ -18,7 +18,7 @@ import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const Knowledge = () => {
-  const { setCurrentDialogInfo } = useContext(ChatContext);
+  const { setCurrentDialogInfo, model } = useContext(ChatContext);
   const [spaceList, setSpaceList] = useState<Array<ISpace> | null>([]);
   const [isAddShow, setIsAddShow] = useState<boolean>(false);
   const [isPanelShow, setIsPanelShow] = useState<boolean>(false);
@@ -63,6 +63,7 @@ const Knowledge = () => {
     const [_, data] = await apiInterceptors(
       newDialogue({
         chat_mode: 'chat_knowledge',
+        model,
       }),
     );
     // 知识库对话都默认私有知识库应用下


### PR DESCRIPTION
…ient-side exception

# Description

知识库"开始对话"崩溃，发起对话时没传模型名，导致请求变成 model_name=undefined，页面拿这个非法模型名渲染时抛出 client-side exception。
ChatContext 里其实有可用的 model（来自 getUsableModels()，会自动取模型列表第一个），但 handleChat 没有使用它。


