### PR TITLE
fix(core): avoid ValueError when LLM output has multiple json fences

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/core/interface/output_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/output_parser.py
@@ -214,7 +214,10 @@ class BaseOutputParser(MapOperator[ModelOutput, Any], ABC):
         """
         cleaned_output = model_out_text.rstrip()
         if "```json" in cleaned_output:
-            _, cleaned_output = cleaned_output.split("```json")
+            # Split only on the first fence: a response may contain more than
+            # one ```json block, and an unbounded split would raise
+            # "too many values to unpack".
+            _, cleaned_output = cleaned_output.split("```json", 1)
         # if "```" in cleaned_output:
         #     cleaned_output, _ = cleaned_output.split("```")
         if cleaned_output.startswith("```json"):

--- a/packages/dbgpt-core/src/dbgpt/core/interface/tests/test_output_parser.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/tests/test_output_parser.py
@@ -1,0 +1,37 @@
+"""Tests for :class:`BaseOutputParser.parse_prompt_response`."""
+
+from dbgpt.core.interface.output_parser import BaseOutputParser
+
+
+def _parser() -> BaseOutputParser:
+    return BaseOutputParser(is_stream_out=False)
+
+
+def test_parse_prompt_response_single_json_fence():
+    """A single ```json fence is unwrapped to the inner object."""
+    parser = _parser()
+    text = '```json\n{"a": 1}\n```'
+    assert parser.parse_prompt_response(text) == '{"a": 1}'
+
+
+def test_parse_prompt_response_multiple_json_fences():
+    """Multiple ```json fences must not raise 'too many values to unpack'.
+
+    A model response can contain more than one ```json code block (e.g. an
+    explanation followed by the answer, or chain-of-thought style output).
+    The old ``split("```json")`` unpacked into exactly two names and raised a
+    ``ValueError`` in that case; we now split on the first fence only.
+    """
+    parser = _parser()
+    text = 'First ```json\n{"a": 1}\n``` then ```json\n{"b": 2}\n```'
+    # Must not raise; everything after the first fence is kept for downstream
+    # extraction.
+    result = parser.parse_prompt_response(text)
+    assert isinstance(result, str)
+    assert '{"a": 1}' in result
+
+
+def test_parse_prompt_response_no_fence():
+    """Plain JSON without a fence is returned unchanged."""
+    parser = _parser()
+    assert parser.parse_prompt_response('{"a": 1}') == '{"a": 1}'


### PR DESCRIPTION
## Summary

- `BaseOutputParser.parse_prompt_response` raised `ValueError: too many values to unpack` when the model output contained more than one ` ```json ` code fence.
- Splitting on the first fence only (`maxsplit=1`) fixes the crash; single-fence and no-fence behavior is unchanged.

## Root Cause

**Symptom** — Parsing a model response that contains two or more ` ```json ` blocks crashes the whole parse with `ValueError: too many values to unpack (expected 2, got 3)`.

**Root cause** — In `parse_prompt_response` (`output_parser.py`):

```python
if "```json" in cleaned_output:
    _, cleaned_output = cleaned_output.split("```json")
```

`str.split("```json")` with no `maxsplit` returns one element per fence + 1. The result is unpacked into exactly two names, so any response with ≥2 ` ```json ` fences yields ≥3 parts and the unpacking raises. Reasoning/explanatory models routinely emit more than one fenced block (e.g. an example followed by the real answer), so this is hit in normal operation, not just on malformed input.

**Evidence** — Reproduced on a real `BaseOutputParser` from current `main`:

```
>>> p = BaseOutputParser(is_stream_out=False)
>>> p.parse_prompt_response('Here ```json\n{"a": 1}\n``` and another ```json\n{"b": 2}\n```')
ValueError: too many values to unpack (expected 2, got 3)
```

**Fix + why this level** — `split("```json", 1)`. This is the correct layer: the intent is to drop the prose *before the first* fence and keep the remainder for the existing downstream fence-stripping/`_extract_json` logic. `maxsplit=1` restores that intent exactly. Fixing downstream (e.g. wrapping the call in try/except) would mask the bug and lose the leading-prose strip; widening the unpack would still mis-handle 3+ parts.

**Scope / risk** — One-line change in one function. Single-fence inputs split into exactly two parts either way, so their behavior is byte-for-byte identical; no-fence inputs never enter the branch. No public API or signature change.

## Verification

```
python3 -m pytest dbgpt/core/interface/tests/test_output_parser.py -q
```

## Real behavior proof

- **Behavior addressed:** crash on multi-`` ```json `` responses; preserve single/no-fence behavior.
- **Real environment:** Python 3.14.6, macOS, `BaseOutputParser` imported from this branch.
- **Captured output AFTER fix:**
  ```
  ...                                                                      [100%]
  3 passed in 0.01s
  ```
- **Captured output BEFORE fix** (source reverted, test kept):
  ```
  >           _, cleaned_output = cleaned_output.split("```json")
  E           ValueError: too many values to unpack (expected 2, got 3)
  output_parser.py:217: ValueError
  FAILED ...::test_parse_prompt_response_multiple_json_fences
  1 failed in 0.02s
  ```
- **Manual check (after fix):** `parse_prompt_response('```json\n{"a": 1}\n```')` → `'{"a": 1}'` (single-fence unchanged); `parse_prompt_response('{"a": 1}')` → `'{"a": 1}'` (no fence unchanged).
- **Regression test:** `packages/dbgpt-core/src/dbgpt/core/interface/tests/test_output_parser.py::test_parse_prompt_response_multiple_json_fences` — asserts no crash on multi-fence input; FAILS without the fix and passes with it. Two companion tests pin the single-fence and no-fence behavior.
- **What was NOT tested:** the full downstream JSON repair pipeline on adversarial multi-block content (out of scope — this PR only removes the crash and preserves existing extraction).
