### PR TITLE
fix(core): StreamedBytesIO ignores negative read size and drops seek(SEEK_END) position

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/core/interface/file.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/file.py
@@ -997,7 +997,7 @@ class StreamedBytesIO(io.BytesIO):
             bytes: The read data
         """
         left_off_at = self._bytes.tell()
-        if size is None:
+        if size is None or size < 0:
             self._load_all()
         else:
             goal_position = left_off_at + size
@@ -1006,20 +1006,22 @@ class StreamedBytesIO(io.BytesIO):
         self._bytes.seek(left_off_at)
         return self._bytes.read(size)
 
-    def seek(self, position: int, whence: int = io.SEEK_SET):
+    def seek(self, position: int, whence: int = io.SEEK_SET) -> int:
         """Seek to a position in the stream.
 
         Args:
             position (int): The position
             whence (int, optional): The reference point. Defaults to io.SEEK
 
+        Returns:
+            int: The new absolute position.
+
         Raises:
             ValueError: If the reference point is invalid
         """
         if whence == io.SEEK_END:
             self._load_all()
-        else:
-            self._bytes.seek(position, whence)
+        return self._bytes.seek(position, whence)
 
     def __enter__(self):
         """Enter the context manager."""

--- a/packages/dbgpt-core/src/dbgpt/core/interface/tests/test_file.py
+++ b/packages/dbgpt-core/src/dbgpt/core/interface/tests/test_file.py
@@ -13,6 +13,7 @@ from ..file import (
     InMemoryStorage,
     LocalFileStorage,
     SimpleDistributedStorage,
+    StreamedBytesIO,
 )
 
 
@@ -504,3 +505,16 @@ def test_simple_distributed_storage_delete_file_remote(
         f"http://{remote_node_address}/api/v2/serve/file/files/{bucket}/{file_id}",
         timeout=360,
     )
+
+
+class TestStreamedBytesIO:
+    def test_read_negative_size_reads_all(self):
+        stream = StreamedBytesIO(iter([b"hello ", b"world"]))
+        assert stream.read(-1) == b"hello world"
+
+    def test_seek_end_loads_all_and_returns_position(self):
+        stream = StreamedBytesIO(iter([b"hello ", b"world"]))
+        position = stream.seek(-5, io.SEEK_END)
+        assert position == 6
+        assert stream.tell() == 6
+        assert stream.read() == b"world"


### PR DESCRIPTION
## Description

Two related `BinaryIO`-contract bugs in `packages/dbgpt-core/src/dbgpt/core/interface/file.py`'s `StreamedBytesIO`:

**1. `read(size)` ignores negative `size`.** The standard convention (and what plain `io.BytesIO.read()` does) is that `size=-1` means "read all remaining data", same as `size=None`. `StreamedBytesIO.read` only special-cased `size is None`:

```python
if size is None:
    self._load_all()
else:
    goal_position = left_off_at + size
    self._load_until(goal_position)
```

For `size=-1`, this falls into the `else` branch and computes `goal_position = left_off_at - 1`, which is behind the current position — `_load_until` loads nothing new, and the subsequent `self._bytes.read(size)` returns `b""` regardless of how much unread data the underlying iterator still has.

**2. `seek(position, whence=SEEK_END)` ignores `position` and returns `None`.**

```python
if whence == io.SEEK_END:
    self._load_all()
else:
    self._bytes.seek(position, whence)
```

For the `SEEK_END` branch, `_load_all()` runs (which itself ends by writing all chunks, leaving the cursor at the very end) but the method never delegates to `self._bytes.seek(position, whence)` — so any non-zero `position` offset (e.g. `seek(-N, SEEK_END)` to seek N bytes before the end) is silently dropped, and the method always implicitly returns `None` instead of the new absolute position that `IO.seek()` is expected to return.

## How Tested

- Reproduced both bugs against the real class before touching source:
  - `StreamedBytesIO(iter([b"hello ", b"world"])).read(-1)` returned `b""` instead of `b"hello world"`.
  - `StreamedBytesIO(iter([b"hello ", b"world"])).seek(-5, io.SEEK_END)` returned `None` and left the cursor at position 11 (the very end) instead of 6.
- Added `TestStreamedBytesIO` to `test_file.py` (this class had zero test coverage before) covering both cases — red before the fix, green after.
- `packages/dbgpt-core/src/dbgpt/core/interface/tests/test_file.py`: 25 passed.
- Full `packages/dbgpt-core/src/dbgpt/core/interface/tests/`: 93 passed.
- `ruff check` / `ruff format --check`: clean.
- `mypy`: one pre-existing, unrelated error at `file.py:550` (a different method returning `None` from a `str`-typed signature) reproduces identically on unmodified `upstream/main`; not touched by this diff.

## Checklist

- [x] AI-Generated: yes. This change was found, implemented, and verified (repro, TDD, full affected test suite, ruff, mypy diff-comparison) with Claude assistance.