### PR TITLE
feat(auth): replace mock headers with revocable sessions

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/base.py
+++ b/packages/dbgpt-app/src/dbgpt_app/base.py
@@ -163,6 +163,15 @@ def _migration_db_storage(
             logger.warning(warn_msg)
 
 
+def _init_default_admin(system_app: SystemApp) -> None:
+    """Create the configured first system administrator when required."""
+    from dbgpt_serve.auth.config import SERVE_SERVICE_COMPONENT_NAME
+    from dbgpt_serve.auth.service.service import Service as AuthService
+
+    service = system_app.get_component(SERVE_SERVICE_COMPONENT_NAME, AuthService)
+    service.ensure_initial_admin()
+
+
 def _initialize_db(
     db_url: str,
     db_type: str,

--- a/packages/dbgpt-app/src/dbgpt_app/component_configs.py
+++ b/packages/dbgpt-app/src/dbgpt_app/component_configs.py
@@ -23,6 +23,11 @@ def initialize_components(
     )
     from dbgpt_app.initialization.scheduler import DefaultScheduler
     from dbgpt_app.initialization.serve_initialization import register_serve_apps
+    from dbgpt_serve.auth.config import (
+        SERVE_CONFIG_KEY_PREFIX as AUTH_CONFIG_KEY_PREFIX,
+    )
+    from dbgpt_serve.auth.config import ServeConfig as AuthServeConfig
+    from dbgpt_serve.auth.service.service import Service as AuthService
     from dbgpt_serve.datasource.manages.connector_manager import ConnectorManager
 
     web_config = param.service.web
@@ -37,6 +42,10 @@ def initialize_components(
     system_app.register_instance(controller)
     system_app.register(ConnectorManager)
     system_app.register(StorageManager)
+    auth_config = AuthServeConfig.from_app_config(
+        system_app.config, AUTH_CONFIG_KEY_PREFIX
+    )
+    system_app.register(AuthService, config=auth_config)
 
     from dbgpt_serve.agent.hub.controller import module_plugin
 

--- a/packages/dbgpt-app/src/dbgpt_app/dbgpt_server.py
+++ b/packages/dbgpt-app/src/dbgpt_app/dbgpt_server.py
@@ -27,6 +27,7 @@ from dbgpt.util.utils import (
 )
 from dbgpt_app.base import (
     _create_model_start_listener,
+    _init_default_admin,
     _migration_db_storage,
     server_init,
 )
@@ -68,6 +69,7 @@ def mount_routers(app: FastAPI):
     from dbgpt_app.openapi.api_v2 import router as api_v2
     from dbgpt_serve.agent.app.controller import router as gpts_v1
     from dbgpt_serve.agent.app.endpoints import router as app_v2
+    from dbgpt_serve.auth.api.endpoints import router as auth_admin_router
 
     app.include_router(api_v1, prefix="/api", tags=["Chat"])
     app.include_router(api_v2, prefix="/api", tags=["ChatV2"])
@@ -80,6 +82,7 @@ def mount_routers(app: FastAPI):
     app.include_router(agentic_data_api, prefix="/api", tags=["AgenticData"])
 
     app.include_router(knowledge_router, tags=["Knowledge"])
+    app.include_router(auth_admin_router, prefix="/api/v1/admin", tags=["Admin"])
 
     from dbgpt_serve.agent.app.recommend_question.controller import (
         router as recommend_question_v1,
@@ -167,6 +170,7 @@ def initialize_app(param: ApplicationConfig, args: List[str] = None):
     _migration_db_storage(
         param.service.web.database, web_config.disable_alembic_upgrade
     )
+    _init_default_admin(system_app)
 
     # After init, when the database is ready
     system_app.after_init()

--- a/packages/dbgpt-app/src/dbgpt_app/initialization/db_model_initialization.py
+++ b/packages/dbgpt-app/src/dbgpt_app/initialization/db_model_initialization.py
@@ -10,8 +10,20 @@ from dbgpt_app.share.models import ShareLinkEntity
 from dbgpt_serve.agent.app.recommend_question.recommend_question import (
     RecommendQuestionEntity,
 )
+from dbgpt_serve.agent.db.gpts_app import GptsAppEntity
 from dbgpt_serve.agent.hub.db.my_plugin_db import MyPluginEntity
 from dbgpt_serve.agent.hub.db.plugin_hub_db import PluginHubEntity
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
 from dbgpt_serve.datasource.manages.connect_config_db import ConnectConfigEntity
 from dbgpt_serve.evaluate.db.benchmark_db import BenchmarkSummaryEntity
 from dbgpt_serve.file.models.models import ServeEntity as FileServeEntity
@@ -24,6 +36,15 @@ from dbgpt_serve.rag.models.models import KnowledgeSpaceEntity
 
 _MODELS = [
     PluginHubEntity,
+    UserEntity,
+    AccountSetEntity,
+    UserAccountGrantEntity,
+    UserResourceGrantEntity,
+    ImportBatchEntity,
+    TokenUsageEntity,
+    TokenDailyEntity,
+    AuditEventEntity,
+    SessionEntity,
     FileServeEntity,
     MyPluginEntity,
     PromptManageEntity,
@@ -37,6 +58,7 @@ _MODELS = [
     ModelInstanceEntity,
     FlowServeEntity,
     RecommendQuestionEntity,
+    GptsAppEntity,
     FlowVariableEntity,
     BenchmarkSummaryEntity,
     ShareLinkEntity,

--- a/packages/dbgpt-serve/pyproject.toml
+++ b/packages/dbgpt-serve/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">= 3.10"
 dependencies = [
     "dbgpt-ext",
     "apscheduler>=3.10,<4",
+    "bcrypt>=4,<5",
+    "passlib[bcrypt]>=1.7.4",
+    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.urls]

--- a/packages/dbgpt-serve/pyproject.toml
+++ b/packages/dbgpt-serve/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "dbgpt-ext",
     "apscheduler>=3.10,<4",
     "bcrypt>=4,<5",
-    "passlib[bcrypt]>=1.7.4",
     "python-jose[cryptography]>=3.3.0",
 ]
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
@@ -314,6 +314,7 @@ class GptsAppEntity(Model):
 
     user_code = Column(String(255), nullable=True, comment="user code")
     sys_code = Column(String(255), nullable=True, comment="system app code")
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     published = Column(String(64), nullable=True, comment="published")
 
     param_need = Column(
@@ -331,7 +332,10 @@ class GptsAppEntity(Model):
     )
     admins = Column(Text, nullable=True, comment="administrators")
 
-    __table_args__ = (UniqueConstraint("app_name", name="uk_gpts_app"),)
+    __table_args__ = (
+        UniqueConstraint("app_name", name="uk_gpts_app"),
+        Index("idx_app_account_set", "account_set_id"),
+    )
 
 
 class GptsAppDetailEntity(Model):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication and authorization persistence package."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP API for the authorization center."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -1,0 +1,112 @@
+"""Authentication endpoints for the administration API."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from starlette.concurrency import run_in_threadpool
+
+from dbgpt.core.schema.api import Result
+from dbgpt_serve.auth.api.schemas import LoginRequest, LoginResponse, UserResponse
+from dbgpt_serve.auth.service.service import (
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+    get_auth_service,
+)
+from dbgpt_serve.utils.auth import UserRequest, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/auth/login", response_model=Result[LoginResponse])
+async def login(
+    login_request: LoginRequest,
+    request: Request,
+    response: Response,
+    service: Service = Depends(get_auth_service),
+) -> Result[LoginResponse]:
+    """Authenticate credentials and set the secure session cookie."""
+    source_ip = request.client.host if request.client else ""
+    user_agent = request.headers.get("user-agent", "")
+    try:
+        token, user = await run_in_threadpool(
+            service.login,
+            login_request.login_name,
+            login_request.password,
+            source_ip,
+            user_agent,
+        )
+    except AuthenticationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid login name or password",
+        ) from exc
+    except AuthConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from exc
+
+    response.set_cookie(
+        key="dbgpt_session",
+        value=token,
+        max_age=service.config.jwt_absolute_expire_minutes * 60,
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    return Result.succ(LoginResponse(access_token=token, user=user))
+
+
+@router.post("/auth/logout", response_model=Result[None])
+async def logout(
+    response: Response,
+    user: UserRequest = Depends(get_current_user),
+    service: Service = Depends(get_auth_service),
+) -> Result[None]:
+    """Revoke the current server-side session and clear its cookie."""
+    if not user.user_id or not user.session_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    await run_in_threadpool(service.logout, user.user_id, user.session_id)
+    response.delete_cookie(
+        key="dbgpt_session",
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return Result.succ(None)
+
+
+@router.get("/auth/me", response_model=Result[UserResponse])
+async def current_user(
+    response: Response,
+    user: UserRequest = Depends(get_current_user),
+) -> Result[UserResponse]:
+    """Return the current database-backed user identity."""
+    if (
+        not user.user_id
+        or not user.login_name
+        or not user.display_name
+        or not user.role
+        or user.gmt_created is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    response.headers["Cache-Control"] = "no-store"
+    return Result.succ(
+        UserResponse(
+            user_id=user.user_id,
+            login_name=user.login_name,
+            display_name=user.display_name,
+            role=user.role,
+            is_active=user.is_active,
+            gmt_created=user.gmt_created,
+            disabled_at=user.disabled_at,
+        )
+    )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -54,6 +54,15 @@ async def login(
         httponly=True,
         samesite="lax",
     )
+    response.set_cookie(
+        key="dbgpt_csrf",
+        value=service.csrf_token(token),
+        max_age=service.config.jwt_absolute_expire_minutes * 60,
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=False,
+        samesite="lax",
+    )
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     return Result.succ(LoginResponse(access_token=token, user=user))
@@ -76,6 +85,13 @@ async def logout(
         path="/",
         secure=service.config.cookie_secure,
         httponly=True,
+        samesite="lax",
+    )
+    response.delete_cookie(
+        key="dbgpt_csrf",
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=False,
         samesite="lax",
     )
     response.headers["Cache-Control"] = "no-store"

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
@@ -1,0 +1,47 @@
+"""Pydantic schemas for authentication endpoints."""
+
+from datetime import datetime
+
+from dbgpt._private.pydantic import BaseModel, ConfigDict, Field, field_validator
+from dbgpt_serve.auth.models.models import UserEntity
+
+
+class LoginRequest(BaseModel):
+    """Credentials accepted by the login endpoint."""
+
+    login_name: str = Field(min_length=1, max_length=128)
+    password: str
+
+    @field_validator("login_name")
+    @classmethod
+    def normalize_login_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("login_name must not be blank")
+        return value
+
+
+class UserResponse(BaseModel):
+    """Non-sensitive user fields returned by authentication APIs."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: str
+    login_name: str
+    display_name: str
+    role: str
+    is_active: bool
+    gmt_created: datetime
+    disabled_at: datetime | None = None
+
+    @classmethod
+    def from_entity(cls, entity: UserEntity) -> "UserResponse":
+        return cls.model_validate(entity)
+
+
+class LoginResponse(BaseModel):
+    """Successful authentication response."""
+
+    access_token: str
+    token_type: str = "bearer"
+    user: UserResponse

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
@@ -1,0 +1,28 @@
+"""Configuration for the authorization service."""
+
+from dataclasses import dataclass, field
+
+from dbgpt_serve.core.config import BaseServeConfig
+
+APP_NAME = "auth"
+SERVE_APP_NAME = "dbgpt_auth"
+SERVE_CONFIG_KEY_PREFIX = "dbgpt.serve.auth."
+SERVE_SERVICE_COMPONENT_NAME = f"{SERVE_APP_NAME}_service"
+
+
+@dataclass
+class ServeConfig(BaseServeConfig):
+    """Authorization service configuration."""
+
+    __type__ = APP_NAME
+
+    jwt_secret: str = field(default="", repr=False, metadata={"tags": "privacy"})
+    jwt_access_expire_minutes: int = field(default=480)
+    jwt_absolute_expire_minutes: int = field(default=1440)
+    login_fail_lock_threshold: int = field(default=5)
+    login_fail_lock_minutes: int = field(default=30)
+    initial_admin_login: str = field(default="admin")
+    initial_admin_password: str = field(
+        default="", repr=False, metadata={"tags": "privacy"}
+    )
+    cookie_secure: bool = field(default=True)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/constants.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/constants.py
@@ -1,0 +1,46 @@
+"""Fixed roles and capability groups for the authorization center."""
+
+ROLE_PERMISSIONS: dict[str, frozenset[str]] = {
+    "system_admin": frozenset(
+        {
+            "USER_MANAGE",
+            "ROLE_READ",
+            "USER_ROLE_ASSIGN",
+            "ACCOUNT_SET_MANAGE",
+            "USER_ACCOUNT_SET_GRANT",
+            "USER_RESOURCE_GRANT",
+            "DATASOURCE_MANAGE",
+            "KNOWLEDGE_BASE_MANAGE",
+            "AGENT_MANAGE",
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+            "AUDIT_READ",
+        }
+    ),
+    "operations_admin": frozenset(
+        {
+            "DATASOURCE_MANAGE",
+            "KNOWLEDGE_BASE_MANAGE",
+            "AGENT_MANAGE",
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+        }
+    ),
+    "query_user": frozenset(
+        {
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+        }
+    ),
+}
+
+FIXED_ROLES = frozenset(ROLE_PERMISSIONS)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/models/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/models/__init__.py
@@ -1,0 +1,43 @@
+"""Authentication and authorization database models."""
+
+from .models import (
+    AccountSetDao,
+    AccountSetEntity,
+    AuditEventDao,
+    AuditEventEntity,
+    ImportBatchDao,
+    ImportBatchEntity,
+    SessionDao,
+    SessionEntity,
+    TokenDailyDao,
+    TokenDailyEntity,
+    TokenUsageDao,
+    TokenUsageEntity,
+    UserAccountGrantDao,
+    UserAccountGrantEntity,
+    UserDao,
+    UserEntity,
+    UserResourceGrantDao,
+    UserResourceGrantEntity,
+)
+
+__all__ = [
+    "AccountSetDao",
+    "AccountSetEntity",
+    "AuditEventDao",
+    "AuditEventEntity",
+    "ImportBatchDao",
+    "ImportBatchEntity",
+    "SessionDao",
+    "SessionEntity",
+    "TokenDailyDao",
+    "TokenDailyEntity",
+    "TokenUsageDao",
+    "TokenUsageEntity",
+    "UserAccountGrantDao",
+    "UserAccountGrantEntity",
+    "UserDao",
+    "UserEntity",
+    "UserResourceGrantDao",
+    "UserResourceGrantEntity",
+]

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/models/models.py
@@ -1,0 +1,522 @@
+"""Database entities and DAOs for the authorization center."""
+
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+
+from dbgpt.storage.metadata import BaseDao, Model
+from dbgpt.util.pagination_utils import PaginationResult
+
+
+class UserEntity(Model):
+    """DB-GPT user account."""
+
+    __tablename__ = "dbgpt_auth_user"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(128), nullable=False)
+    login_name = Column(String(128), nullable=False)
+    display_name = Column(String(255), nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    role = Column(String(64), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    activation_token = Column(String(255), nullable=True)
+    activation_token_exp = Column(DateTime, nullable=True)
+    reset_token = Column(String(255), nullable=True)
+    reset_token_exp = Column(DateTime, nullable=True)
+    login_fail_count = Column(Integer, nullable=False, default=0)
+    locked_until = Column(DateTime, nullable=True)
+    created_by = Column(String(128), nullable=True)
+    disabled_by = Column(String(128), nullable=True)
+    disabled_at = Column(DateTime, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uk_dbgpt_auth_user_user_id"),
+        UniqueConstraint("login_name", name="uk_dbgpt_auth_user_login_name"),
+        Index("ix_dbgpt_auth_user_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_login_name", "login_name"),
+    )
+
+
+class AccountSetEntity(Model):
+    """ERP or MES account set managed by DB-GPT."""
+
+    __tablename__ = "dbgpt_auth_account_set"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_set_id = Column(String(128), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_by = Column(String(128), nullable=False)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "account_set_id", name="uk_dbgpt_auth_account_set_business_id"
+        ),
+        UniqueConstraint("name", name="uk_dbgpt_auth_account_set_name"),
+        Index("ix_dbgpt_auth_account_set_id", "account_set_id"),
+    )
+
+
+class UserAccountGrantEntity(Model):
+    """Account-set scope granted to a user."""
+
+    __tablename__ = "dbgpt_auth_user_account_grant"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    grant_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    account_set_id = Column(String(128), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    granted_by = Column(String(128), nullable=False)
+    revoked_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+    revoke_reason = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("grant_id", name="uk_dbgpt_auth_user_account_grant_id"),
+        UniqueConstraint(
+            "user_id",
+            "account_set_id",
+            name="uk_dbgpt_auth_user_account_grant_scope",
+        ),
+        Index("ix_dbgpt_auth_user_account_grant_id", "grant_id"),
+        Index("ix_dbgpt_auth_user_account_grant_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_account_grant_account_set_id", "account_set_id"),
+    )
+
+
+class UserResourceGrantEntity(Model):
+    """Specific resource granted to a query user."""
+
+    __tablename__ = "dbgpt_auth_user_resource_grant"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    grant_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    resource_type = Column(String(64), nullable=False)
+    resource_id = Column(String(128), nullable=False)
+    account_set_id = Column(String(128), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    granted_by = Column(String(128), nullable=False)
+    revoked_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+    revoke_reason = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("grant_id", name="uk_dbgpt_auth_user_resource_grant_id"),
+        UniqueConstraint(
+            "user_id",
+            "resource_type",
+            "resource_id",
+            name="uk_dbgpt_auth_user_resource_grant_resource",
+        ),
+        Index("ix_dbgpt_auth_user_resource_grant_id", "grant_id"),
+        Index("ix_dbgpt_auth_user_resource_grant_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_resource_grant_resource_id", "resource_id"),
+    )
+
+
+class ImportBatchEntity(Model):
+    """Audit summary for a one-time external user import."""
+
+    __tablename__ = "dbgpt_auth_import_batch"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    batch_id = Column(String(128), nullable=False, unique=True)
+    operator_user_id = Column(String(128), nullable=False)
+    source_name = Column(String(255), nullable=False)
+    selected_count = Column(Integer, nullable=False)
+    created_count = Column(Integer, nullable=False, default=0)
+    skipped_count = Column(Integer, nullable=False, default=0)
+    selected_summary = Column(Text, nullable=True)
+    result_summary = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+
+
+class TokenUsageEntity(Model):
+    """One physical model call and its metering result."""
+
+    __tablename__ = "dbgpt_auth_token_usage"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    call_id = Column(String(128), nullable=False)
+    request_id = Column(String(128), nullable=False)
+    session_id = Column(String(128), nullable=True)
+    user_id = Column(String(128), nullable=False)
+    role_snapshot = Column(String(64), nullable=False)
+    account_set_id = Column(String(128), nullable=True)
+    account_set_snapshot = Column(String(255), nullable=True)
+    entry_resource_type = Column(String(64), nullable=True)
+    entry_resource_id = Column(String(128), nullable=True)
+    agent_id = Column(String(128), nullable=True)
+    model = Column(String(255), nullable=False)
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    metering_source = Column(String(64), nullable=False)
+    duration_ms = Column(Integer, nullable=True)
+    status = Column(String(32), nullable=False)
+    error_type = Column(String(64), nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint("call_id", name="uk_dbgpt_auth_token_usage_call_id"),
+        Index("ix_dbgpt_auth_token_usage_call_id", "call_id"),
+        Index("ix_dbgpt_auth_token_usage_request_id", "request_id"),
+        Index("ix_dbgpt_auth_token_usage_session_id", "session_id"),
+        Index("ix_dbgpt_auth_token_usage_user_id", "user_id"),
+        Index("ix_dbgpt_auth_token_usage_account_set_id", "account_set_id"),
+        Index("ix_dbgpt_auth_token_usage_gmt_created", "gmt_created"),
+    )
+
+
+class TokenDailyEntity(Model):
+    """Daily token aggregation in the Asia/Shanghai reporting timezone."""
+
+    __tablename__ = "dbgpt_auth_token_daily"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    stat_date = Column(String(10), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    role_snapshot = Column(String(64), nullable=False)
+    account_set_id = Column(String(128), nullable=False, default="")
+    model = Column(String(255), nullable=False)
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    call_count = Column(Integer, nullable=False, default=0)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "stat_date",
+            "user_id",
+            "role_snapshot",
+            "account_set_id",
+            "model",
+            name="uk_dbgpt_auth_token_daily_dimensions",
+        ),
+        Index("ix_dbgpt_auth_token_daily_stat_date", "stat_date"),
+        Index("ix_dbgpt_auth_token_daily_user_id", "user_id"),
+        Index("ix_dbgpt_auth_token_daily_account_set_id", "account_set_id"),
+    )
+
+
+class AuditEventEntity(Model):
+    """Append-only security and administrative audit event."""
+
+    __tablename__ = "dbgpt_auth_audit_event"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(String(128), nullable=False)
+    event_time = Column(DateTime, nullable=False, default=datetime.now)
+    operator_user_id = Column(String(128), nullable=True)
+    operator_role_snapshot = Column(String(64), nullable=True)
+    target_account_set_id = Column(String(128), nullable=True)
+    target_type = Column(String(64), nullable=False)
+    target_id = Column(String(128), nullable=True)
+    action = Column(String(64), nullable=False)
+    result = Column(String(32), nullable=False)
+    source_ip = Column(String(64), nullable=True)
+    user_agent = Column(String(512), nullable=True)
+    request_id = Column(String(128), nullable=True)
+    before_snapshot = Column(Text, nullable=True)
+    after_snapshot = Column(Text, nullable=True)
+    deny_reason = Column(String(512), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("event_id", name="uk_dbgpt_auth_audit_event_id"),
+        Index("ix_dbgpt_auth_audit_event_event_id", "event_id"),
+        Index("ix_dbgpt_auth_audit_event_event_time", "event_time"),
+        Index("ix_dbgpt_auth_audit_event_operator_user_id", "operator_user_id"),
+        Index(
+            "ix_dbgpt_auth_audit_event_target_account_set_id",
+            "target_account_set_id",
+        ),
+        Index("ix_dbgpt_auth_audit_event_target_type", "target_type"),
+        Index("ix_dbgpt_auth_audit_event_target_id", "target_id"),
+        Index("ix_dbgpt_auth_audit_event_request_id", "request_id"),
+    )
+
+
+class SessionEntity(Model):
+    """Server-side state for a revocable authenticated session."""
+
+    __tablename__ = "dbgpt_auth_session"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    issued_at = Column(DateTime, nullable=False, default=datetime.now)
+    last_seen_at = Column(DateTime, nullable=False, default=datetime.now)
+    idle_expires_at = Column(DateTime, nullable=False)
+    absolute_expires_at = Column(DateTime, nullable=False)
+    revoked_at = Column(DateTime, nullable=True)
+    revoked_by = Column(String(128), nullable=True)
+    revoke_reason = Column(String(512), nullable=True)
+    source_ip = Column(String(64), nullable=True)
+    user_agent = Column(String(512), nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("session_id", name="uk_dbgpt_auth_session_id"),
+        Index("ix_dbgpt_auth_session_id", "session_id"),
+        Index("ix_dbgpt_auth_session_user_id", "user_id"),
+        Index("ix_dbgpt_auth_session_idle_expires_at", "idle_expires_at"),
+        Index("ix_dbgpt_auth_session_absolute_expires_at", "absolute_expires_at"),
+    )
+
+
+class _EntityDao(BaseDao):
+    """Common private helpers for entity-specific DAOs."""
+
+    entity_type: Any
+
+    def _get_one(self, **filters: Any) -> Any:
+        with self.session(commit=False) as session:
+            return session.query(self.entity_type).filter_by(**filters).first()
+
+
+class UserDao(_EntityDao):
+    """Persistence operations for DB-GPT users."""
+
+    entity_type = UserEntity
+
+    def get_by_user_id(self, user_id: str) -> Optional[UserEntity]:
+        return self._get_one(user_id=user_id)
+
+    def get_by_login_name(self, login_name: str) -> Optional[UserEntity]:
+        return self._get_one(login_name=login_name)
+
+    def count_active_admins(self) -> int:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.role == "system_admin",
+                    UserEntity.is_active.is_(True),
+                )
+                .count()
+            )
+
+
+class AccountSetDao(_EntityDao):
+    """Persistence operations for account sets."""
+
+    entity_type = AccountSetEntity
+
+    def get_by_account_set_id(self, account_set_id: str) -> Optional[AccountSetEntity]:
+        return self._get_one(account_set_id=account_set_id)
+
+
+class UserAccountGrantDao(_EntityDao):
+    """Persistence operations for user account-set grants."""
+
+    entity_type = UserAccountGrantEntity
+
+    def get_by_grant_id(self, grant_id: str) -> Optional[UserAccountGrantEntity]:
+        return self._get_one(grant_id=grant_id)
+
+    def has_active_grant(self, user_id: str, account_set_id: str) -> bool:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserAccountGrantEntity.id)
+                .filter(
+                    UserAccountGrantEntity.user_id == user_id,
+                    UserAccountGrantEntity.account_set_id == account_set_id,
+                    UserAccountGrantEntity.is_active.is_(True),
+                )
+                .first()
+                is not None
+            )
+
+
+class UserResourceGrantDao(_EntityDao):
+    """Persistence operations for query-user resource grants."""
+
+    entity_type = UserResourceGrantEntity
+
+    def get_by_grant_id(self, grant_id: str) -> Optional[UserResourceGrantEntity]:
+        return self._get_one(grant_id=grant_id)
+
+    def has_active_grant(
+        self, user_id: str, resource_type: str, resource_id: str
+    ) -> bool:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserResourceGrantEntity.id)
+                .filter(
+                    UserResourceGrantEntity.user_id == user_id,
+                    UserResourceGrantEntity.resource_type == resource_type,
+                    UserResourceGrantEntity.resource_id == resource_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .first()
+                is not None
+            )
+
+
+class ImportBatchDao(_EntityDao):
+    """Persistence operations for account import batches."""
+
+    entity_type = ImportBatchEntity
+
+    def get_by_batch_id(self, batch_id: str) -> Optional[ImportBatchEntity]:
+        return self._get_one(batch_id=batch_id)
+
+
+class TokenUsageDao(_EntityDao):
+    """Persistence operations for model call usage details."""
+
+    entity_type = TokenUsageEntity
+
+    def get_by_call_id(self, call_id: str) -> Optional[TokenUsageEntity]:
+        return self._get_one(call_id=call_id)
+
+
+class TokenDailyDao(_EntityDao):
+    """Persistence operations for daily token aggregations."""
+
+    entity_type = TokenDailyEntity
+
+    def get_by_dimensions(
+        self,
+        stat_date: str,
+        user_id: str,
+        role_snapshot: str,
+        account_set_id: Optional[str],
+        model: str,
+    ) -> Optional[TokenDailyEntity]:
+        with self.session(commit=False) as session:
+            return (
+                session.query(TokenDailyEntity)
+                .filter(
+                    TokenDailyEntity.stat_date == stat_date,
+                    TokenDailyEntity.user_id == user_id,
+                    TokenDailyEntity.role_snapshot == role_snapshot,
+                    TokenDailyEntity.account_set_id == (account_set_id or ""),
+                    TokenDailyEntity.model == model,
+                )
+                .first()
+            )
+
+
+class SessionDao(_EntityDao):
+    """Persistence operations for authenticated sessions."""
+
+    entity_type = SessionEntity
+
+    def get_by_session_id(self, session_id: str) -> Optional[SessionEntity]:
+        return self._get_one(session_id=session_id)
+
+    def get_active_session(
+        self, session_id: str, user_id: str, now: Optional[datetime] = None
+    ) -> Optional[SessionEntity]:
+        current_time = now or datetime.now()
+        with self.session(commit=False) as session:
+            return (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                    SessionEntity.revoked_at.is_(None),
+                    SessionEntity.idle_expires_at > current_time,
+                    SessionEntity.absolute_expires_at > current_time,
+                )
+                .first()
+            )
+
+
+class AuditEventDao(BaseDao):
+    """Append-only persistence operations for audit events."""
+
+    _FILTER_FIELDS = {
+        "operator_user_id",
+        "target_account_set_id",
+        "target_type",
+        "target_id",
+        "action",
+        "result",
+        "request_id",
+    }
+
+    def append(
+        self, event: Union[AuditEventEntity, Dict[str, Any]]
+    ) -> AuditEventEntity:
+        entity = (
+            event if isinstance(event, AuditEventEntity) else AuditEventEntity(**event)
+        )
+        with self.session() as session:
+            session.add(entity)
+            session.flush()
+            session.expunge(entity)
+        return entity
+
+    def query(
+        self, filters: Dict[str, Any], page: int, page_size: int
+    ) -> PaginationResult[AuditEventEntity]:
+        unknown_fields = set(filters) - self._FILTER_FIELDS
+        if unknown_fields:
+            raise ValueError(f"Unsupported audit filters: {sorted(unknown_fields)}")
+        with self.session(commit=False) as session:
+            query = session.query(AuditEventEntity)
+            for field, value in filters.items():
+                if value is not None:
+                    query = query.filter(getattr(AuditEventEntity, field) == value)
+            total_count = query.count()
+            items = (
+                query.order_by(AuditEventEntity.event_time.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            return PaginationResult(
+                items=items,
+                total_count=total_count,
+                total_pages=(total_count + page_size - 1) // page_size,
+                page=page,
+                page_size=page_size,
+            )
+
+    def create(self, request: Any) -> Any:
+        raise TypeError("Audit events must be written with append()")
+
+    def update(self, query_request: Any, update_request: Any) -> Any:
+        raise TypeError("Audit events are append-only")
+
+    def delete(self, query_request: Any) -> None:
+        raise TypeError("Audit events are append-only")

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/__init__.py
@@ -1,0 +1,5 @@
+"""Authorization service layer."""
+
+from .service import AuthenticationError, Service
+
+__all__ = ["AuthenticationError", "Service"]

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -1,5 +1,7 @@
 """Core authentication service."""
 
+import hashlib
+import hmac
 import logging
 import secrets
 import uuid
@@ -253,6 +255,21 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             user_response = UserResponse.from_entity(user)
 
         return user_response, session_id
+
+    def csrf_token(self, token: str) -> str:
+        """Derive a CSRF token without exposing the session cookie value."""
+        self._require_jwt_secret()
+        return hmac.new(
+            self._config.jwt_secret.encode("utf-8"),
+            token.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def validate_csrf_token(self, token: str, candidate: str) -> bool:
+        """Compare a submitted CSRF token using constant-time equality."""
+        if not candidate:
+            return False
+        return hmac.compare_digest(self.csrf_token(token), candidate)
 
     def logout(self, user_id: str, session_id: str) -> None:
         """Idempotently revoke the current authenticated session."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -8,8 +8,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+import bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 
 from dbgpt._private.config import Config
 from dbgpt.component import SystemApp
@@ -63,11 +63,8 @@ class Service(BaseService[UserEntity, object, UserResponse]):
         self._validate_config()
         self._dao = user_dao or UserDao()
         self._session_dao = session_dao or SessionDao()
-        self._password_context = CryptContext(
-            schemes=["bcrypt"], bcrypt__rounds=12, deprecated="auto"
-        )
         self._dummy_password = secrets.token_urlsafe(32)
-        self._dummy_password_hash = self._password_context.hash(self._dummy_password)
+        self._dummy_password_hash = self.hash_password(self._dummy_password)
 
     @property
     def dao(self) -> BaseDao:
@@ -83,7 +80,21 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             raise ValueError("Password must not be empty")
         if len(password.encode("utf-8")) > 72:
             raise ValueError("Password must not exceed 72 bytes")
-        return self._password_context.hash(password)
+        return bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt(rounds=12)
+        ).decode("ascii")
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str) -> bool:
+        """Verify a supported plaintext password against a bcrypt hash."""
+        if not password or len(password.encode("utf-8")) > 72:
+            return False
+        try:
+            return bcrypt.checkpw(
+                password.encode("utf-8"), password_hash.encode("ascii")
+            )
+        except (TypeError, ValueError, UnicodeError):
+            return False
 
     def login(
         self, login_name: str, password: str, ip: str, user_agent: str
@@ -116,12 +127,7 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             candidate_password = (
                 password if password_is_supported else self._dummy_password
             )
-            try:
-                password_matches = self._password_context.verify(
-                    candidate_password, candidate_hash
-                )
-            except (TypeError, ValueError):
-                password_matches = False
+            password_matches = self.verify_password(candidate_password, candidate_hash)
             password_matches = password_matches and password_is_supported
 
             is_locked = bool(user and user.locked_until and user.locked_until > now)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -1,0 +1,427 @@
+"""Core authentication service."""
+
+import logging
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from dbgpt._private.config import Config
+from dbgpt.component import SystemApp
+from dbgpt.storage.metadata import BaseDao
+from dbgpt_serve.auth.api.schemas import UserResponse
+from dbgpt_serve.auth.config import SERVE_SERVICE_COMPONENT_NAME, ServeConfig
+from dbgpt_serve.auth.constants import FIXED_ROLES
+from dbgpt_serve.auth.models.models import (
+    AuditEventEntity,
+    SessionDao,
+    SessionEntity,
+    UserDao,
+    UserEntity,
+)
+from dbgpt_serve.core import BaseService
+
+logger = logging.getLogger(__name__)
+
+JWT_ALGORITHM = "HS256"
+JWT_AUDIENCE = "dbgpt-admin"
+JWT_ISSUER = "dbgpt"
+GENERIC_LOGIN_ERROR = "Invalid login name or password"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class AuthenticationError(Exception):
+    """Raised when credentials or session state are invalid."""
+
+
+class AuthConfigurationError(RuntimeError):
+    """Raised when authentication cannot operate securely."""
+
+
+class Service(BaseService[UserEntity, object, UserResponse]):
+    """Password authentication and revocable session management."""
+
+    name = SERVE_SERVICE_COMPONENT_NAME
+
+    def __init__(
+        self,
+        system_app: Optional[SystemApp],
+        config: ServeConfig,
+        user_dao: Optional[UserDao] = None,
+        session_dao: Optional[SessionDao] = None,
+    ) -> None:
+        super().__init__(system_app)
+        self._config = config
+        self._validate_config()
+        self._dao = user_dao or UserDao()
+        self._session_dao = session_dao or SessionDao()
+        self._password_context = CryptContext(
+            schemes=["bcrypt"], bcrypt__rounds=12, deprecated="auto"
+        )
+        self._dummy_password = secrets.token_urlsafe(32)
+        self._dummy_password_hash = self._password_context.hash(self._dummy_password)
+
+    @property
+    def dao(self) -> BaseDao:
+        return self._dao
+
+    @property
+    def config(self) -> ServeConfig:
+        return self._config
+
+    def hash_password(self, password: str) -> str:
+        """Hash a password using the configured adaptive password scheme."""
+        if not password:
+            raise ValueError("Password must not be empty")
+        if len(password.encode("utf-8")) > 72:
+            raise ValueError("Password must not exceed 72 bytes")
+        return self._password_context.hash(password)
+
+    def login(
+        self, login_name: str, password: str, ip: str, user_agent: str
+    ) -> tuple[str, UserResponse]:
+        """Authenticate credentials and create a revocable session."""
+        self._require_jwt_secret()
+        ip = (ip or "")[:64]
+        user_agent = (user_agent or "")[:512]
+        now = _utcnow()
+        session_id = str(uuid.uuid4())
+        absolute_expires_at = now + timedelta(
+            minutes=self._config.jwt_absolute_expire_minutes
+        )
+        idle_expires_at = min(
+            now + timedelta(minutes=self._config.jwt_access_expire_minutes),
+            absolute_expires_at,
+        )
+        login_error: Optional[AuthenticationError] = None
+        user_response: Optional[UserResponse] = None
+
+        with self._dao.session() as session:
+            user = (
+                session.query(UserEntity)
+                .filter(UserEntity.login_name == login_name)
+                .with_for_update()
+                .first()
+            )
+            password_is_supported = 0 < len(password.encode("utf-8")) <= 72
+            candidate_hash = user.password_hash if user else self._dummy_password_hash
+            candidate_password = (
+                password if password_is_supported else self._dummy_password
+            )
+            try:
+                password_matches = self._password_context.verify(
+                    candidate_password, candidate_hash
+                )
+            except (TypeError, ValueError):
+                password_matches = False
+            password_matches = password_matches and password_is_supported
+
+            is_locked = bool(user and user.locked_until and user.locked_until > now)
+            is_allowed = bool(
+                user
+                and user.is_active
+                and user.role in FIXED_ROLES
+                and not is_locked
+                and password_matches
+            )
+            if not is_allowed:
+                if user and user.is_active and not is_locked and not password_matches:
+                    user.login_fail_count += 1
+                    if user.login_fail_count >= self._config.login_fail_lock_threshold:
+                        user.locked_until = now + timedelta(
+                            minutes=self._config.login_fail_lock_minutes
+                        )
+                if is_locked:
+                    deny_reason = "ACCOUNT_LOCKED"
+                elif user and not user.is_active:
+                    deny_reason = "ACCOUNT_DISABLED"
+                elif user and user.role not in FIXED_ROLES:
+                    deny_reason = "INVALID_ROLE"
+                else:
+                    deny_reason = "INVALID_CREDENTIALS"
+                session.add(
+                    self._audit_event(
+                        action="AUTH.LOGIN",
+                        result="denied",
+                        operator_user_id=user.user_id if user else None,
+                        operator_role=user.role if user else None,
+                        target_id=user.user_id if user else None,
+                        source_ip=ip,
+                        user_agent=user_agent,
+                        deny_reason=deny_reason,
+                    )
+                )
+                login_error = AuthenticationError(GENERIC_LOGIN_ERROR)
+            else:
+                user.login_fail_count = 0
+                user.locked_until = None
+                session.add(
+                    SessionEntity(
+                        session_id=session_id,
+                        user_id=user.user_id,
+                        issued_at=now,
+                        last_seen_at=now,
+                        idle_expires_at=idle_expires_at,
+                        absolute_expires_at=absolute_expires_at,
+                        source_ip=ip or None,
+                        user_agent=(user_agent or "")[:512] or None,
+                    )
+                )
+                session.add(
+                    self._audit_event(
+                        action="AUTH.LOGIN",
+                        result="success",
+                        operator_user_id=user.user_id,
+                        operator_role=user.role,
+                        target_id=user.user_id,
+                        source_ip=ip,
+                        user_agent=user_agent,
+                    )
+                )
+                user_response = UserResponse.from_entity(user)
+
+        if login_error:
+            raise login_error
+        if user_response is None:
+            raise AuthenticationError(GENERIC_LOGIN_ERROR)
+
+        token = jwt.encode(
+            {
+                "sub": user_response.user_id,
+                "jti": session_id,
+                "iat": now,
+                "exp": absolute_expires_at,
+                "iss": JWT_ISSUER,
+                "aud": JWT_AUDIENCE,
+            },
+            self._config.jwt_secret,
+            algorithm=JWT_ALGORITHM,
+        )
+        return token, user_response
+
+    def authenticate_token(self, token: str) -> tuple[UserResponse, str]:
+        """Validate a JWT, its server-side session, and current user state."""
+        self._require_jwt_secret()
+        try:
+            payload = jwt.decode(
+                token,
+                self._config.jwt_secret,
+                algorithms=[JWT_ALGORITHM],
+                audience=JWT_AUDIENCE,
+                issuer=JWT_ISSUER,
+            )
+        except JWTError as exc:
+            raise AuthenticationError("Invalid or expired session") from exc
+
+        user_id = payload.get("sub")
+        session_id = payload.get("jti")
+        if not isinstance(user_id, str) or not isinstance(session_id, str):
+            raise AuthenticationError("Invalid or expired session")
+
+        now = _utcnow()
+        with self._session_dao.session() as session:
+            auth_session = (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                    SessionEntity.revoked_at.is_(None),
+                    SessionEntity.idle_expires_at > now,
+                    SessionEntity.absolute_expires_at > now,
+                )
+                .first()
+            )
+            user = (
+                session.query(UserEntity)
+                .filter(UserEntity.user_id == user_id, UserEntity.is_active.is_(True))
+                .first()
+            )
+            if auth_session is None or user is None or user.role not in FIXED_ROLES:
+                raise AuthenticationError("Invalid or expired session")
+
+            auth_session.last_seen_at = now
+            auth_session.idle_expires_at = min(
+                now + timedelta(minutes=self._config.jwt_access_expire_minutes),
+                auth_session.absolute_expires_at,
+            )
+            user_response = UserResponse.from_entity(user)
+
+        return user_response, session_id
+
+    def logout(self, user_id: str, session_id: str) -> None:
+        """Idempotently revoke the current authenticated session."""
+        now = _utcnow()
+        with self._session_dao.session() as session:
+            auth_session = (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                )
+                .first()
+            )
+            if auth_session is not None and auth_session.revoked_at is None:
+                auth_session.revoked_at = now
+                auth_session.revoked_by = user_id
+                auth_session.revoke_reason = "LOGOUT"
+            user = (
+                session.query(UserEntity).filter(UserEntity.user_id == user_id).first()
+            )
+            session.add(
+                self._audit_event(
+                    action="AUTH.LOGOUT",
+                    result="success",
+                    operator_user_id=user_id,
+                    operator_role=user.role if user else None,
+                    target_type="SESSION",
+                    target_id=session_id,
+                )
+            )
+
+    def get_user(self, user_id: str) -> UserResponse:
+        """Return the current non-sensitive user representation."""
+        user = self._dao.get_by_user_id(user_id)
+        if user is None or not user.is_active or user.role not in FIXED_ROLES:
+            raise AuthenticationError("User is not active")
+        return UserResponse.from_entity(user)
+
+    def ensure_initial_admin(self) -> Optional[UserResponse]:
+        """Create the configured first administrator when no active admin exists."""
+        if self._dao.count_active_admins() > 0:
+            return None
+        if not isinstance(self._config.initial_admin_password, str):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_password must be a string"
+            )
+        if not self._config.initial_admin_password:
+            logger.warning(
+                "No initial administrator exists and initial_admin_password is empty"
+            )
+            return None
+
+        if not isinstance(self._config.initial_admin_login, str):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_login must be a string"
+            )
+        login_name = self._config.initial_admin_login.strip()
+        if not login_name or len(login_name) > 128:
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_login must contain 1 to 128 characters"
+            )
+        try:
+            password_hash = self.hash_password(self._config.initial_admin_password)
+        except ValueError as exc:
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_password is invalid"
+            ) from exc
+
+        now = _utcnow()
+        with self._dao.session() as session:
+            if (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.role == "system_admin",
+                    UserEntity.is_active.is_(True),
+                )
+                .count()
+                > 0
+            ):
+                return None
+            if (
+                session.query(UserEntity)
+                .filter(UserEntity.login_name == login_name)
+                .first()
+                is not None
+            ):
+                raise AuthConfigurationError(
+                    "dbgpt.serve.auth.initial_admin_login already exists"
+                )
+            user = UserEntity(
+                user_id=str(uuid.uuid4()),
+                login_name=login_name,
+                display_name=login_name,
+                password_hash=password_hash,
+                role="system_admin",
+                is_active=True,
+                gmt_created=now,
+                gmt_modified=now,
+            )
+            session.add(user)
+            session.flush()
+            session.add(
+                self._audit_event(
+                    action="SYSTEM.INIT_ADMIN",
+                    result="success",
+                    operator_user_id=user.user_id,
+                    operator_role=user.role,
+                    target_id=user.user_id,
+                )
+            )
+            return UserResponse.from_entity(user)
+
+    def _require_jwt_secret(self) -> None:
+        if (
+            not isinstance(self._config.jwt_secret, str)
+            or len(self._config.jwt_secret.encode("utf-8")) < 32
+        ):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.jwt_secret must contain at least 32 bytes"
+            )
+
+    def _validate_config(self) -> None:
+        if not isinstance(self._config.cookie_secure, bool):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.cookie_secure must be a boolean"
+            )
+        positive_integer_fields = (
+            "jwt_access_expire_minutes",
+            "jwt_absolute_expire_minutes",
+            "login_fail_lock_threshold",
+            "login_fail_lock_minutes",
+        )
+        for field_name in positive_integer_fields:
+            value = getattr(self._config, field_name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise AuthConfigurationError(
+                    f"dbgpt.serve.auth.{field_name} must be a positive integer"
+                )
+
+    @staticmethod
+    def _audit_event(
+        action: str,
+        result: str,
+        operator_user_id: Optional[str],
+        operator_role: Optional[str],
+        target_id: Optional[str],
+        target_type: str = "USER",
+        source_ip: str = "",
+        user_agent: str = "",
+        deny_reason: Optional[str] = None,
+    ) -> AuditEventEntity:
+        return AuditEventEntity(
+            event_id=str(uuid.uuid4()),
+            event_time=_utcnow(),
+            operator_user_id=operator_user_id,
+            operator_role_snapshot=operator_role,
+            target_type=target_type,
+            target_id=target_id,
+            action=action,
+            result=result,
+            source_ip=(source_ip or "")[:64] or None,
+            user_agent=(user_agent or "")[:512] or None,
+            deny_reason=deny_reason,
+        )
+
+
+def get_auth_service() -> Service:
+    """Resolve the initialized authorization service from the application."""
+    system_app = Config().SYSTEM_APP
+    if system_app is None:
+        raise AuthConfigurationError("SystemApp is not initialized")
+    return system_app.get_component(SERVE_SERVICE_COMPONENT_NAME, Service)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_alembic_migration.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_alembic_migration.py
@@ -1,0 +1,136 @@
+"""Integration test for the dynamic Alembic migration flow."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Column, Index, Integer, MetaData, String, Table, create_engine
+from sqlalchemy import inspect as sqlalchemy_inspect
+
+from dbgpt.storage.metadata import Model
+from dbgpt_serve.auth.models.models import (  # noqa: F401
+    AccountSetEntity,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
+
+AUTH_TABLES = {
+    "dbgpt_auth_user",
+    "dbgpt_auth_account_set",
+    "dbgpt_auth_user_account_grant",
+    "dbgpt_auth_user_resource_grant",
+    "dbgpt_auth_import_batch",
+    "dbgpt_auth_token_usage",
+    "dbgpt_auth_token_daily",
+    "dbgpt_auth_audit_event",
+    "dbgpt_auth_session",
+}
+
+RESOURCE_INDEXES = {
+    "connect_config": "idx_connect_account_set",
+    "knowledge_space": "idx_ks_account_set",
+    "gpts_app": "idx_app_account_set",
+}
+
+ALEMBIC_ENV = """from alembic import context
+
+config = context.config
+connection = config.attributes["connection"]
+target_metadata = config.attributes["target_metadata"]
+
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_as_batch=connection.dialect.name == "sqlite",
+    compare_type=True,
+)
+
+with context.begin_transaction():
+    context.run_migrations()
+"""
+
+
+def _create_baseline(engine) -> None:
+    metadata = MetaData()
+    for table_name in RESOURCE_INDEXES:
+        Table(table_name, metadata, Column("id", Integer, primary_key=True))
+    metadata.create_all(engine)
+
+
+def _build_target_metadata() -> MetaData:
+    metadata = MetaData()
+    for table_name in AUTH_TABLES:
+        Model.metadata.tables[table_name].to_metadata(metadata)
+    for table_name, index_name in RESOURCE_INDEXES.items():
+        table = Table(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("account_set_id", String(128), nullable=True),
+        )
+        Index(index_name, table.c.account_set_id)
+    return metadata
+
+
+def _create_alembic_config(tmp_path: Path, target_metadata: MetaData) -> Config:
+    script_location = tmp_path / "alembic"
+    versions = script_location / "versions"
+    versions.mkdir(parents=True)
+    (script_location / "env.py").write_text(ALEMBIC_ENV, encoding="utf-8")
+
+    repository_root = Path(__file__).parents[6]
+    template = repository_root / "pilot" / "meta_data" / "alembic" / "script.py.mako"
+    (script_location / "script.py.mako").write_text(
+        template.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    ini_path = tmp_path / "alembic.ini"
+    ini_path.write_text("[alembic]\n", encoding="utf-8")
+    config = Config(str(ini_path))
+    config.set_main_option("script_location", str(script_location))
+    config.attributes["target_metadata"] = target_metadata
+    return config
+
+
+def test_alembic_upgrade_and_downgrade_auth_schema(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+    _create_baseline(engine)
+    config = _create_alembic_config(tmp_path, _build_target_metadata())
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        revision = command.revision(
+            config, message="add authorization center tables", autogenerate=True
+        )
+    assert revision is not None
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, "head")
+
+    inspector = sqlalchemy_inspect(engine)
+    assert AUTH_TABLES <= set(inspector.get_table_names())
+    for table_name, index_name in RESOURCE_INDEXES.items():
+        assert "account_set_id" in {
+            column["name"] for column in inspector.get_columns(table_name)
+        }
+        assert index_name in {
+            index["name"] for index in inspector.get_indexes(table_name)
+        }
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, "base")
+
+    inspector = sqlalchemy_inspect(engine)
+    assert AUTH_TABLES.isdisjoint(inspector.get_table_names())
+    for table_name in RESOURCE_INDEXES:
+        assert "account_set_id" not in {
+            column["name"] for column in inspector.get_columns(table_name)
+        }

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
@@ -1,0 +1,192 @@
+"""HTTP contract tests for authentication endpoints."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.endpoints import router
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import UserEntity
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.utils.auth import (
+    UserRequest,
+    get_current_user,
+    get_user_from_headers,
+    require_permission,
+)
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    auth_service = Service(
+        None,
+        ServeConfig(
+            jwt_secret=TEST_SECRET,
+            cookie_secure=True,
+            jwt_access_expire_minutes=30,
+            jwt_absolute_expire_minutes=120,
+        ),
+    )
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash=auth_service.hash_password("correct-password"),
+                role="query_user",
+                is_active=True,
+            )
+        )
+    return auth_service
+
+
+@pytest.fixture
+def app(service):
+    api = FastAPI()
+    api.include_router(router, prefix="/api/v1/admin")
+    api.dependency_overrides[get_auth_service] = lambda: service
+    return api
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, base_url="https://testserver")
+
+
+def test_login_cookie_me_and_logout(client):
+    login_response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "correct-password"},
+    )
+
+    assert login_response.status_code == 200
+    assert login_response.json()["data"]["user"]["user_id"] == "user-1"
+    assert login_response.headers["cache-control"] == "no-store"
+    assert login_response.headers["pragma"] == "no-cache"
+    set_cookie = login_response.headers["set-cookie"].lower()
+    assert "httponly" in set_cookie
+    assert "secure" in set_cookie
+    assert "samesite=lax" in set_cookie
+
+    me_response = client.get("/api/v1/admin/auth/me")
+    assert me_response.status_code == 200
+    assert me_response.json()["data"]["role"] == "query_user"
+    assert me_response.headers["cache-control"] == "no-store"
+
+    logout_response = client.post("/api/v1/admin/auth/logout")
+    assert logout_response.status_code == 200
+    assert logout_response.headers["cache-control"] == "no-store"
+    assert client.get("/api/v1/admin/auth/me").status_code == 401
+
+
+def test_login_failure_does_not_reveal_account_state(client):
+    existing = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "wrong-password"},
+    )
+    missing = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "missing", "password": "wrong-password"},
+    )
+
+    assert existing.status_code == missing.status_code == 401
+    assert existing.json()["detail"] == missing.json()["detail"]
+
+
+def test_login_handles_password_beyond_bcrypt_limit_as_invalid_credentials(client):
+    response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "密" * 25},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid login name or password"
+    assert "密" * 25 not in response.text
+
+
+def test_bearer_token_authentication(client):
+    login_response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "correct-password"},
+    )
+    token = login_response.json()["data"]["access_token"]
+    client.cookies.clear()
+
+    response = client.get(
+        "/api/v1/admin/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+
+
+def test_legacy_dependency_name_remains_overridable():
+    api = FastAPI()
+
+    @api.get("/legacy")
+    async def legacy(user: UserRequest = Depends(get_user_from_headers)):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_user_from_headers] = lambda: UserRequest(
+        user_id="test-user"
+    )
+    with TestClient(api) as test_client:
+        response = test_client.get("/legacy")
+
+    assert response.status_code == 200
+    assert response.json() == {"user_id": "test-user"}
+
+
+def test_legacy_dependency_no_longer_accepts_mock_user_headers(service):
+    api = FastAPI()
+
+    @api.get("/legacy")
+    async def legacy(user: UserRequest = Depends(get_user_from_headers)):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_auth_service] = lambda: service
+    with TestClient(api) as test_client:
+        response = test_client.get("/legacy", headers={"user-id": "admin"})
+
+    assert response.status_code == 401
+
+
+def test_permission_dependency_uses_fixed_role_capabilities():
+    api = FastAPI()
+
+    @api.get("/chat")
+    async def chat(
+        user: UserRequest = Depends(require_permission("CHAT_USE")),
+    ):
+        return {"user_id": user.user_id}
+
+    @api.get("/users")
+    async def users(
+        user: UserRequest = Depends(require_permission("USER_MANAGE")),
+    ):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_current_user] = lambda: UserRequest(
+        user_id="query-user", role="query_user"
+    )
+    with TestClient(api) as test_client:
+        assert test_client.get("/chat").status_code == 200
+        assert test_client.get("/users").status_code == 403

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
@@ -86,13 +86,28 @@ def test_login_cookie_me_and_logout(client):
     assert "httponly" in set_cookie
     assert "secure" in set_cookie
     assert "samesite=lax" in set_cookie
+    csrf_token = client.cookies["dbgpt_csrf"]
+    csrf_cookie_header = next(
+        header
+        for header in login_response.headers.get_list("set-cookie")
+        if header.startswith("dbgpt_csrf=")
+    ).lower()
+    assert "secure" in csrf_cookie_header
+    assert "samesite=lax" in csrf_cookie_header
+    assert "httponly" not in csrf_cookie_header
 
     me_response = client.get("/api/v1/admin/auth/me")
     assert me_response.status_code == 200
     assert me_response.json()["data"]["role"] == "query_user"
     assert me_response.headers["cache-control"] == "no-store"
 
-    logout_response = client.post("/api/v1/admin/auth/logout")
+    csrf_failure = client.post("/api/v1/admin/auth/logout")
+    assert csrf_failure.status_code == 403
+
+    logout_response = client.post(
+        "/api/v1/admin/auth/logout",
+        headers={"X-CSRF-Token": csrf_token},
+    )
     assert logout_response.status_code == 200
     assert logout_response.headers["cache-control"] == "no-store"
     assert client.get("/api/v1/admin/auth/me").status_code == 401
@@ -136,6 +151,12 @@ def test_bearer_token_authentication(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
+
+    logout_response = client.post(
+        "/api/v1/admin/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert logout_response.status_code == 200
 
 
 def test_legacy_dependency_name_remains_overridable():

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
@@ -180,7 +180,7 @@ def test_initial_admin_is_created_once(service):
     with db.session(commit=False) as session:
         user = session.query(UserEntity).one()
         assert user.password_hash != "initial-password"
-        assert service._password_context.verify("initial-password", user.password_hash)
+        assert service.verify_password("initial-password", user.password_hash)
 
 
 def test_initial_admin_rejects_invalid_bootstrap_credentials(service):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
@@ -1,0 +1,228 @@
+"""Tests for password authentication and server-side sessions."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from jose import jwt
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import (
+    AuditEventEntity,
+    SessionEntity,
+    UserEntity,
+)
+from dbgpt_serve.auth.service.service import (
+    JWT_ALGORITHM,
+    JWT_AUDIENCE,
+    JWT_ISSUER,
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+)
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+def utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    return Service(
+        None,
+        ServeConfig(
+            jwt_secret=TEST_SECRET,
+            jwt_access_expire_minutes=30,
+            jwt_absolute_expire_minutes=120,
+            login_fail_lock_threshold=2,
+            login_fail_lock_minutes=15,
+            cookie_secure=True,
+        ),
+    )
+
+
+def create_user(service, role="query_user", is_active=True):
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash=service.hash_password("correct-password"),
+                role=role,
+                is_active=is_active,
+            )
+        )
+
+
+def test_login_creates_audited_revocable_session(service):
+    create_user(service)
+
+    token, user = service.login("alice", "correct-password", "x" * 100, "test")
+    authenticated_user, session_id = service.authenticate_token(token)
+
+    assert user.user_id == "user-1"
+    assert authenticated_user.role == "query_user"
+    claims = jwt.decode(
+        token,
+        TEST_SECRET,
+        algorithms=[JWT_ALGORITHM],
+        audience=JWT_AUDIENCE,
+        issuer=JWT_ISSUER,
+    )
+    assert "role" not in claims
+    with db.session(commit=False) as session:
+        auth_session = session.query(SessionEntity).one()
+        events = session.query(AuditEventEntity).all()
+        assert auth_session.session_id == session_id
+        assert auth_session.source_ip == "x" * 64
+        assert [event.action for event in events] == ["AUTH.LOGIN"]
+        assert events[0].result == "success"
+        assert events[0].source_ip == "x" * 64
+
+    service.logout("user-1", session_id)
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+    with db.session(commit=False) as session:
+        assert [
+            event.action
+            for event in session.query(AuditEventEntity)
+            .order_by(AuditEventEntity.id)
+            .all()
+        ] == ["AUTH.LOGIN", "AUTH.LOGOUT"]
+
+
+def test_login_failure_is_generic_and_locks_account(service):
+    create_user(service)
+
+    for password in ["wrong-one", "wrong-two"]:
+        with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+            service.login("alice", password, "127.0.0.1", "test")
+
+    with db.session(commit=False) as session:
+        user = session.query(UserEntity).one()
+        assert user.login_fail_count == 2
+        assert user.locked_until is not None
+        assert session.query(AuditEventEntity).count() == 2
+
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("missing", "wrong-two", "127.0.0.1", "test")
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "correct-password", "127.0.0.1", "test")
+    with db.session(commit=False) as session:
+        assert (
+            session.query(AuditEventEntity)
+            .order_by(AuditEventEntity.id.desc())
+            .first()
+            .deny_reason
+            == "ACCOUNT_LOCKED"
+        )
+
+
+def test_authentication_reads_current_role_and_active_state(service):
+    create_user(service)
+    token, _ = service.login("alice", "correct-password", "", "")
+
+    with db.session() as session:
+        user = session.query(UserEntity).one()
+        user.role = "operations_admin"
+    authenticated_user, _ = service.authenticate_token(token)
+    assert authenticated_user.role == "operations_admin"
+
+    with db.session() as session:
+        user = session.query(UserEntity).one()
+        user.is_active = False
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+
+
+def test_invalid_database_role_fails_closed(service):
+    create_user(service, role="invalid_role")
+
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "correct-password", "", "")
+    with db.session(commit=False) as session:
+        assert session.query(AuditEventEntity).one().deny_reason == "INVALID_ROLE"
+
+
+def test_expired_server_session_rejects_otherwise_valid_jwt(service):
+    create_user(service)
+    token, _ = service.login("alice", "correct-password", "", "")
+
+    with db.session() as session:
+        auth_session = session.query(SessionEntity).one()
+        auth_session.idle_expires_at = utcnow() - timedelta(seconds=1)
+
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+
+
+def test_initial_admin_is_created_once(service):
+    service.config.initial_admin_login = "admin"
+    service.config.initial_admin_password = "initial-password"
+
+    created = service.ensure_initial_admin()
+    duplicate = service.ensure_initial_admin()
+
+    assert created is not None
+    assert created.role == "system_admin"
+    assert duplicate is None
+    with db.session(commit=False) as session:
+        user = session.query(UserEntity).one()
+        assert user.password_hash != "initial-password"
+        assert service._password_context.verify("initial-password", user.password_hash)
+
+
+def test_initial_admin_rejects_invalid_bootstrap_credentials(service):
+    service.config.initial_admin_login = " "
+    service.config.initial_admin_password = "initial-password"
+
+    with pytest.raises(AuthConfigurationError, match="initial_admin_login"):
+        service.ensure_initial_admin()
+
+
+def test_invalid_session_or_lock_configuration_fails_closed():
+    with pytest.raises(AuthConfigurationError, match="login_fail_lock_minutes"):
+        Service(None, ServeConfig(login_fail_lock_minutes=0))
+    with pytest.raises(AuthConfigurationError, match="cookie_secure"):
+        Service(None, ServeConfig(cookie_secure="false"))
+
+
+def test_auth_config_masks_secrets_when_printed():
+    config = ServeConfig(
+        jwt_secret="jwt-secret-that-must-not-be-printed",
+        initial_admin_password="admin-password-that-must-not-be-printed",
+    )
+
+    printed_config = str(config)
+    represented_config = repr(config)
+    assert config.jwt_secret not in printed_config
+    assert config.initial_admin_password not in printed_config
+    assert config.jwt_secret not in represented_config
+    assert config.initial_admin_password not in represented_config
+
+
+def test_short_jwt_secret_fails_closed():
+    service = Service(None, ServeConfig(jwt_secret="too-short"))
+
+    with pytest.raises(AuthConfigurationError):
+        service.login("alice", "password", "", "")
+
+
+def test_bcrypt_password_length_is_enforced(service):
+    with pytest.raises(ValueError, match="72 bytes"):
+        service.hash_password("密" * 25)
+
+    create_user(service)
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "密" * 25, "", "")

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_models.py
@@ -1,0 +1,445 @@
+"""Tests for authorization-center persistence models."""
+
+import ast
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventDao,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionDao,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantDao,
+    UserAccountGrantEntity,
+    UserDao,
+    UserEntity,
+    UserResourceGrantDao,
+    UserResourceGrantEntity,
+)
+
+AUTH_TABLE_COLUMNS = {
+    "dbgpt_auth_user": {
+        "id",
+        "user_id",
+        "login_name",
+        "display_name",
+        "password_hash",
+        "role",
+        "is_active",
+        "activation_token",
+        "activation_token_exp",
+        "reset_token",
+        "reset_token_exp",
+        "login_fail_count",
+        "locked_until",
+        "created_by",
+        "disabled_by",
+        "disabled_at",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_account_set": {
+        "id",
+        "account_set_id",
+        "name",
+        "description",
+        "is_active",
+        "created_by",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_user_account_grant": {
+        "id",
+        "grant_id",
+        "user_id",
+        "account_set_id",
+        "is_active",
+        "granted_by",
+        "revoked_by",
+        "revoked_at",
+        "revoke_reason",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_user_resource_grant": {
+        "id",
+        "grant_id",
+        "user_id",
+        "resource_type",
+        "resource_id",
+        "account_set_id",
+        "is_active",
+        "granted_by",
+        "revoked_by",
+        "revoked_at",
+        "revoke_reason",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_import_batch": {
+        "id",
+        "batch_id",
+        "operator_user_id",
+        "source_name",
+        "selected_count",
+        "created_count",
+        "skipped_count",
+        "selected_summary",
+        "result_summary",
+        "gmt_created",
+    },
+    "dbgpt_auth_token_usage": {
+        "id",
+        "call_id",
+        "request_id",
+        "session_id",
+        "user_id",
+        "role_snapshot",
+        "account_set_id",
+        "account_set_snapshot",
+        "entry_resource_type",
+        "entry_resource_id",
+        "agent_id",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "metering_source",
+        "duration_ms",
+        "status",
+        "error_type",
+        "gmt_created",
+    },
+    "dbgpt_auth_token_daily": {
+        "id",
+        "stat_date",
+        "user_id",
+        "role_snapshot",
+        "account_set_id",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "call_count",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_audit_event": {
+        "id",
+        "event_id",
+        "event_time",
+        "operator_user_id",
+        "operator_role_snapshot",
+        "target_account_set_id",
+        "target_type",
+        "target_id",
+        "action",
+        "result",
+        "source_ip",
+        "user_agent",
+        "request_id",
+        "before_snapshot",
+        "after_snapshot",
+        "deny_reason",
+    },
+    "dbgpt_auth_session": {
+        "id",
+        "session_id",
+        "user_id",
+        "issued_at",
+        "last_seen_at",
+        "idle_expires_at",
+        "absolute_expires_at",
+        "revoked_at",
+        "revoked_by",
+        "revoke_reason",
+        "source_ip",
+        "user_agent",
+        "gmt_created",
+        "gmt_modified",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+def test_auth_tables_match_design():
+    inspector = inspect(db.engine)
+    table_names = set(inspector.get_table_names())
+
+    assert AUTH_TABLE_COLUMNS.keys() <= table_names
+    for table_name, expected_columns in AUTH_TABLE_COLUMNS.items():
+        actual_columns = {
+            column["name"] for column in inspector.get_columns(table_name)
+        }
+        assert actual_columns == expected_columns
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "entity_name", "expected_index"),
+    [
+        (
+            "datasource/manages/connect_config_db.py",
+            "ConnectConfigEntity",
+            "idx_connect_account_set",
+        ),
+        ("rag/models/models.py", "KnowledgeSpaceEntity", "idx_ks_account_set"),
+        ("agent/db/gpts_app.py", "GptsAppEntity", "idx_app_account_set"),
+    ],
+)
+def test_resource_models_have_account_set_scope_without_runtime_imports(
+    relative_path, entity_name, expected_index
+):
+    source_path = Path(__file__).parents[2] / relative_path
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    entity = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == entity_name
+    )
+    account_set_assignment = next(
+        node
+        for node in entity.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id == "account_set_id"
+    )
+    column_call = account_set_assignment.value
+    assert isinstance(column_call, ast.Call)
+    assert isinstance(column_call.func, ast.Name)
+    assert column_call.func.id == "Column"
+    string_type = column_call.args[0]
+    assert isinstance(string_type, ast.Call)
+    assert isinstance(string_type.func, ast.Name)
+    assert string_type.func.id == "String"
+    assert isinstance(string_type.args[0], ast.Constant)
+    assert string_type.args[0].value == 128
+    nullable = next(
+        keyword.value for keyword in column_call.keywords if keyword.arg == "nullable"
+    )
+    assert isinstance(nullable, ast.Constant)
+    assert nullable.value is True
+
+    index_names = {
+        argument.value
+        for node in ast.walk(entity)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Index"
+        for argument in node.args[:1]
+        if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+    }
+
+    assert expected_index in index_names
+
+
+def test_migration_registry_imports_all_authorization_entities():
+    repository_root = Path(__file__).parents[6]
+    registry_path = (
+        repository_root
+        / "packages"
+        / "dbgpt-app"
+        / "src"
+        / "dbgpt_app"
+        / "initialization"
+        / "db_model_initialization.py"
+    )
+    module = ast.parse(registry_path.read_text(encoding="utf-8"))
+    registry_assignment = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_MODELS"
+            for target in node.targets
+        )
+    )
+    assert isinstance(registry_assignment.value, ast.List)
+    registered_names = {
+        item.id for item in registry_assignment.value.elts if isinstance(item, ast.Name)
+    }
+
+    assert {
+        "UserEntity",
+        "AccountSetEntity",
+        "UserAccountGrantEntity",
+        "UserResourceGrantEntity",
+        "ImportBatchEntity",
+        "TokenUsageEntity",
+        "TokenDailyEntity",
+        "AuditEventEntity",
+        "SessionEntity",
+        "GptsAppEntity",
+    } <= registered_names
+
+
+def test_user_unique_constraints_and_defaults():
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash="not-a-real-hash",
+                role="query_user",
+            )
+        )
+
+    user = UserDao().get_by_login_name("alice")
+    assert user is not None
+    assert user.is_active is True
+    assert user.login_fail_count == 0
+    assert user.gmt_created is not None
+    assert UserDao().count_active_admins() == 0
+
+    with pytest.raises(IntegrityError):
+        with db.session() as session:
+            session.add(
+                UserEntity(
+                    user_id="user-2",
+                    login_name="alice",
+                    display_name="Other Alice",
+                    password_hash="not-a-real-hash",
+                    role="query_user",
+                )
+            )
+
+
+def test_grant_dao_checks_only_active_grants():
+    with db.session() as session:
+        session.add_all(
+            [
+                UserAccountGrantEntity(
+                    grant_id="account-grant-1",
+                    user_id="user-1",
+                    account_set_id="account-set-1",
+                    granted_by="admin-1",
+                ),
+                UserResourceGrantEntity(
+                    grant_id="resource-grant-1",
+                    user_id="user-1",
+                    resource_type="DATASOURCE",
+                    resource_id="datasource-1",
+                    account_set_id="account-set-1",
+                    granted_by="admin-1",
+                ),
+            ]
+        )
+
+    assert UserAccountGrantDao().has_active_grant("user-1", "account-set-1")
+    assert UserResourceGrantDao().has_active_grant(
+        "user-1", "DATASOURCE", "datasource-1"
+    )
+    assert not UserResourceGrantDao().has_active_grant(
+        "user-1", "KNOWLEDGE_BASE", "datasource-1"
+    )
+
+
+def test_daily_usage_dimensions_are_unique_for_pure_chat():
+    assert TokenUsageEntity.__table__.c.account_set_id.nullable is True
+    assert TokenDailyEntity.__table__.c.account_set_id.nullable is False
+
+    daily = {
+        "stat_date": "2026-07-17",
+        "user_id": "user-1",
+        "role_snapshot": "query_user",
+        "account_set_id": "",
+        "model": "test-model",
+    }
+    with db.session() as session:
+        session.add(TokenDailyEntity(**daily))
+
+    with pytest.raises(IntegrityError):
+        with db.session() as session:
+            session.add(TokenDailyEntity(**daily))
+
+    with db.session() as session:
+        session.add(TokenDailyEntity(**{**daily, "role_snapshot": "operations_admin"}))
+
+
+def test_session_dao_rejects_expired_and_revoked_sessions():
+    now = datetime.now()
+    with db.session() as session:
+        session.add_all(
+            [
+                SessionEntity(
+                    session_id="active-session",
+                    user_id="user-1",
+                    idle_expires_at=now + timedelta(minutes=30),
+                    absolute_expires_at=now + timedelta(hours=8),
+                ),
+                SessionEntity(
+                    session_id="expired-session",
+                    user_id="user-1",
+                    idle_expires_at=now - timedelta(minutes=1),
+                    absolute_expires_at=now + timedelta(hours=8),
+                ),
+                SessionEntity(
+                    session_id="revoked-session",
+                    user_id="user-1",
+                    idle_expires_at=now + timedelta(minutes=30),
+                    absolute_expires_at=now + timedelta(hours=8),
+                    revoked_at=now,
+                ),
+            ]
+        )
+
+    dao = SessionDao()
+    assert dao.get_active_session("active-session", "user-1", now) is not None
+    assert dao.get_active_session("expired-session", "user-1", now) is None
+    assert dao.get_active_session("revoked-session", "user-1", now) is None
+
+
+def test_audit_dao_is_append_only():
+    dao = AuditEventDao()
+    event = dao.append(
+        {
+            "event_id": "event-1",
+            "target_type": "SYSTEM",
+            "action": "MIGRATION.VERIFY",
+            "result": "success",
+        }
+    )
+
+    result = dao.query({"target_type": "SYSTEM"}, page=1, page_size=20)
+    assert event.id is not None
+    assert result.total_count == 1
+    assert result.items[0].event_id == "event-1"
+
+    with pytest.raises(TypeError, match="append-only"):
+        dao.delete({"event_id": "event-1"})
+    with pytest.raises(TypeError, match="append-only"):
+        dao.update({"event_id": "event-1"}, {"result": "error"})
+
+
+def test_all_entity_classes_are_registered():
+    expected_entities = {
+        UserEntity,
+        AccountSetEntity,
+        UserAccountGrantEntity,
+        UserResourceGrantEntity,
+        ImportBatchEntity,
+        TokenUsageEntity,
+        TokenDailyEntity,
+        AuditEventEntity,
+        SessionEntity,
+    }
+
+    assert {entity.__table__.name for entity in expected_entities} == set(
+        AUTH_TABLE_COLUMNS
+    )

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
@@ -44,6 +44,7 @@ class ConnectConfigEntity(Model):
     sys_code = Column(String(128), index=True, nullable=True, comment="System code")
     user_id = Column(String(128), index=True, nullable=True, comment="User id")
     user_name = Column(String(128), index=True, nullable=True, comment="User name")
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     gmt_created = Column(DateTime, default=datetime.now, comment="Record creation time")
     gmt_modified = Column(DateTime, default=datetime.now, comment="Record update time")
     ext_config = Column(
@@ -52,6 +53,7 @@ class ConnectConfigEntity(Model):
     __table_args__ = (
         UniqueConstraint("db_name", name="uk_db"),
         Index("idx_q_db_type", "db_type"),
+        Index("idx_connect_account_set", "account_set_id"),
     )
 
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, Union
 
-from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text
 
 from dbgpt._private.pydantic import model_to_dict
 from dbgpt.storage.metadata import BaseDao, Model
@@ -18,8 +18,11 @@ class KnowledgeSpaceEntity(Model):
     desc = Column(String(100))
     owner = Column(String(100))
     context = Column(Text)
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     gmt_created = Column(DateTime)
     gmt_modified = Column(DateTime)
+
+    __table_args__ = (Index("idx_ks_account_set", "account_set_id"),)
 
     def __repr__(self):
         return (

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,38 +1,117 @@
-import logging
+"""Authentication dependencies shared by DB-GPT HTTP endpoints."""
+
+from datetime import datetime
 from typing import Optional
 
-from fastapi import Header
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from dbgpt._private.pydantic import BaseModel
+from dbgpt._private.pydantic import BaseModel, Field
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.service.service import (
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+    get_auth_service,
+)
 
-logger = logging.getLogger(__name__)
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 class UserRequest(BaseModel):
+    """Current user plus legacy aliases used by existing endpoints."""
+
     user_id: Optional[str] = None
+    login_name: Optional[str] = None
+    display_name: Optional[str] = None
+    role: Optional[str] = "normal"
+    is_active: bool = True
+    session_id: Optional[str] = Field(default=None, exclude=True)
+    gmt_created: Optional[datetime] = None
+    disabled_at: Optional[datetime] = None
+
+    # Compatibility fields for existing endpoint and unit-test call sites.
     user_no: Optional[str] = None
     real_name: Optional[str] = None
-    # same with user_id
     user_name: Optional[str] = None
     user_channel: Optional[str] = None
-    role: Optional[str] = "normal"
     nick_name: Optional[str] = None
     email: Optional[str] = None
     avatar_url: Optional[str] = None
     nick_name_like: Optional[str] = None
 
 
-def get_user_from_headers(user_id: Optional[str] = Header(None)):
+def _not_authenticated() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def get_current_user(
+    request: Request,
+    auth: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    service: Service = Depends(get_auth_service),
+) -> UserRequest:
+    """Authenticate from a bearer token or the secure session cookie."""
+    token = auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    if not token:
+        token = request.cookies.get("dbgpt_session")
+    if not token:
+        raise _not_authenticated()
+
     try:
-        # Mock User Info
-        if user_id:
-            return UserRequest(
-                user_id=user_id, role="admin", nick_name=user_id, real_name=user_id
+        user, session_id = service.authenticate_token(token)
+    except AuthenticationError as exc:
+        raise _not_authenticated() from exc
+    except AuthConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from exc
+
+    return UserRequest(
+        user_id=user.user_id,
+        login_name=user.login_name,
+        display_name=user.display_name,
+        role=user.role,
+        is_active=user.is_active,
+        session_id=session_id,
+        gmt_created=user.gmt_created,
+        disabled_at=user.disabled_at,
+        user_no=user.user_id,
+        real_name=user.display_name,
+        user_name=user.login_name,
+        nick_name=user.display_name,
+    )
+
+
+async def get_user_from_headers(
+    request: Request,
+    auth: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    service: Service = Depends(get_auth_service),
+) -> UserRequest:
+    """Compatibility name for endpoints that previously used mock header auth."""
+    return await get_current_user(request, auth, service)
+
+
+def require_permission(permission: str):
+    """Build a FastAPI dependency that enforces a fixed role permission."""
+
+    async def dependency(
+        user: UserRequest = Depends(get_current_user),
+    ) -> UserRequest:
+        if permission not in ROLE_PERMISSIONS.get(user.role or "", set()):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
             )
-        else:
-            return UserRequest(
-                user_id="001", role="admin", nick_name="dbgpt", real_name="dbgpt"
-            )
-    except Exception as e:
-        logging.exception("Authentication failed!")
-        raise Exception(f"Authentication failed. {str(e)}")
+        return user
+
+    return dependency
+
+
+def require_admin():
+    """Require the system-administrator user-management capability."""
+    return require_permission("USER_MANAGE")

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -16,6 +16,7 @@ from dbgpt_serve.auth.service.service import (
 )
 
 _bearer_scheme = HTTPBearer(auto_error=False)
+_SAFE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 class UserRequest(BaseModel):
@@ -55,7 +56,10 @@ async def get_current_user(
     service: Service = Depends(get_auth_service),
 ) -> UserRequest:
     """Authenticate from a bearer token or the secure session cookie."""
-    token = auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    bearer_token = (
+        auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    )
+    token = bearer_token
     if not token:
         token = request.cookies.get("dbgpt_session")
     if not token:
@@ -70,6 +74,17 @@ async def get_current_user(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Authentication service unavailable",
         ) from exc
+
+    if request.method.upper() not in _SAFE_HTTP_METHODS and not bearer_token:
+        csrf_cookie = request.cookies.get("dbgpt_csrf", "")
+        csrf_header = request.headers.get("x-csrf-token", "")
+        if csrf_cookie != csrf_header or not service.validate_csrf_token(
+            token, csrf_header
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CSRF validation failed",
+            )
 
     return UserRequest(
         user_id=user.user_id,

--- a/uv.lock
+++ b/uv.lock
@@ -6186,7 +6186,6 @@ dependencies = [
     { name = "apscheduler" },
     { name = "bcrypt" },
     { name = "dbgpt-ext" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "python-jose", extra = ["cryptography"] },
 ]
 
@@ -6204,7 +6203,6 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4,<5" },
     { name = "dbgpt-ext", editable = "packages/dbgpt-ext" },
     { name = "libro", marker = "extra == 'libro'", specifier = ">=0.1.25" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "poetry", marker = "extra == 'dbgpts'" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
 ]
@@ -14596,20 +14594,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/9c/9c366aed65acb40a97842ce1375a87b27ea37d735fc9717f7729bae3cc00/partial_json_parser-0.2.1.1.post5.tar.gz", hash = "sha256:992710ac67e90b367921d52727698928040f7713ba7ecb33b96371ea7aec82ca", size = 10313, upload-time = "2025-01-08T15:44:02.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ee/a9476f01f27c74420601be208c6c2c0dd3486681d515e9d765931b89851c/partial_json_parser-0.2.1.1.post5-py3-none-any.whl", hash = "sha256:627715aaa3cb3fb60a65b0d62223243acaa6c70846520a90326fef3a2f0b61ca", size = 10885, upload-time = "2025-01-08T15:44:00.987Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -6184,7 +6184,10 @@ version = "0.8.1"
 source = { editable = "packages/dbgpt-serve" }
 dependencies = [
     { name = "apscheduler" },
+    { name = "bcrypt" },
     { name = "dbgpt-ext" },
+    { name = "passlib", extra = ["bcrypt"] },
+    { name = "python-jose", extra = ["cryptography"] },
 ]
 
 [package.optional-dependencies]
@@ -6198,9 +6201,12 @@ libro = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.10,<4" },
+    { name = "bcrypt", specifier = ">=4,<5" },
     { name = "dbgpt-ext", editable = "packages/dbgpt-ext" },
     { name = "libro", marker = "extra == 'libro'", specifier = ">=0.1.25" },
+    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "poetry", marker = "extra == 'dbgpts'" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
 ]
 provides-extras = ["libro", "dbgpts"]
 
@@ -6455,6 +6461,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186, upload-time = "2024-10-02T17:59:00.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461, upload-time = "2024-10-02T17:58:59.349Z" },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -14581,6 +14599,20 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
+]
+
+[package.optional-dependencies]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
 name = "pathlib-abc"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -15831,6 +15863,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/06/1ef763af20d0572c032fa22882cfbfb005fba6e7300715a37840858c919e/python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba", size = 37399, upload-time = "2023-02-24T06:46:37.282Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/2f/62ea1c8b593f4e093cc1a7768f0d46112107e790c3e478532329e434f00b/python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a", size = 19482, upload-time = "2023-02-24T06:46:36.009Z" },
+]
+
+[[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Stacked PR:** depends on #3142. Review the Phase 2 delta in commits `f9018f5`, `e9c816d`, and `7e360cc`; do not merge before Phase 1.

## Summary

- replace the mock `user-id` header/default administrator with DB-backed password authentication
- add HS256 JWTs backed by revocable server-side sessions with idle and absolute expiry
- add `/api/v1/admin/auth/login`, `/logout`, and `/me`, with HttpOnly/Secure/SameSite cookies and non-cacheable token responses
- define the fixed role capability matrix and fail closed for inactive users, invalid roles, invalid sessions, and unsafe configuration
- register the auth component/router and create the configured first `system_admin` after migrations
- preserve the `get_user_from_headers` and `UserRequest` compatibility surface for existing dependency overrides and direct unit-test construction

## Security decisions

- JWT claims contain identity/session/timing only; current role and active state are loaded from the database on every request
- bcrypt uses 12 rounds directly and is pinned to `<5`; passwords over bcrypt's 72-byte limit are rejected uniformly
- login failures use dummy password verification, account locking, row locking for concurrent attempts, uniform client errors, and detailed internal audit reasons
- JWT and bootstrap password config fields are masked when printed; JWT secrets shorter than 32 bytes fail closed
- cookie-authenticated writes require a session-derived double-submit CSRF token; Bearer clients are unaffected
- logout revokes the server-side session, so a copied JWT cannot be reused

## Configuration

Required before login is available:

- `dbgpt.serve.auth.jwt_secret`: at least 32 bytes
- `dbgpt.serve.auth.initial_admin_password`: bootstrap password, only used when no active system administrator exists

Optional settings include `initial_admin_login`, idle/absolute expiry minutes, login lock threshold/duration, and `cookie_secure` (defaults to true).

## Verification

- `pytest packages/dbgpt-serve/src/dbgpt_serve/auth/tests -q`: 30 passed
- existing `python_upload`, `examples`, and `scheduled_task` compatibility tests: 15 passed, 1 Windows symlink test skipped
- Ruff check and format check: passed
- compileall plus auth config parsing smoke test: passed
- `uv sync --locked --dry-run --package dbgpt-serve --no-dev`: resolved 565 packages
- `pip check`: no broken requirements
- staged diff check and secret scan: passed

`test_skill_upload_api.py` was not executed in the lightweight test environment because importing its unrelated agent/model stack still requires `shortuuid`; the retained `UserRequest` construction and dependency override behavior is covered directly by the new auth endpoint tests.