### PR TITLE
feat(core): tolerant JSON parsing for LLM output (repair_json, loads_robust)

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/json_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/json_utils.py
@@ -136,6 +136,160 @@ def _format_json_str(jstr):
     return "".join(result)
 
 
+def _strip_json_code_fence(text: str) -> str:
+    """Strip a leading/trailing Markdown code fence from a JSON string.
+
+    LLMs frequently wrap JSON payloads in fenced code blocks such as
+    ``` ```json ... ``` ```. This helper removes a single surrounding fence
+    (optionally tagged with a language such as ``json``) so the inner payload
+    can be parsed. If no fence is detected the text is returned unchanged.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    # Drop the opening fence line (``` or ```json etc.)
+    lines = stripped.split("\n")
+    lines = lines[1:]
+    # Drop the closing fence line if present.
+    if lines and lines[-1].strip().startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines)
+
+
+def _strip_json_comments(text: str) -> str:
+    """Remove ``//`` and ``/* */`` comments that live outside of strings.
+
+    Comments are not valid JSON but are commonly emitted by language models.
+    Characters inside double-quoted strings (respecting escapes) are preserved.
+    """
+    result = []
+    inside_string = False
+    escape = False
+    i = 0
+    n = len(text)
+    while i < n:
+        char = text[i]
+        if inside_string:
+            result.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                inside_string = False
+            i += 1
+            continue
+        # Not inside a string.
+        if char == '"':
+            inside_string = True
+            result.append(char)
+            i += 1
+            continue
+        if char == "/" and i + 1 < n and text[i + 1] == "/":
+            # Line comment: skip until end of line.
+            i += 2
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if char == "/" and i + 1 < n and text[i + 1] == "*":
+            # Block comment: skip until closing */.
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        result.append(char)
+        i += 1
+    return "".join(result)
+
+
+def _remove_trailing_commas(text: str) -> str:
+    """Remove trailing commas before ``}`` or ``]`` that live outside strings.
+
+    Example: ``{"a": 1,}`` becomes ``{"a": 1}``. Commas inside double-quoted
+    strings (respecting escapes) are preserved.
+    """
+    result = []
+    inside_string = False
+    escape = False
+    for char in text:
+        if inside_string:
+            result.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                inside_string = False
+            continue
+        if char == '"':
+            inside_string = True
+            result.append(char)
+            continue
+        if char in "}]":
+            # Walk back over any whitespace, dropping a trailing comma.
+            j = len(result) - 1
+            while j >= 0 and result[j] in " \t\r\n":
+                j -= 1
+            if j >= 0 and result[j] == ",":
+                del result[j]
+        result.append(char)
+    return "".join(result)
+
+
+def repair_json(text: str) -> str:
+    """Best-effort repair of common JSON defects in LLM output.
+
+    Applies, in order:
+
+    1. Strips a surrounding Markdown code fence (e.g. ```` ```json ... ``` ````).
+    2. Removes ``//`` line comments and ``/* */`` block comments.
+    3. Removes trailing commas before ``}`` or ``]``.
+
+    All transformations preserve the contents of double-quoted strings. The
+    result is a string that is more likely to parse with ``json.loads`` but is
+    not guaranteed to be valid JSON.
+
+    Args:
+        text (str): The raw text to repair.
+
+    Returns:
+        str: The repaired text.
+    """
+    if not text:
+        return text
+    repaired = _strip_json_code_fence(text)
+    repaired = _strip_json_comments(repaired)
+    repaired = _remove_trailing_commas(repaired)
+    return repaired.strip()
+
+
+def loads_robust(text: str, **kwargs):
+    """Parse JSON, falling back to a repaired version on failure.
+
+    First attempts a strict ``json.loads``. If that raises
+    ``json.JSONDecodeError``, the text is run through :func:`repair_json`
+    (stripping code fences, comments and trailing commas) and parsed again.
+    This is convenient for tolerating the small defects commonly present in
+    language-model JSON output without giving up strictness on well-formed
+    input.
+
+    Args:
+        text (str): The JSON text to parse.
+        **kwargs: Extra keyword arguments forwarded to ``json.loads``.
+
+    Returns:
+        The parsed Python object.
+
+    Raises:
+        json.JSONDecodeError: If the text cannot be parsed even after repair.
+    """
+    try:
+        return json.loads(text, **kwargs)
+    except json.JSONDecodeError:
+        return json.loads(repair_json(text), **kwargs)
+
+
 def compare_json_properties(json1, json2):
     """
     Check whether the attributes of two json are consistent

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_json_utils.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_json_utils.py
@@ -1,6 +1,8 @@
+import json
+
 import pytest
 
