### PR TITLE
fix(client): create_datasource/create_flow must POST, not GET

### DIFF
--- a/packages/dbgpt-client/src/dbgpt_client/datasource.py
+++ b/packages/dbgpt-client/src/dbgpt_client/datasource.py
@@ -19,7 +19,7 @@ async def create_datasource(
         datasource (DatasourceModel): The datasource model.
     """
     try:
-        res = await client.get("/datasources", model_to_dict(datasource))
+        res = await client.post("/datasources", model_to_dict(datasource))
         result: Result = res.json()
         if result["success"]:
             return DatasourceModel(**result["data"])

--- a/packages/dbgpt-client/src/dbgpt_client/flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/flow.py
@@ -18,7 +18,7 @@ async def create_flow(client: Client, flow: FlowPanel) -> FlowPanel:
         flow (FlowPanel): The flow panel.
     """
     try:
-        res = await client.get("/awel/flows", flow.to_dict())
+        res = await client.post("/awel/flows", flow.to_dict())
         result: Result = res.json()
         if result["success"]:
             return FlowPanel(**result["data"])

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_datasource.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_datasource.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbgpt._private.pydantic import model_to_dict
 from dbgpt_client.datasource import create_datasource
 from dbgpt_client.schema import DatasourceModel
 
@@ -67,3 +68,4 @@ async def test_create_datasource_posts_instead_of_get():
     assert created.db_name == "test_db"
     assert client.requests[0][0] == "post"
     assert client.requests[0][1] == "/datasources"
+    assert client.requests[0][2] == model_to_dict(request)

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_datasource.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_datasource.py
@@ -1,0 +1,69 @@
+import pytest
+
+from dbgpt_client.datasource import create_datasource
+from dbgpt_client.schema import DatasourceModel
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _CreateDatasourceClient:
+    """Mirrors the real `Client`'s method signatures closely enough to
+    reproduce the real bug: httpx's `AsyncClient.get()` only accepts a
+    request body via the keyword-only `params`, so calling `.get(path,
+    body)` with the body as a positional argument raises TypeError before
+    any request is sent.
+    """
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    async def get(self, path, *args, **kwargs):
+        self.requests.append(("get", path, args, kwargs))
+        if args:
+            raise TypeError(
+                "AsyncClient.get() takes 2 positional arguments but 3 "
+                "positional arguments (and 1 keyword-only argument) were "
+                "given"
+            )
+        return _Response(self.payload)
+
+    async def post(self, path, body):
+        self.requests.append(("post", path, body))
+        return _Response(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_create_datasource_posts_instead_of_get():
+    client = _CreateDatasourceClient(
+        {
+            "success": True,
+            "err_code": None,
+            "err_msg": None,
+            "data": {
+                "id": 1,
+                "db_type": "mysql",
+                "db_name": "test_db",
+                "db_path": "",
+                "db_host": "",
+                "db_port": 0,
+                "db_user": "",
+                "db_pwd": "",
+                "comment": "",
+            },
+        }
+    )
+    request = DatasourceModel(db_type="mysql", db_name="test_db")
+
+    created = await create_datasource(client, request)
+
+    assert created.id == 1
+    assert created.db_name == "test_db"
+    assert client.requests[0][0] == "post"
+    assert client.requests[0][1] == "/datasources"

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -1,0 +1,58 @@
+import pytest
+
+from dbgpt.core.awel.flow.flow_factory import FlowPanel
+from dbgpt_client.flow import create_flow
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _CreateFlowClient:
+    """Mirrors the real `Client`'s method signatures closely enough to
+    reproduce the real bug: httpx's `AsyncClient.get()` only accepts a
+    request body via the keyword-only `params`, so calling `.get(path,
+    body)` with the body as a positional argument raises TypeError before
+    any request is sent.
+    """
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    async def get(self, path, *args, **kwargs):
+        self.requests.append(("get", path, args, kwargs))
+        if args:
+            raise TypeError(
+                "AsyncClient.get() takes 2 positional arguments but 3 "
+                "positional arguments (and 1 keyword-only argument) were "
+                "given"
+            )
+        return _Response(self.payload)
+
+    async def post(self, path, body):
+        self.requests.append(("post", path, body))
+        return _Response(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_create_flow_posts_instead_of_get():
+    client = _CreateFlowClient(
+        {
+            "success": True,
+            "err_code": None,
+            "err_msg": None,
+            "data": {"label": "test-flow", "name": "test_flow"},
+        }
+    )
+    request = FlowPanel(label="test-flow", name="test_flow")
+
+    created = await create_flow(client, request)
+
+    assert created.name == "test_flow"
+    assert client.requests[0][0] == "post"
+    assert client.requests[0][1] == "/awel/flows"

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -56,3 +56,4 @@ async def test_create_flow_posts_instead_of_get():
     assert created.name == "test_flow"
     assert client.requests[0][0] == "post"
     assert client.requests[0][1] == "/awel/flows"
+    assert client.requests[0][2] == request.to_dict()


### PR DESCRIPTION
## Description

`create_datasource` and `create_flow` in the Python client call `client.get(path, body)` against endpoints that are POST routes (creating a resource with a request body):

```python
# datasource.py
res = await client.get("/datasources", model_to_dict(datasource))
# flow.py
res = await client.get("/awel/flows", flow.to_dict())
```

Two problems:
1. Semantically wrong — creating a datasource/flow is a POST, and the server exposes these as POST endpoints; a GET will not create the resource.
2. It also fails before any network call: `Client.get(...)` forwards to httpx, whose `get()` takes no positional body argument, so passing the dict raises `TypeError` at the binding stage (reproducible offline). The sibling create/update helpers in the client already use `post`.

Fix: both call `client.post(...)` instead of `client.get(...)`.

## How Has This Been Tested?

- Added `test_datasource.py` / `test_flow.py` using a stub client that mirrors the real `Client.get`/`post` signatures; they assert `create_datasource`/`create_flow` issue a **POST** to the correct path with the serialized body (red before the fix, green after).
- `packages/dbgpt-client` full test suite: `4 passed`.
- `ruff check` clean on the changed files.

## Checklist

- [x] My code follows the style guidelines (ruff clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally

---
AI disclosure: found and fixed with Claude (Anthropic) assistance.