### PR TITLE
fix(rag): deserialize table chunks when a separated chunk is present

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/db_schema.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/db_schema.py
@@ -215,8 +215,11 @@ class DBSchemaRetriever(BaseRetriever):
         separated_chunks = [
             chunk for chunk in table_chunks if chunk.metadata.get("separated")
         ]
+        not_sep_chunks = [
+            self._deserialize_table_chunk(chunk) for chunk in not_sep_chunks
+        ]
         if not separated_chunks:
-            return [self._deserialize_table_chunk(chunk) for chunk in not_sep_chunks]
+            return not_sep_chunks
 
         # Create tasks list
         # The fields of table is too large, and it has to be separated into chunks,

--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/tests/test_db_struct.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/tests/test_db_struct.py
@@ -64,3 +64,44 @@ def test_retrieve_with_mocked_summary(dbstruct_retriever):
 async def async_mock_parse_db_summary() -> str:
     """Asynchronous patch for _parse_db_summary method."""
     return "Table summary"
+
+
+_SEPARATOR = "--table-field-separator--"
+
+
+def _table_chunk(table_name: str, separated: bool) -> Chunk:
+    """Build a stored table chunk in the serialized summary format."""
+    return Chunk(
+        content=(
+            f"table_name: {table_name}\r\n"
+            f"table_comment: comment of {table_name}\r\n"
+            f"index_keys: pk\r\n"
+            f"{_SEPARATOR}\r\n"
+            f"id int"
+        ),
+        metadata={"db_summary_version": "v1", "separated": separated},
+    )
+
+
+@pytest.mark.parametrize("with_separated", [False, True])
+def test_similarity_search_deserializes_table_chunks(
+    dbstruct_retriever, mock_table_vector_store_connector, with_separated
+):
+    """Non-separated chunks must be deserialized whether or not a separated
+    chunk is also returned.
+
+    The mixed branch returned not_sep_chunks untouched, so the same chunk was
+    deserialized or leaked in the stored format depending on what else the
+    search happened to return.
+    """
+    chunks = [_table_chunk("users", separated=False)]
+    if with_separated:
+        chunks.append(_table_chunk("orders", separated=True))
+    mock_table_vector_store_connector.similar_search_with_scores.return_value = chunks
+    dbstruct_retriever._retrieve_field = lambda chunk, query: chunk
+
+    results = dbstruct_retriever._similarity_search("query")
+
+    users_chunk = next(c for c in results if "users" in c.content)
+    assert users_chunk.content.startswith("CREATE TABLE `users`")
+    assert "table_name: users" not in users_chunk.content

--- a/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/tests/test_db_struct.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/tests/test_db_struct.py
@@ -69,17 +69,31 @@ async def async_mock_parse_db_summary() -> str:
 _SEPARATOR = "--table-field-separator--"
 
 
-def _table_chunk(table_name: str, separated: bool) -> Chunk:
-    """Build a stored table chunk in the serialized summary format."""
+def _table_part(table_name: str) -> str:
+    return (
+        f"table_name: {table_name}\r\n"
+        f"table_comment: comment of {table_name}\r\n"
+        f"index_keys: pk\r\n"
+    )
+
+
+def _not_separated_chunk(table_name: str) -> Chunk:
+    """A table whose fields fit in one chunk: stored with its fields inline."""
     return Chunk(
-        content=(
-            f"table_name: {table_name}\r\n"
-            f"table_comment: comment of {table_name}\r\n"
-            f"index_keys: pk\r\n"
-            f"{_SEPARATOR}\r\n"
-            f"id int"
-        ),
-        metadata={"db_summary_version": "v1", "separated": separated},
+        content=f"{_table_part(table_name)}{_SEPARATOR}\r\nid int",
+        metadata={"db_summary_version": "v1", "separated": 0, "part": "table"},
+    )
+
+
+def _separated_chunk(table_name: str) -> Chunk:
+    """A table whose fields were split out into their own chunks.
+
+    RDBTextSplitter stores only the table part here (content.split(separator)[0]),
+    so this chunk carries no separator — _retrieve_field appends the fields back.
+    """
+    return Chunk(
+        content=_table_part(table_name),
+        metadata={"db_summary_version": "v1", "separated": 1, "part": "table"},
     )
 
 
@@ -94,14 +108,24 @@ def test_similarity_search_deserializes_table_chunks(
     deserialized or leaked in the stored format depending on what else the
     search happened to return.
     """
-    chunks = [_table_chunk("users", separated=False)]
+    chunks = [_not_separated_chunk("users")]
     if with_separated:
-        chunks.append(_table_chunk("orders", separated=True))
+        chunks.append(_separated_chunk("orders"))
     mock_table_vector_store_connector.similar_search_with_scores.return_value = chunks
-    dbstruct_retriever._retrieve_field = lambda chunk, query: chunk
 
     results = dbstruct_retriever._similarity_search("query")
 
-    users_chunk = next(c for c in results if "users" in c.content)
-    assert users_chunk.content.startswith("CREATE TABLE `users`")
-    assert "table_name: users" not in users_chunk.content
+    assert len(results) == len(chunks)
+    contents = [c.content for c in results]
+
+    users_chunk = contents[0]
+    assert users_chunk.startswith("CREATE TABLE `users`")
+    assert "table_name: users" not in users_chunk
+
+    if with_separated:
+        # The separated table goes through _retrieve_field, which fetches its
+        # fields from the field store and deserializes them back together.
+        orders_chunk = contents[1]
+        assert orders_chunk.startswith("CREATE TABLE `orders`")
+        assert "Field summary" in orders_chunk
+        assert _SEPARATOR not in orders_chunk


### PR DESCRIPTION
## Description

`_similarity_search` deserializes the non-separated table chunks **only when no separated chunk came back**:

```python
if not separated_chunks:
    return [self._deserialize_table_chunk(chunk) for chunk in not_sep_chunks]
...
return not_sep_chunks + separated_result   # <-- not_sep_chunks untouched
```

In the mixed branch `not_sep_chunks` is returned as-is. So whether a table chunk reaches the LLM as a readable `CREATE TABLE` statement or as the raw stored summary depends on **what else the search happened to return**:

```
only non-separated chunks  ->  CREATE TABLE `users`
                               (
                                   id int
                               ) COMMENT "comment of users"

plus one separated chunk   ->  table_name: users
                               table_comment: comment of users
                               index_keys: pk
                               --table-field-separator--
                               id int
```

The same chunk, two different formats — the second leaks the internal storage format (separator token and all) into the prompt.

## How Tested

- Added a parametrized test over `with_separated=[False, True]` to the existing `test_db_struct.py`, asserting the non-separated chunk is deserialized either way. **It fails on `main` for `[True]` and passes for `[False]`**, matching the diagnosis exactly, and both pass with this change.
- `pytest packages/dbgpt-ext/src/dbgpt_ext/rag/retriever/tests/` — 4 passed, no regressions.
- Verified separated chunks still go through `_retrieve_field` unchanged.
- `ruff check` and `ruff format --check` clean.

The fix hoists the deserialization above the branch so both paths agree.

## Snapshots

N/A — retrieval output formatting, no UI surface.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the tests locally and reviewed the diff before opening.
