### PR TITLE
fix(core): correct invalid string-literal escape sequences

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/scene/operators/app_operator.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/operators/app_operator.py
@@ -151,7 +151,7 @@ def build_cached_chat_operator(
     system_app: SystemApp,
     cache_manager: Optional[CacheManager] = None,
 ):
-    """Builds and returns a model processing workflow (DAG) operator.
+    r"""Builds and returns a model processing workflow (DAG) operator.
 
     This function constructs a Directed Acyclic Graph (DAG) for processing data using
     a model.

--- a/packages/dbgpt-core/src/dbgpt/agent/expand/actions/websearch_action.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/expand/actions/websearch_action.py
@@ -64,7 +64,7 @@ def clean_text(text):
     cleaned = re.sub(r"\n+", "\n\n", cleaned).strip()
     cleaned = re.sub(r" +", " ", cleaned)
     cleaned = re.sub(
-        r'[^\u4e00-\u9fa5a-zA-Z0-9\s,.，。；;！!？?：:""' "（）()【】[\]{}、/\\-]",
+        r'[^\u4e00-\u9fa5a-zA-Z0-9\s,.，。；;！!？?：:""' "（）()【】[\\]{}、/\\-]",
         "",
         cleaned,
     )

--- a/packages/dbgpt-core/src/dbgpt/agent/util/api_call.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/util/api_call.py
@@ -120,7 +120,7 @@ class ApiCall:
         raw_api_context = (
             raw_api_context.replace("\\n", " ")
             .replace("\n", " ")
-            .replace("\_", "_")
+            .replace("\\_", "_")
             .replace("\\", " ")
         )
         return raw_api_context

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_no_invalid_escape.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_no_invalid_escape.py
@@ -1,0 +1,48 @@
+r"""Guard against invalid string-literal escape sequences.
+
+Python emits a ``SyntaxWarning: invalid escape sequence`` for backslash
+sequences that are not recognized escapes (e.g. ``"\\d"`` written as
+``"\d"``). These have been deprecated for years and become a hard
+``SyntaxError`` in newer CPython releases, so a single offending literal can
+make an entire module fail to import.
+
+This test compiles the source files that previously contained such literals
+and asserts none of them emit an ``invalid escape sequence`` warning.
+"""
+
+import py_compile
+import warnings
+from pathlib import Path
+
+import pytest
+
+# Resolve the monorepo's ``packages`` directory from this test file's location:
+# .../packages/dbgpt-core/src/dbgpt/util/tests/test_no_invalid_escape.py
+_PACKAGES_DIR = Path(__file__).resolve().parents[5]
+
+# Files that historically carried invalid escape sequences. Relative to the
+# monorepo ``packages`` directory so the test works from any checkout.
+_GUARDED_FILES = [
+    "dbgpt-core/src/dbgpt/agent/util/api_call.py",
+    "dbgpt-core/src/dbgpt/agent/expand/actions/websearch_action.py",
+    "dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_vertica.py",
+    "dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py",
+    "dbgpt-app/src/dbgpt_app/scene/operators/app_operator.py",
+]
+
+
+def _invalid_escape_warnings(path: Path):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", SyntaxWarning)
+        py_compile.compile(str(path), doraise=True)
+        return [w for w in caught if "invalid escape sequence" in str(w.message)]
+
+
+@pytest.mark.parametrize("rel_path", _GUARDED_FILES)
+def test_no_invalid_escape_sequence(rel_path):
+    path = _PACKAGES_DIR / rel_path
+    if not path.exists():
+        pytest.skip(f"{rel_path} not present in this checkout")
+    warns = _invalid_escape_warnings(path)
+    messages = "\n".join(f"  line {w.lineno}: {w.message}" for w in warns)
+    assert not warns, f"invalid escape sequence(s) in {rel_path}:\n{messages}"

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_vertica.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_vertica.py
@@ -98,11 +98,11 @@ table name should keep its schema name in "
                     """
                     SELECT table_schema||'.'||table_name
                     FROM v_catalog.tables
-                    WHERE table_schema NOT LIKE 'v\_%'
+                    WHERE table_schema NOT LIKE 'v\\_%'
                     UNION
                     SELECT table_schema||'.'||table_name
                     FROM v_catalog.views
-                    WHERE table_schema NOT LIKE 'v\_%';
+                    WHERE table_schema NOT LIKE 'v\\_%';
                     """
                 )
             )
@@ -292,7 +292,7 @@ table name should keep its schema name in "
             SELECT table_schema||'.'||table_name
               , listagg(column_name using parameters max_length=65000)
             FROM v_catalog.columns
