### PR TITLE
fix(file): preserve bucket in simplified fsspec paths

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/file/service/fsspec_impl.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/file/service/fsspec_impl.py
@@ -74,7 +74,9 @@ class DBGPTFileSystem(AbstractFileSystem):
                 raise ValueError(f"Failed to parse URI {path}: {str(e)}")
 
         # Handle local files
-        if FileStorageURI.is_local_file(path):
+        if FileStorageURI.is_local_file(path) and (
+            path.startswith("file://") or os.path.isabs(path)
+        ):
             # Treat as a local file reference
             file_name = os.path.basename(path)
             return "local", self.bucket, file_name

--- a/packages/dbgpt-serve/src/dbgpt_serve/file/tests/test_fsspec_impl.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/file/tests/test_fsspec_impl.py
@@ -1,0 +1,14 @@
+from unittest.mock import MagicMock
+
+from dbgpt_serve.file.service.fsspec_impl import DBGPTFileSystem
+
+
+def test_rm_uses_bucket_from_simplified_path():
+    client = MagicMock()
+    client.storage_system.get_file_metadata.return_value = object()
+    client.delete_file_by_id.return_value = True
+    filesystem = DBGPTFileSystem(client=client)
+
+    filesystem.rm("documents/file.txt")
+
+    client.delete_file_by_id.assert_called_once_with("documents", "file.txt")

--- a/packages/dbgpt-serve/src/dbgpt_serve/file/tests/test_fsspec_impl.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/file/tests/test_fsspec_impl.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from dbgpt_serve.file.service.fsspec_impl import DBGPTFileSystem
 
 
@@ -10,5 +12,19 @@ def test_rm_uses_bucket_from_simplified_path():
     filesystem = DBGPTFileSystem(client=client)
 
     filesystem.rm("documents/file.txt")
+
+    client.delete_file_by_id.assert_called_once_with("documents", "file.txt")
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/tmp/folder/file.txt", "file:///tmp/folder/file.txt"],
+)
+def test_rm_preserves_local_path_forms(path):
+    client = MagicMock()
+    client.delete_file_by_id.return_value = True
+    filesystem = DBGPTFileSystem(client=client, bucket="documents")
+
+    filesystem.rm(path)
 
     client.delete_file_by_id.assert_called_once_with("documents", "file.txt")


### PR DESCRIPTION
# Description

`DBGPTFileSystem._parse_path()` documents `bucket/file_id` as its simplified path format, but `FileStorageURI.is_local_file()` classifies every path without a URI scheme as local. As a result, operations such as `rm("documents/file.txt")` discard the requested bucket and act on `default/file.txt` instead.

This change limits the local-file branch to absolute paths and explicit `file://` URIs, allowing relative simplified paths to reach the existing bucket parser. No dependencies are added.

# How Has This Been Tested?

- Added a regression test that failed before the fix with an actual call to `delete_file_by_id("default", "file.txt")` instead of the expected `("documents", "file.txt")`.
- `pytest -q packages/dbgpt-serve/src/dbgpt_serve/file/tests` — 26 passed.
- `ruff check` and `ruff format --check` on both changed files.

# Snapshots:

Not applicable; this change has no UI impact.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commit and made the commit message conform to the project standard
- [x] I have performed a self-review of my own code
- [x] I have added a regression test for the affected behavior
- [x] No documentation change is needed because the documented simplified path format is unchanged
- [x] No dependent changes are required

AI assistance disclosure: Claude Opus 4.8 assisted with implementation and test drafting; the contributor reviewed the diff and ran the validation above.
