### PR TITLE
fix(rag): correct empty/non-list guard in TeiRerankEmbeddings._parse_results

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/rag/embedding/rerank.py
+++ b/packages/dbgpt-core/src/dbgpt/rag/embedding/rerank.py
@@ -643,7 +643,7 @@ class TeiRerankEmbeddings(OpenAPIRerankEmbeddings):
         Returns:
             List[float]: The rank scores of the candidates.
         """
-        if not isinstance(response, list) and len(response) == 0:
+        if not isinstance(response, list) or len(response) == 0:
             raise RuntimeError("Results should be a not empty list")
 
         # Sort by index, 0 in the first element


### PR DESCRIPTION
## Problem

`TeiRerankEmbeddings._parse_results` (`packages/dbgpt-core/src/dbgpt/rag/embedding/rerank.py`) uses the wrong boolean operator in its "not a non-empty list" guard:

```python
if not isinstance(response, list) and len(response) == 0:
    raise RuntimeError("Results should be a not empty list")

results = sorted(response, key=lambda x: x.get("index", 0))
```

With `and`, the two subconditions are mutually defeating — it only fires for the nonsensical case of a **non-list that is also empty**. It fails the two cases the guard exists to catch:

- **Empty list `[]`**: `not isinstance([], list)` is `False`, so the guard is skipped. `sorted([])` → `[]`, `predict()` returns `[]`, and `RerankEmbeddingsRanker._rerank_with_scores` zips against an empty score list — all rerank scores are silently dropped instead of erroring.
- **Non-list error payload** (e.g. TEI returns `{"error": ...}`): the guard is skipped, then `sorted(response, key=lambda x: x.get(...))` iterates the dict's keys (strings) and raises a misleading `AttributeError: 'str' object has no attribute 'get'` instead of the intended `RuntimeError`.

## Reproduction

| response | current (`and`) | fixed (`or`) |
|---|---|---|
| `[]` | returns OK, no error ❌ | `RuntimeError: Results should be a not empty list` |
| `{"error": "busy"}` | `AttributeError: 'str' object has no attribute 'get'` ❌ | `RuntimeError: Results should be a not empty list` |

## Fix

```python
if not isinstance(response, list) or len(response) == 0:
    raise RuntimeError("Results should be a not empty list")
```

## Intent proof (siblings in the same file)

The other `_parse_results` implementations guard emptiness and list-type correctly and separately:
- `OpenAPIRerankEmbeddings._parse_results` (base): `if not data: raise ...` then `if not isinstance(data, list): raise ...`
- `SiliconFlowRerankEmbeddings` and `InfiniAIRerankEmbeddings`: same `if not results: raise` + `if not isinstance(results, list): raise`.

Only the TEI variant collapses these into one condition and picks the wrong operator. `python -m py_compile` passes. (The `rag/embedding/tests/` dir has only `__init__.py`; no existing coverage for `_parse_results`.)