-            WHERE table_schema NOT LIKE 'v\_%'
+            WHERE table_schema NOT LIKE 'v\\_%'
             GROUP BY 1;
             """
         with self.session_scope() as session:

--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py
@@ -304,7 +304,7 @@ class PDFProcessor:
         for line in range(len(lines)):
             each_line = lines[line]
             check_re = (
-                "(?:。|；|单位：人民币元|金额单位：人民币元|单位：万元|币种：人民币|\d|"
+                "(?:。|；|单位：人民币元|金额单位：人民币元|单位：万元|币种：人民币|\\d|"
                 "报告(?:全文)?(?:（修订版）|（修订稿）|（更正后）)?)$"
             )
             if top == "" and buttom == "":
@@ -473,7 +473,7 @@ class PDFProcessor:
                 self.allrow += 1
 
         first_re = "[^计](?:报告(?:全文)?(?:（修订版）|（修订稿）|（更正后）)?)$"
-        end_re = "^(?:\d|\\|\/|第|共|页|-|_| ){1,}"
+        end_re = "^(?:\\d|\\|\\/|第|共|页|-|_| ){1,}"
         if self.last_num == 0:
             try:
                 first_text = str(self.all_text[1]["inside"])


### PR DESCRIPTION
## Summary

- Fixes several string literals that used unrecognized backslash escape sequences (`\_`, `\d`, `\]`, `\ `).
- These produce `SyntaxWarning: invalid escape sequence` on Python 3.12+ and become a hard `SyntaxError` in newer CPython, where a single offending literal can prevent the whole module from importing.

## Root Cause

**Symptom** — Compiling these modules emits `SyntaxWarning: "\_" is an invalid escape sequence ...` (and `\d`, `\]`, `\ `). On a CPython version that has promoted these to errors, importing the affected module fails outright.

**Root cause** — In a normal (non-raw) Python string, a backslash followed by a character that is not a recognized escape (`\n`, `\t`, ...) is a deprecated "invalid escape sequence." The affected literals were *intended* to contain a literal backslash:
- `api_call.py:123` — `.replace("\_", "_")` meant the two-character text `\_`.
- `conn_vertica.py` (3 sites) — SQL `LIKE 'v\_%'` (escaped underscore in a LIKE pattern).
- `pdf.py` (2 sites) — regex fragments `\d`, `\/` embedded in plain (non-`r`) strings.
- `websearch_action.py:67` — a `\]` inside a character class in a plain string concatenated onto an `r"..."` prefix.
- `app_operator.py:172` — ASCII-art (`\` in a diagram) inside a plain docstring.

**Evidence** — Compiling each file on Python 3.14 with warnings enabled:

```
packages/dbgpt-core/src/dbgpt/agent/util/api_call.py:123: "\_" is an invalid escape sequence
packages/dbgpt-core/src/dbgpt/agent/expand/actions/websearch_action.py:67: "\]" is an invalid escape sequence
packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_vertica.py:101: "\_" is an invalid escape sequence
packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_vertica.py:295: "\_" is an invalid escape sequence
packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py:307: "\d" is an invalid escape sequence
packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/pdf.py:476: "\d" is an invalid escape sequence
packages/dbgpt-app/src/dbgpt_app/scene/operators/app_operator.py:172: "\ " is an invalid escape sequence
```

**Fix + why this level** — Escape the backslash explicitly (`\\_`, `\\d`, `\\]`, `\\/`) or mark the ASCII-art docstring raw (`r"""`). This is the correct layer: the literals already produced the right runtime value via the deprecated implicit behavior, so escaping at the literal makes the intent explicit and forward-compatible **without changing any resulting string value**. Suppressing the warning globally would have been the wrong level — it hides future breakage instead of removing the cause.

**Scope / risk** — Touches only string-literal spelling in 5 files; the produced string values are byte-for-byte identical (verified below). No logic, control flow, or public API changes. The SQL `LIKE 'v\\_%'` and the regex fragments evaluate to exactly the same patterns as before.

## Verification

Each edited literal was confirmed to evaluate to the identical string before and after:

```
api_call  \_  -> identical: True  ('\\_')
vertica   v\_%  -> identical: True  ('v\\_%')
pdf       \d  -> identical: True
pdf end_re ^(?:\d|\\|\/|...){1,}  -> identical: True
websearch [...[\]{}...]  -> identical: True
app_operator (ascii art)  -> identical: True
```

After the fix, re-compiling all five files yields **0** invalid-escape warnings.

## Real behavior proof

- **Behavior addressed:** `SyntaxWarning: invalid escape sequence` on 7 literals across 5 modules (hard error on newer CPython).
- **Real environment:** Python 3.14.6, macOS, fresh `upstream/main`.
- **Exact command run after the patch:**
  ```
  python3 -m pytest packages/dbgpt-core/src/dbgpt/util/tests/test_no_invalid_escape.py -q
  ```
- **Captured output AFTER fix:**
  ```
  .....                                                                    [100%]
  5 passed in 0.08s
  ```
- **Captured output BEFORE fix (one file reverted to original):**
  ```
  E   AssertionError: invalid escape sequence(s) in dbgpt-core/src/dbgpt/agent/util/api_call.py:
  E       line 123: "\_" is an invalid escape sequence. ...
  FAILED ...::test_no_invalid_escape_sequence[dbgpt-core/src/dbgpt/agent/util/api_call.py]
  1 failed in 0.07s
  ```
- **Regression test:** `packages/dbgpt-core/src/dbgpt/util/tests/test_no_invalid_escape.py` — parametrized over the five files, asserts none emit an invalid-escape `SyntaxWarning`. It FAILS without the fix and passes with it.
- **What was NOT tested:** Runtime behavior of the Vertica connector / PDF parser themselves (they require a live DB / PDF fixtures); this change is provably value-preserving at the literal level, so their behavior is unchanged.