-from dbgpt.util.json_utils import find_json_objects
+from dbgpt.util.json_utils import find_json_objects, loads_robust, repair_json
 
 # 定义参数化测试数据
 test_data = [
@@ -63,3 +65,76 @@ def test_find_json_objects(text, expected, description):
     assert result == expected, (
         f"Test failed: {description}\nExpected: {expected}\nGot: {result}"
     )
+
+
+repair_data = [
+    (
+        '{"a": 1, "b": 2,}',
+        {"a": 1, "b": 2},
+        "Trailing comma in object",
+    ),
+    (
+        '{"a": [1, 2, 3,]}',
+        {"a": [1, 2, 3]},
+        "Trailing comma in array",
+    ),
+    (
+        '```json\n{"a": 1}\n```',
+        {"a": 1},
+        "Fenced json code block",
+    ),
+    (
+        '```\n{"a": 1}\n```',
+        {"a": 1},
+        "Fenced code block without language",
+    ),
+    (
+        '{\n  // a comment\n  "a": 1\n}',
+        {"a": 1},
+        "Line comment",
+    ),
+    (
+        '{"a": 1 /* inline */, "b": 2}',
+        {"a": 1, "b": 2},
+        "Block comment",
+    ),
+    (
+        '```json\n{\n  "a": 1, // trailing\n  "b": [1, 2,],\n}\n```',
+        {"a": 1, "b": [1, 2]},
+        "Combined fence + comment + trailing commas",
+    ),
+    (
+        '{"a": "value, with comma,", "b": "http://x.com"}',
+        {"a": "value, with comma,", "b": "http://x.com"},
+        "Defect-like characters inside strings are preserved",
+    ),
+]
+
+
+@pytest.mark.parametrize("text, expected, description", repair_data)
+def test_loads_robust(text, expected, description):
+    result = loads_robust(text)
+    assert result == expected, (
+        f"Test failed: {description}\nExpected: {expected}\nGot: {result}"
+    )
+
+
+def test_loads_robust_passthrough_valid_json():
+    """Well-formed JSON must parse identically to json.loads."""
+    text = '{"a": 1, "b": [1, 2, 3], "c": "x"}'
+    assert loads_robust(text) == json.loads(text)
+
+
+def test_loads_robust_raises_on_unrepairable():
+    with pytest.raises(json.JSONDecodeError):
+        loads_robust("{not valid at all")
+
+
+def test_repair_json_preserves_string_contents():
+    text = '{"note": "keep // this and , this"}'
+    # No structural defects outside strings -> unchanged content semantics.
+    assert json.loads(repair_json(text)) == {"note": "keep // this and , this"}
+
+
+def test_repair_json_empty():
+    assert repair_json("") == ""


### PR DESCRIPTION
## Problem

LLM responses very often emit JSON that is *almost* valid but breaks `json.loads`:

- wrapped in a Markdown code fence (```` ```json … ``` ````),
- containing `//` line comments or `/* … */` block comments,
- containing trailing commas before `}` or `]`.

These defects are a recurring source of parse failures in the agent / output-parsing
paths. Today callers must hand-roll cleanup (and the existing `_format_json_str`
only handles newlines/tabs).

## Solution

Two small, stdlib-only helpers added to `dbgpt.util.json_utils`:

- **`repair_json(text)`** — best-effort cleanup that, in order, strips a surrounding
  code fence, removes `//` and `/* */` comments, and removes trailing commas before
  `}`/`]`. All transformations preserve the contents of double-quoted strings
  (escape-aware), so commas/slashes inside string values are never touched.
- **`loads_robust(text, **kwargs)`** — tries strict `json.loads` first and only falls
  back to parsing `repair_json(text)` if that raises `JSONDecodeError`. Well-formed
  input parses identically to `json.loads`; `**kwargs` are forwarded.

## Tests

Added 12 tests in `packages/dbgpt-core/src/dbgpt/util/tests/test_json_utils.py`
covering trailing commas (object/array), fenced blocks (with/without language tag),
line/block comments, a combined case, string-content preservation, valid-JSON
passthrough, and the unrepairable-input raise path.

```
$ python -m pytest dbgpt/util/tests/test_json_utils.py -q
17 passed in 0.15s
```

## Compatibility

- No breaking changes — purely additive; existing functions untouched.
- Pure standard library (no new dependencies).
- `loads_robust` only diverges from `json.loads` when strict parsing already fails.
