### PR TITLE
fix(rag): ExcelKnowledge._load must handle headerless sheets and multi-sheet workbooks

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/excel.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/excel.py
@@ -175,6 +175,7 @@ class ExcelKnowledge(Knowledge):
                 )
             else:
                 data_rows = unmerged_data
+                df_start_row_index = 0
                 logging.info(
                     f"Sheet '{sheet_name}': No clear header row found. "
                     f"All rows considered data."
@@ -261,7 +262,7 @@ class ExcelKnowledge(Knowledge):
                 )
                 docs.append(doc)
 
-            return docs
+        return docs
 
     @classmethod
     def support_chunk_strategy(cls) -> List[ChunkStrategy]:

--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_excel.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_excel.py
@@ -1,0 +1,44 @@
+import openpyxl
+import pytest
+
+from ..excel import ExcelKnowledge
+
+
+@pytest.fixture
+def multi_sheet_xlsx(tmp_path):
+    path = tmp_path / "multi_sheet.xlsx"
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Sheet1"
+    ws1.append(["name", "value"])
+    ws1.append(["a", 1])
+    ws2 = wb.create_sheet("Sheet2")
+    ws2.append(["name", "value"])
+    ws2.append(["b", 2])
+    wb.save(path)
+    return str(path)
+
+
+@pytest.fixture
+def numeric_only_xlsx(tmp_path):
+    path = tmp_path / "numeric_only.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "NumericSheet"
+    for r in range(6):
+        ws.append([r, r + 1, r + 2])
+    wb.save(path)
+    return str(path)
+
+
+def test_load_reads_all_sheets(multi_sheet_xlsx):
+    knowledge = ExcelKnowledge(file_path=multi_sheet_xlsx)
+    docs = knowledge._load()
+    sheets_seen = {doc.metadata["sheet_name"] for doc in docs}
+    assert sheets_seen == {"Sheet1", "Sheet2"}
+
+
+def test_load_does_not_crash_without_header_row(numeric_only_xlsx):
+    knowledge = ExcelKnowledge(file_path=numeric_only_xlsx)
+    docs = knowledge._load()
+    assert len(docs) == 6


### PR DESCRIPTION
### Problem

`ExcelKnowledge._load()` (`packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/excel.py`) has two bugs:

**1. `UnboundLocalError` on sheets with no detectable text header row**

`_find_header_row` returns `header_row_idx == -1` when it can't confidently
identify a header row (e.g. a sheet of purely numeric data). The `if
header_row_idx != -1:` branch sets `df_start_row_index`, but the `else`
branch does not — and `df_start_row_index` is read a few lines later to
build each row's `row` metadata field, crashing with
`UnboundLocalError: cannot access local variable 'df_start_row_index'`.

**2. Only the first sheet of a multi-sheet workbook is ever loaded**

`return docs` is indented one level too deep — inside the `for sheet_name
in workbook.sheetnames:` loop (right after the per-row `for index, row in
df.iterrows():` loop), instead of after the whole sheet loop. So the
function returns as soon as the first sheet's rows are processed, silently
dropping every other sheet in the workbook.

### Repro (bare, before fix)

```python
from dbgpt_ext.rag.knowledge.excel import ExcelKnowledge

# multi-sheet workbook -> only Sheet1 comes back
docs = ExcelKnowledge(file_path="multi_sheet.xlsx")._load()
{d.metadata["sheet_name"] for d in docs}   # {'Sheet1'}, expected {'Sheet1', 'Sheet2'}

# sheet with no text header row -> crashes
ExcelKnowledge(file_path="numeric_only.xlsx")._load()
# UnboundLocalError: cannot access local variable 'df_start_row_index'
```

### Fix

- Initialize `df_start_row_index = 0` in the `else` branch (no header row
  found → treat row 0 as the start of data, consistent with `data_rows =
  unmerged_data`).
- Dedent `return docs` to the sheet-loop level so all sheets are processed
  before returning.

### Testing

Added `packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_excel.py`
using real `openpyxl`-generated workbooks (no mocking of openpyxl itself),
covering both cases. Confirmed red against unfixed code (`UnboundLocalError`
/ single-sheet result), green after the fix:

```
packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_excel.py::test_load_reads_all_sheets PASSED
packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/test_excel.py::test_load_does_not_crash_without_header_row PASSED
```

Also ran the full `packages/dbgpt-ext/src/dbgpt_ext/rag/knowledge/tests/`
directory (excluding two pre-existing, unrelated collection errors from
optional deps not installed in this environment — `olefile`/`python-docx`
for `test_doc.py`/`test_docx.py`, and a `pdfplumber` import error in
`test_pdf.py`, none of which touch `excel.py`): 8 passed, 0 regressions.
`ruff check` and `ruff format --check` on both changed files: clean.

### Duplicate-work check

Searched open PRs and recent PR history for `excel.py` under
`rag/knowledge/` — no overlap. One open PR (#3088) touches an unrelated
file that happens to share the word "excel" in its path
(`chat_data/chat_excel/excel_analyze/chat.py`).

---

*Disclosure: I used AI assistance (Claude) to find these bugs and draft
the fix and tests. I independently reproduced both crashes against
unfixed code, verified the fix red→green, ran the full affected test
directory, and take responsibility for the change's correctness.*