### PR TITLE
fix(dbgpts): inner_copy_and_install must not report a failed build as success

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/dbgpts/repo.py
+++ b/packages/dbgpt-core/src/dbgpt/util/dbgpts/repo.py
@@ -470,9 +470,9 @@ def inner_copy_and_install(repo: str, name: str, package_path: Path):
         is_poetry = _is_poetry_project(install_path)
 
         # Build the package
-        build_success = _build_package(install_path, is_poetry)
+        build_success, build_error = _build_package(install_path, is_poetry)
         if not build_success:
-            raise ValueError("Failed to build the package")
+            raise ValueError(f"Failed to build the package: {build_error}")
 
         wheel_files = list(install_path.glob("dist/*.whl"))
         if not wheel_files:
@@ -485,9 +485,11 @@ def inner_copy_and_install(repo: str, name: str, package_path: Path):
             f"Installing dbgpts '{name}' wheel file {_print_path(wheel_file)}..."
         )
 
-        install_success = _install_wheel(str(wheel_file))
+        install_success, install_error = _install_wheel(str(wheel_file))
         if not install_success:
-            raise ValueError(f"Failed to install wheel file: {wheel_file}")
+            raise ValueError(
+                f"Failed to install wheel file: {wheel_file}: {install_error}"
+            )
 
         _write_install_metadata(name, repo, install_path)
         logger.info(f"Installed dbgpts at {_print_path(install_path)}.")

--- a/packages/dbgpt-core/src/dbgpt/util/tests/test_dbgpts_repo.py
+++ b/packages/dbgpt-core/src/dbgpt/util/tests/test_dbgpts_repo.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from dbgpt.util.dbgpts import repo as repo_module
+
+
+@pytest.fixture
+def package_path(tmp_path):
+    """A source package directory, as copied from a dbgpts repo."""
+    src = tmp_path / "src" / "hello_world"
+    src.mkdir(parents=True)
+    (src / "pyproject.toml").write_text("[project]\nname = 'hello-world'\n")
+    return src
+
+
+@pytest.fixture
+def install_root(tmp_path, monkeypatch):
+    """Point the installer at a temporary DBGPTS_HOME."""
+    root = tmp_path / "packages"
+    root.mkdir()
+    monkeypatch.setattr(repo_module, "INSTALL_DIR", root)
+    return root
+
+
+def test_inner_copy_and_install_raises_when_build_fails(
+    package_path, install_root, monkeypatch
+):
+    """A failed build must abort the install, not be reported as success.
+
+    _build_package returns (ok, error); assigning the whole tuple made the
+    guard test a non-empty tuple, which is always truthy.
+    """
+    monkeypatch.setattr(
+        repo_module, "_build_package", lambda *a, **kw: (False, "build blew up")
+    )
+
+    with pytest.raises(ValueError, match="build blew up"):
+        repo_module.inner_copy_and_install(
+            "eosphoros/dbgpts", "hello_world", package_path
+        )
+
+    assert not (install_root / "hello_world" / "install_metadata.toml").exists()
+
+
+def test_inner_copy_and_install_raises_when_wheel_install_fails(
+    package_path, install_root, monkeypatch
+):
+    """Same for a failed wheel install."""
+
+    def fake_build(install_path: Path, *a, **kw):
+        dist = install_path / "dist"
+        dist.mkdir(parents=True, exist_ok=True)
+        (dist / "hello_world-0.1.0-py3-none-any.whl").write_bytes(b"")
+        return True, ""
+
+    monkeypatch.setattr(repo_module, "_build_package", fake_build)
+    monkeypatch.setattr(
+        repo_module, "_install_wheel", lambda *a, **kw: (False, "not a zip file")
+    )
+
+    with pytest.raises(ValueError, match="not a zip file"):
+        repo_module.inner_copy_and_install(
+            "eosphoros/dbgpts", "hello_world", package_path
+        )
+
+    assert not (install_root / "hello_world" / "install_metadata.toml").exists()


### PR DESCRIPTION
# Description

`_build_package` and `_install_wheel` are both declared `-> tuple[bool, str]` (`repo.py:89`, `:146`). The CLI twin `copy_and_install` unpacks them correctly (`:532`, `:547`). `inner_copy_and_install` — the serve-side twin — assigns the whole tuple to a single name:

```python
build_success = _build_package(install_path, is_poetry)   # -> (False, "...")
if not build_success:                                     # never True: non-empty tuple is truthy
    raise ValueError("Failed to build the package")
```

A non-empty tuple is always truthy, so **both failure guards are dead**. A failed build and a failed wheel install fall through to `_write_install_metadata()` and `return True`.

This is the path behind `POST /install` (`dbgpts/hub/api/endpoints.py:198` → `install_gpts` → `inner_copy_and_install`, `dbgpts/my/service/service.py:138`). `install_gpts` relies entirely on an exception to detect failure, so a failed install gets its metadata written, a DB row persisted, and `Result.succ(None)` returned to the client.

Both lines came in with the same commit that introduced the tuple returns (`d5a2a0bf`, #2397) — `copy_and_install` was updated, `inner_copy_and_install` was not.

The fix unpacks both tuples and includes the error in the raised message, matching `copy_and_install`.

# How Has This Been Tested?

**Reproduced against the real module** (no stubbing) with a package whose build backend can't be resolved, shipping a stale non-zip `dist/*.whl`:

```
_build_package returned : (False, 'No suitable build method found. Please install build: pip install build')
  bool(rv)              : True    <- what `if not build_success` sees
  -> guard fires?       : False
inner_copy_and_install RETURNED: True   <- build failed AND wheel install failed
```

The wheel install independently failed too (`Manual installation failed: File is not a zip file`) and was swallowed by the second guard. The CLI twin `copy_and_install`, given the same input, correctly aborts — which is the control showing this is an asymmetry, not intended behavior.

**Regression tests** — new `packages/dbgpt-core/src/dbgpt/util/tests/test_dbgpts_repo.py`, one per swallowed guard, asserting the install raises and writes no metadata. Verified red before the fix (`Failed: DID NOT RAISE <class 'ValueError'>`), green after. There were previously **zero** tests importing `dbgpt.util.dbgpts` anywhere in the repo, which is why this went unnoticed.

**No regressions:**
- `packages/dbgpt-serve/src/dbgpt_serve/dbgpts/` (the caller): 24 passed
- `packages/dbgpt-core/src/dbgpt/util/tests/`: 166 passed, 1 failed — `test_db_migration_utils.py::test_create_alembic_config_creates_versions_dir`, which fails identically on a pristine tree (baseline: 164 passed, 1 failed). Missing `alembic` dep in my env, unrelated to this diff.
- `ruff check` / `ruff format --check` clean on both files.

# Snapshots:

n/a — behavior change is in the install path's error handling, covered by the tests above.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, no user-facing docs cover this internal guard
- [x] Any dependent changes have been merged and published in downstream modules — none

---

*Disclosure — correcting my original wording, which implied a human did the checking: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the tests, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff — it was just done by the AI, not a person. Please review it as unsupervised AI output, and tell me if that is not something you want here.*


