### PR TITLE
feat(admin): add authenticated frontend shell

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/base.py
+++ b/packages/dbgpt-app/src/dbgpt_app/base.py
@@ -163,6 +163,15 @@ def _migration_db_storage(
             logger.warning(warn_msg)
 
 
+def _init_default_admin(system_app: SystemApp) -> None:
+    """Create the configured first system administrator when required."""
+    from dbgpt_serve.auth.config import SERVE_SERVICE_COMPONENT_NAME
+    from dbgpt_serve.auth.service.service import Service as AuthService
+
+    service = system_app.get_component(SERVE_SERVICE_COMPONENT_NAME, AuthService)
+    service.ensure_initial_admin()
+
+
 def _initialize_db(
     db_url: str,
     db_type: str,

--- a/packages/dbgpt-app/src/dbgpt_app/component_configs.py
+++ b/packages/dbgpt-app/src/dbgpt_app/component_configs.py
@@ -23,6 +23,11 @@ def initialize_components(
     )
     from dbgpt_app.initialization.scheduler import DefaultScheduler
     from dbgpt_app.initialization.serve_initialization import register_serve_apps
+    from dbgpt_serve.auth.config import (
+        SERVE_CONFIG_KEY_PREFIX as AUTH_CONFIG_KEY_PREFIX,
+    )
+    from dbgpt_serve.auth.config import ServeConfig as AuthServeConfig
+    from dbgpt_serve.auth.service.service import Service as AuthService
     from dbgpt_serve.datasource.manages.connector_manager import ConnectorManager
 
     web_config = param.service.web
@@ -37,6 +42,10 @@ def initialize_components(
     system_app.register_instance(controller)
     system_app.register(ConnectorManager)
     system_app.register(StorageManager)
+    auth_config = AuthServeConfig.from_app_config(
+        system_app.config, AUTH_CONFIG_KEY_PREFIX
+    )
+    system_app.register(AuthService, config=auth_config)
 
     from dbgpt_serve.agent.hub.controller import module_plugin
 

--- a/packages/dbgpt-app/src/dbgpt_app/dbgpt_server.py
+++ b/packages/dbgpt-app/src/dbgpt_app/dbgpt_server.py
@@ -27,6 +27,7 @@ from dbgpt.util.utils import (
 )
 from dbgpt_app.base import (
     _create_model_start_listener,
+    _init_default_admin,
     _migration_db_storage,
     server_init,
 )
@@ -68,6 +69,7 @@ def mount_routers(app: FastAPI):
     from dbgpt_app.openapi.api_v2 import router as api_v2
     from dbgpt_serve.agent.app.controller import router as gpts_v1
     from dbgpt_serve.agent.app.endpoints import router as app_v2
+    from dbgpt_serve.auth.api.endpoints import router as auth_admin_router
 
     app.include_router(api_v1, prefix="/api", tags=["Chat"])
     app.include_router(api_v2, prefix="/api", tags=["ChatV2"])
@@ -80,6 +82,7 @@ def mount_routers(app: FastAPI):
     app.include_router(agentic_data_api, prefix="/api", tags=["AgenticData"])
 
     app.include_router(knowledge_router, tags=["Knowledge"])
+    app.include_router(auth_admin_router, prefix="/api/v1/admin", tags=["Admin"])
 
     from dbgpt_serve.agent.app.recommend_question.controller import (
         router as recommend_question_v1,
@@ -167,6 +170,7 @@ def initialize_app(param: ApplicationConfig, args: List[str] = None):
     _migration_db_storage(
         param.service.web.database, web_config.disable_alembic_upgrade
     )
+    _init_default_admin(system_app)
 
     # After init, when the database is ready
     system_app.after_init()

--- a/packages/dbgpt-app/src/dbgpt_app/initialization/db_model_initialization.py
+++ b/packages/dbgpt-app/src/dbgpt_app/initialization/db_model_initialization.py
@@ -10,8 +10,20 @@ from dbgpt_app.share.models import ShareLinkEntity
 from dbgpt_serve.agent.app.recommend_question.recommend_question import (
     RecommendQuestionEntity,
 )
+from dbgpt_serve.agent.db.gpts_app import GptsAppEntity
 from dbgpt_serve.agent.hub.db.my_plugin_db import MyPluginEntity
 from dbgpt_serve.agent.hub.db.plugin_hub_db import PluginHubEntity
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
 from dbgpt_serve.datasource.manages.connect_config_db import ConnectConfigEntity
 from dbgpt_serve.evaluate.db.benchmark_db import BenchmarkSummaryEntity
 from dbgpt_serve.file.models.models import ServeEntity as FileServeEntity
@@ -24,6 +36,15 @@ from dbgpt_serve.rag.models.models import KnowledgeSpaceEntity
 
 _MODELS = [
     PluginHubEntity,
+    UserEntity,
+    AccountSetEntity,
+    UserAccountGrantEntity,
+    UserResourceGrantEntity,
+    ImportBatchEntity,
+    TokenUsageEntity,
+    TokenDailyEntity,
+    AuditEventEntity,
+    SessionEntity,
     FileServeEntity,
     MyPluginEntity,
     PromptManageEntity,
@@ -37,6 +58,7 @@ _MODELS = [
     ModelInstanceEntity,
     FlowServeEntity,
     RecommendQuestionEntity,
+    GptsAppEntity,
     FlowVariableEntity,
     BenchmarkSummaryEntity,
     ShareLinkEntity,

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/api_v1.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/api_v1.py
@@ -47,6 +47,7 @@ from dbgpt_app.openapi.api_view_model import (
 )
 from dbgpt_app.scene import BaseChat, ChatFactory, ChatParam, ChatScene
 from dbgpt_serve.agent.db.gpts_app import UserRecentAppsDao, adapt_native_app_model
+from dbgpt_serve.auth.service.access import AccessService, get_access_service
 from dbgpt_serve.core import blocking_func_to_async
 from dbgpt_serve.datasource.manages.db_conn_info import DBConfig, DbTypeInfo
 from dbgpt_serve.datasource.service.db_summary_client import DBSummaryClient
@@ -509,10 +510,17 @@ async def get_chat_instance(dialogue: ConversationVo = Body()) -> BaseChat:
 async def chat_prepare(
     dialogue: ConversationVo = Body(),
     user_token: UserRequest = Depends(get_user_from_headers),
+    access: AccessService = Depends(get_access_service),
 ):
     logger.info(json.dumps(dialogue.__dict__))
     # dialogue.model_name = CFG.LLM_MODEL
     dialogue.user_name = user_token.user_id if user_token else dialogue.user_name
+    access.require_chat_access(
+        user_token,
+        dialogue.chat_mode,
+        dialogue.select_param,
+        dialogue.app_code,
+    )
     logger.info(f"chat_prepare:{dialogue}")
     ## check conv_uid
     chat: BaseChat = await get_chat_instance(dialogue)
@@ -528,6 +536,7 @@ async def chat_completions(
     dialogue: ConversationVo = Body(),
     flow_service: FlowService = Depends(get_chat_flow),
     user_token: UserRequest = Depends(get_user_from_headers),
+    access: AccessService = Depends(get_access_service),
 ):
     logger.info(
         f"chat_completions:{dialogue.chat_mode},{dialogue.select_param},"
@@ -543,6 +552,12 @@ async def chat_completions(
             # Switch to chat_knowledge mode with selected space
             dialogue.chat_mode = ChatScene.ChatKnowledge.value()
             dialogue.select_param = knowledge_space
+    access.require_chat_access(
+        user_token,
+        dialogue.chat_mode,
+        dialogue.select_param,
+        dialogue.app_code,
+    )
     headers = {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v2.py
@@ -2,10 +2,9 @@ import json
 import re
 import time
 import uuid
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator
 
 from fastapi import APIRouter, Body, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.responses import JSONResponse, StreamingResponse
 
 from dbgpt._private.pydantic import model_to_dict, model_to_json
@@ -33,45 +32,20 @@ from dbgpt_app.openapi.api_v1.api_v1 import (
 from dbgpt_app.scene import BaseChat, ChatParam, ChatScene
 from dbgpt_client.schema import ChatCompletionRequestBody, ChatMode
 from dbgpt_serve.agent.agents.controller import multi_agents
+from dbgpt_serve.auth.service.access import AccessService, get_access_service
 from dbgpt_serve.flow.api.endpoints import get_service
+from dbgpt_serve.utils.auth import UserRequest, get_current_user
 
 router = APIRouter()
 api_settings = APISettings()
-get_bearer_token = HTTPBearer(auto_error=False)
 
 
-async def check_api_key(
-    auth: Optional[HTTPAuthorizationCredentials] = Depends(get_bearer_token),
-    service=Depends(get_service),
-) -> Optional[str]:
-    """Check the api key
-    Args:
-        auth (Optional[HTTPAuthorizationCredentials]): The bearer token.
-        service (Service): The flow service.
-    """
-    if service.config.api_keys:
-        api_keys = [key.strip() for key in service.config.api_keys.split(",")]
-        if auth is None or (token := auth.credentials) not in api_keys:
-            raise HTTPException(
-                status_code=401,
-                detail={
-                    "error": {
-                        "message": "",
-                        "type": "invalid_request_error",
-                        "param": None,
-                        "code": "invalid_api_key",
-                    }
-                },
-            )
-        return token
-    else:
-        return None
-
-
-@router.post("/v2/chat/completions", dependencies=[Depends(check_api_key)])
+@router.post("/v2/chat/completions")
 async def chat_completions(
     request: ChatCompletionRequestBody = Body(),
     service=Depends(get_service),
+    user: UserRequest = Depends(get_current_user),
+    access: AccessService = Depends(get_access_service),
 ):
     """Chat V2 completions
     Args:
@@ -80,6 +54,12 @@ async def chat_completions(
     Raises:
         HTTPException: If the request is invalid.
     """
+    access.require_chat_access(
+        user,
+        request.chat_mode,
+        request.chat_param,
+        getattr(request, "app_code", None),
+    )
     logger.info(
         f"chat_completions:{request.chat_mode},{request.chat_param},{request.model}"
     )

--- a/packages/dbgpt-serve/pyproject.toml
+++ b/packages/dbgpt-serve/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">= 3.10"
 dependencies = [
     "dbgpt-ext",
     "apscheduler>=3.10,<4",
+    "bcrypt>=4,<5",
+    "passlib[bcrypt]>=1.7.4",
+    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.urls]

--- a/packages/dbgpt-serve/pyproject.toml
+++ b/packages/dbgpt-serve/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "dbgpt-ext",
     "apscheduler>=3.10,<4",
     "bcrypt>=4,<5",
-    "passlib[bcrypt]>=1.7.4",
     "python-jose[cryptography]>=3.3.0",
 ]
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/app/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/app/endpoints.py
@@ -1,14 +1,17 @@
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from dbgpt_serve.agent.db.gpts_app import (
     GptsApp,
     GptsAppCollectionDao,
     GptsAppDao,
     GptsAppQuery,
+    GptsAppResponse,
 )
+from dbgpt_serve.auth.service.access import AccessService, get_access_service
 from dbgpt_serve.core import Result
+from dbgpt_serve.utils.auth import UserRequest, require_permission
 
 router = APIRouter()
 gpts_dao = GptsAppDao()
@@ -22,18 +25,37 @@ async def app_list(
     is_collected: Optional[str] = Query(default=None, description="system code"),
     page: int = Query(default=1, description="current page"),
     page_size: int = Query(default=20, description="page size"),
+    operator: UserRequest = Depends(require_permission("AGENT_USE")),
+    access: AccessService = Depends(get_access_service),
 ):
+    allowed_ids = access.allowed_resource_ids(operator, "AGENT")
+    if allowed_ids == set():
+        return Result.succ(
+            GptsAppResponse(
+                total_count=0,
+                total_page=0,
+                current_page=page,
+                app_list=[],
+            )
+        )
     try:
         query = GptsAppQuery(
             page_no=page, page_size=page_size, is_collected=is_collected
         )
+        if allowed_ids is not None:
+            query.app_codes = sorted(allowed_ids)
         return Result.succ(gpts_dao.app_list(query, True))
     except Exception as ex:
         return Result.failed(err_code="E000X", msg=f"query app error: {ex}")
 
 
 @router.get("/v2/serve/apps/{app_id}")
-async def app_detail(app_id: str):
+async def app_detail(
+    app_id: str,
+    operator: UserRequest = Depends(require_permission("AGENT_USE")),
+    access: AccessService = Depends(get_access_service),
+):
+    access.require_resource_access(operator, "AGENT", app_id)
     try:
         return Result.succ(gpts_dao.app_detail(app_id))
     except Exception as ex:
@@ -41,7 +63,22 @@ async def app_detail(app_id: str):
 
 
 @router.put("/v2/serve/apps/{app_id}")
-async def app_update(app_id: str, gpts_app: GptsApp):
+async def app_update(
+    app_id: str,
+    gpts_app: GptsApp,
+    operator: UserRequest = Depends(require_permission("AGENT_MANAGE")),
+    access: AccessService = Depends(get_access_service),
+):
+    resource = access.require_resource_access(operator, "AGENT", app_id, manage=True)
+    if gpts_app.account_set_id not in (None, resource.account_set_id):
+        raise HTTPException(
+            status_code=409,
+            detail="Use the resource account-set impact and assignment APIs",
+        )
+    gpts_app.account_set_id = resource.account_set_id
+    access.require_agent_definition_access(
+        operator, gpts_app.account_set_id, gpts_app.details
+    )
     try:
         return Result.succ(gpts_dao.edit(gpts_app))
     except Exception as ex:
@@ -49,7 +86,16 @@ async def app_update(app_id: str, gpts_app: GptsApp):
 
 
 @router.post("/v2/serve/apps")
-async def app_create(gpts_app: GptsApp):
+async def app_create(
+    gpts_app: GptsApp,
+    operator: UserRequest = Depends(require_permission("AGENT_MANAGE")),
+    access: AccessService = Depends(get_access_service),
+):
+    if not gpts_app.account_set_id:
+        raise HTTPException(status_code=422, detail="account_set_id is required")
+    access.require_agent_definition_access(
+        operator, gpts_app.account_set_id, gpts_app.details
+    )
     try:
         return Result.succ(gpts_dao.create(gpts_app))
     except Exception as ex:
@@ -57,7 +103,14 @@ async def app_create(gpts_app: GptsApp):
 
 
 @router.delete("/v2/serve/apps/{app_id}")
-async def app_delete(app_id: str, user_code: Optional[str], sys_code: Optional[str]):
+async def app_delete(
+    app_id: str,
+    user_code: Optional[str],
+    sys_code: Optional[str],
+    operator: UserRequest = Depends(require_permission("AGENT_MANAGE")),
+    access: AccessService = Depends(get_access_service),
+):
+    access.require_resource_access(operator, "AGENT", app_id, manage=True)
     try:
         gpts_dao.delete(app_id, user_code, sys_code)
         return Result.succ([])

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
@@ -112,6 +112,7 @@ class GptsApp(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     app_code: Optional[str] = None
+    account_set_id: Optional[str] = None
     app_name: Optional[str] = None
     app_describe: Optional[str] = None
     team_mode: Optional[str] = None
@@ -155,6 +156,7 @@ class GptsApp(BaseModel):
     def from_dict(cls, d: Dict[str, Any]):
         return cls(
             app_code=d.get("app_code", None),
+            account_set_id=d.get("account_set_id", None),
             app_name=d["app_name"],
             language=d["language"],
             app_describe=d["app_describe"],
@@ -691,6 +693,7 @@ class GptsAppDao(BaseDao):
     ):
         return {
             "app_code": app_info.app_code,
+            "account_set_id": app_info.account_set_id,
             "app_name": app_info.app_name,
             "language": app_info.language,
             "app_describe": app_info.app_describe,
@@ -850,6 +853,7 @@ class GptsAppDao(BaseDao):
         with self.session() as session:
             app_entity = GptsAppEntity(
                 app_code=gpts_app.app_code if gpts_app.app_code else str(uuid.uuid1()),
+                account_set_id=gpts_app.account_set_id,
                 app_name=gpts_app.app_name,
                 app_describe=gpts_app.app_describe,
                 team_mode=gpts_app.team_mode,
@@ -925,6 +929,7 @@ class GptsAppDao(BaseDao):
             app_entity = app_qry.one()
 
             app_entity.app_name = gpts_app.app_name
+            app_entity.account_set_id = gpts_app.account_set_id
             app_entity.app_describe = gpts_app.app_describe
             app_entity.language = gpts_app.language
             app_entity.team_mode = gpts_app.team_mode

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_app.py
@@ -314,6 +314,7 @@ class GptsAppEntity(Model):
 
     user_code = Column(String(255), nullable=True, comment="user code")
     sys_code = Column(String(255), nullable=True, comment="system app code")
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     published = Column(String(64), nullable=True, comment="published")
 
     param_need = Column(
@@ -331,7 +332,10 @@ class GptsAppEntity(Model):
     )
     admins = Column(Text, nullable=True, comment="administrators")
 
-    __table_args__ = (UniqueConstraint("app_name", name="uk_gpts_app"),)
+    __table_args__ = (
+        UniqueConstraint("app_name", name="uk_gpts_app"),
+        Index("idx_app_account_set", "account_set_id"),
+    )
 
 
 class GptsAppDetailEntity(Model):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication and authorization persistence package."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP API for the authorization center."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -11,21 +11,33 @@ from dbgpt_serve.auth.api.schemas import (
     AccountSetImpactResponse,
     AccountSetResponse,
     AccountSetUpdateRequest,
+    AssignResourceAccountRequest,
     ConfirmImpactRequest,
+    ConfirmRevokeRequest,
     ImportBatchRequest,
     ImportBatchResponse,
     ImportCandidateResponse,
     LoginRequest,
     LoginResponse,
     Page,
+    ResourceImpactResponse,
+    ResourceResponse,
+    ResourceTypeName,
+    RevokeImpactResponse,
+    RevokeRequest,
     RoleName,
     RoleResponse,
     SetPasswordRequest,
+    UserAccountGrantRequest,
+    UserAccountGrantResponse,
     UserCreateRequest,
     UserListRequest,
+    UserResourceGrantRequest,
+    UserResourceGrantResponse,
     UserResponse,
     UserUpdateRequest,
 )
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
 from dbgpt_serve.auth.service.errors import (
     ImpactConfirmationRequiredError,
     ImportSourceError,
@@ -48,6 +60,20 @@ def _prevent_admin_response_caching(response: Response) -> None:
 
 
 router = APIRouter(dependencies=[Depends(_prevent_admin_response_caching)])
+
+
+async def _require_resource_manager(
+    user: UserRequest = Depends(get_current_user),
+) -> UserRequest:
+    permissions = ROLE_PERMISSIONS.get(user.role or "", set())
+    if not permissions.intersection(
+        {"DATASOURCE_MANAGE", "KNOWLEDGE_BASE_MANAGE", "AGENT_MANAGE"}
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied",
+        )
+    return user
 
 
 async def _run_management(method: Callable, *args):
@@ -416,6 +442,235 @@ async def deactivate_account_set(
         False,
         operator,
         request,
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/users/{user_id}/account-grants",
+    response_model=Result[Page[UserAccountGrantResponse]],
+)
+async def list_user_account_grants(
+    user_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    is_active: Optional[bool] = None,
+    operator: UserRequest = Depends(require_permission("USER_ACCOUNT_SET_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[UserAccountGrantResponse]]:
+    result = await _run_management(
+        service.list_user_account_grants,
+        user_id,
+        page,
+        page_size,
+        operator,
+        is_active,
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/users/{user_id}/account-grants",
+    response_model=Result[UserAccountGrantResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def grant_user_account(
+    user_id: str,
+    request: UserAccountGrantRequest,
+    operator: UserRequest = Depends(require_permission("USER_ACCOUNT_SET_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserAccountGrantResponse]:
+    result = await _run_management(
+        service.grant_user_account,
+        user_id,
+        request.account_set_id,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/users/{user_id}/account-grants/{grant_id}/impact",
+    response_model=Result[RevokeImpactResponse],
+)
+async def get_user_account_revoke_impact(
+    user_id: str,
+    grant_id: str,
+    operator: UserRequest = Depends(require_permission("USER_ACCOUNT_SET_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[RevokeImpactResponse]:
+    result = await _run_management(
+        service.get_user_account_revoke_impact,
+        user_id,
+        grant_id,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.delete(
+    "/users/{user_id}/account-grants/{grant_id}",
+    response_model=Result[RevokeImpactResponse],
+)
+async def revoke_user_account(
+    user_id: str,
+    grant_id: str,
+    request: ConfirmRevokeRequest,
+    operator: UserRequest = Depends(require_permission("USER_ACCOUNT_SET_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[RevokeImpactResponse]:
+    result = await _run_management(
+        service.revoke_user_account,
+        user_id,
+        grant_id,
+        request,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/users/{user_id}/resource-grants",
+    response_model=Result[Page[UserResourceGrantResponse]],
+)
+async def list_user_resource_grants(
+    user_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    resource_type: Optional[ResourceTypeName] = None,
+    is_active: Optional[bool] = None,
+    operator: UserRequest = Depends(require_permission("USER_RESOURCE_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[UserResourceGrantResponse]]:
+    result = await _run_management(
+        service.list_user_resource_grants,
+        user_id,
+        page,
+        page_size,
+        operator,
+        resource_type,
+        is_active,
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/users/{user_id}/resource-grants/available",
+    response_model=Result[list[ResourceResponse]],
+)
+async def list_available_user_resources(
+    user_id: str,
+    operator: UserRequest = Depends(require_permission("USER_RESOURCE_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[list[ResourceResponse]]:
+    result = await _run_management(
+        service.list_available_user_resources, user_id, operator
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/users/{user_id}/resource-grants",
+    response_model=Result[UserResourceGrantResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def grant_user_resource(
+    user_id: str,
+    request: UserResourceGrantRequest,
+    operator: UserRequest = Depends(require_permission("USER_RESOURCE_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResourceGrantResponse]:
+    result = await _run_management(
+        service.grant_user_resource,
+        user_id,
+        request.resource_type,
+        request.resource_id,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.delete(
+    "/users/{user_id}/resource-grants/{grant_id}",
+    response_model=Result[UserResourceGrantResponse],
+)
+async def revoke_user_resource(
+    user_id: str,
+    grant_id: str,
+    request: RevokeRequest,
+    operator: UserRequest = Depends(require_permission("USER_RESOURCE_GRANT")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResourceGrantResponse]:
+    result = await _run_management(
+        service.revoke_user_resource,
+        user_id,
+        grant_id,
+        request,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.get("/resources", response_model=Result[Page[ResourceResponse]])
+async def list_managed_resources(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    resource_type: Optional[ResourceTypeName] = None,
+    account_set_id: Optional[str] = Query(default=None, max_length=128),
+    unassigned: bool = False,
+    operator: UserRequest = Depends(_require_resource_manager),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[ResourceResponse]]:
+    result = await _run_management(
+        service.list_managed_resources,
+        page,
+        page_size,
+        operator,
+        resource_type,
+        account_set_id,
+        unassigned,
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/resources/{resource_type}/{resource_id}/impact",
+    response_model=Result[ResourceImpactResponse],
+)
+async def get_resource_impact(
+    resource_type: ResourceTypeName,
+    resource_id: str,
+    new_account_set_id: str = Query(min_length=1, max_length=128),
+    operator: UserRequest = Depends(_require_resource_manager),
+    service: Service = Depends(get_auth_service),
+) -> Result[ResourceImpactResponse]:
+    result = await _run_management(
+        service.get_resource_impact,
+        resource_type,
+        resource_id,
+        new_account_set_id,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.patch(
+    "/resources/{resource_type}/{resource_id}/account-set",
+    response_model=Result[ResourceResponse],
+)
+async def assign_resource_account(
+    resource_type: ResourceTypeName,
+    resource_id: str,
+    request: AssignResourceAccountRequest,
+    operator: UserRequest = Depends(_require_resource_manager),
+    service: Service = Depends(get_auth_service),
+) -> Result[ResourceResponse]:
+    result = await _run_management(
+        service.assign_resource_account,
+        resource_type,
+        resource_id,
+        request,
+        operator,
     )
     return Result.succ(result)
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -1,19 +1,83 @@
 """Authentication endpoints for the administration API."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from typing import Callable, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from starlette.concurrency import run_in_threadpool
 
 from dbgpt.core.schema.api import Result
-from dbgpt_serve.auth.api.schemas import LoginRequest, LoginResponse, UserResponse
+from dbgpt_serve.auth.api.schemas import (
+    AccountSetCreateRequest,
+    AccountSetImpactResponse,
+    AccountSetResponse,
+    AccountSetUpdateRequest,
+    ConfirmImpactRequest,
+    ImportBatchRequest,
+    ImportBatchResponse,
+    ImportCandidateResponse,
+    LoginRequest,
+    LoginResponse,
+    Page,
+    RoleName,
+    RoleResponse,
+    SetPasswordRequest,
+    UserCreateRequest,
+    UserListRequest,
+    UserResponse,
+    UserUpdateRequest,
+)
+from dbgpt_serve.auth.service.errors import (
+    ImpactConfirmationRequiredError,
+    ImportSourceError,
+    ManagementConflictError,
+    ManagementError,
+    ManagementNotFoundError,
+    ManagementValidationError,
+)
 from dbgpt_serve.auth.service.service import (
     AuthConfigurationError,
     AuthenticationError,
     Service,
     get_auth_service,
 )
-from dbgpt_serve.utils.auth import UserRequest, get_current_user
+from dbgpt_serve.utils.auth import UserRequest, get_current_user, require_permission
 
-router = APIRouter()
+
+def _prevent_admin_response_caching(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+
+
+router = APIRouter(dependencies=[Depends(_prevent_admin_response_caching)])
+
+
+async def _run_management(method: Callable, *args):
+    try:
+        return await run_in_threadpool(method, *args)
+    except ManagementNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except (ImpactConfirmationRequiredError, ManagementConflictError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except ManagementValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except ImportSourceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except ManagementError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
 
 
 @router.post("/auth/login", response_model=Result[LoginResponse])
@@ -126,3 +190,278 @@ async def current_user(
             disabled_at=user.disabled_at,
         )
     )
+
+
+@router.get("/users", response_model=Result[Page[UserResponse]])
+async def list_users(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    login_name_like: Optional[str] = Query(default=None, max_length=128),
+    display_name_like: Optional[str] = Query(default=None, max_length=255),
+    role: Optional[RoleName] = None,
+    is_active: Optional[bool] = None,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[UserResponse]]:
+    filters = UserListRequest(
+        login_name_like=login_name_like,
+        display_name_like=display_name_like,
+        role=role,
+        is_active=is_active,
+    )
+    result = await _run_management(
+        service.list_users, filters, page, page_size, operator
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/users", response_model=Result[UserResponse], status_code=status.HTTP_201_CREATED
+)
+async def create_user(
+    request: UserCreateRequest,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResponse]:
+    result = await _run_management(service.create_user, request, operator)
+    return Result.succ(result)
+
+
+@router.get("/users/{user_id}", response_model=Result[UserResponse])
+async def get_user(
+    user_id: str,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResponse]:
+    result = await _run_management(service.get_managed_user, user_id, operator)
+    return Result.succ(result)
+
+
+@router.patch("/users/{user_id}", response_model=Result[UserResponse])
+async def update_user(
+    user_id: str,
+    request: UserUpdateRequest,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResponse]:
+    result = await _run_management(service.update_user, user_id, request, operator)
+    return Result.succ(result)
+
+
+@router.post("/users/{user_id}/activate", response_model=Result[UserResponse])
+async def activate_user(
+    user_id: str,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResponse]:
+    result = await _run_management(service.toggle_user_active, user_id, True, operator)
+    return Result.succ(result)
+
+
+@router.post("/users/{user_id}/deactivate", response_model=Result[UserResponse])
+async def deactivate_user(
+    user_id: str,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[UserResponse]:
+    result = await _run_management(service.toggle_user_active, user_id, False, operator)
+    return Result.succ(result)
+
+
+@router.post("/users/{user_id}/set-password", response_model=Result[None])
+async def set_user_password(
+    user_id: str,
+    request: SetPasswordRequest,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[None]:
+    await _run_management(
+        service.set_password,
+        user_id,
+        request.new_password.get_secret_value(),
+        operator,
+    )
+    return Result.succ(None)
+
+
+@router.get("/roles", response_model=Result[list[RoleResponse]])
+async def list_roles(
+    operator: UserRequest = Depends(require_permission("ROLE_READ")),
+    service: Service = Depends(get_auth_service),
+) -> Result[list[RoleResponse]]:
+    result = await _run_management(service.list_roles, operator)
+    return Result.succ(result)
+
+
+@router.get("/roles/{role}/users", response_model=Result[Page[UserResponse]])
+async def list_role_users(
+    role: RoleName,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    operator: UserRequest = Depends(require_permission("ROLE_READ")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[UserResponse]]:
+    result = await _run_management(
+        service.list_users,
+        UserListRequest(role=role),
+        page,
+        page_size,
+        operator,
+    )
+    return Result.succ(result)
+
+
+@router.get("/account-sets", response_model=Result[Page[AccountSetResponse]])
+async def list_account_sets(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    name_like: Optional[str] = Query(default=None, max_length=255),
+    is_active: Optional[bool] = None,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[AccountSetResponse]]:
+    result = await _run_management(
+        service.list_account_sets,
+        page,
+        page_size,
+        operator,
+        name_like,
+        is_active,
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/account-sets",
+    response_model=Result[AccountSetResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_account_set(
+    request: AccountSetCreateRequest,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetResponse]:
+    result = await _run_management(service.create_account_set, request, operator)
+    return Result.succ(result)
+
+
+@router.get("/account-sets/{account_set_id}", response_model=Result[AccountSetResponse])
+async def get_account_set(
+    account_set_id: str,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetResponse]:
+    result = await _run_management(service.get_account_set, account_set_id, operator)
+    return Result.succ(result)
+
+
+@router.patch(
+    "/account-sets/{account_set_id}", response_model=Result[AccountSetResponse]
+)
+async def update_account_set(
+    account_set_id: str,
+    request: AccountSetUpdateRequest,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetResponse]:
+    result = await _run_management(
+        service.update_account_set, account_set_id, request, operator
+    )
+    return Result.succ(result)
+
+
+@router.get(
+    "/account-sets/{account_set_id}/impact",
+    response_model=Result[AccountSetImpactResponse],
+)
+async def get_account_set_impact(
+    account_set_id: str,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetImpactResponse]:
+    result = await _run_management(
+        service.get_account_set_impact, account_set_id, operator
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/account-sets/{account_set_id}/activate",
+    response_model=Result[AccountSetResponse],
+)
+async def activate_account_set(
+    account_set_id: str,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetResponse]:
+    result = await _run_management(
+        service.toggle_account_set_active, account_set_id, True, operator, None
+    )
+    return Result.succ(result)
+
+
+@router.post(
+    "/account-sets/{account_set_id}/deactivate",
+    response_model=Result[AccountSetResponse],
+)
+async def deactivate_account_set(
+    account_set_id: str,
+    request: ConfirmImpactRequest,
+    operator: UserRequest = Depends(require_permission("ACCOUNT_SET_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[AccountSetResponse]:
+    result = await _run_management(
+        service.toggle_account_set_active,
+        account_set_id,
+        False,
+        operator,
+        request,
+    )
+    return Result.succ(result)
+
+
+@router.get("/import/candidates", response_model=Result[list[ImportCandidateResponse]])
+async def preview_import_candidates(
+    limit: int = Query(default=100, ge=1, le=100),
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[list[ImportCandidateResponse]]:
+    result = await _run_management(service.preview_import_candidates, operator, limit)
+    return Result.succ(result)
+
+
+@router.post(
+    "/import/batch",
+    response_model=Result[ImportBatchResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_import_batch(
+    request: ImportBatchRequest,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[ImportBatchResponse]:
+    result = await _run_management(service.create_from_import, request, operator)
+    return Result.succ(result)
+
+
+@router.get("/import/batches", response_model=Result[Page[ImportBatchResponse]])
+async def list_import_batches(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[Page[ImportBatchResponse]]:
+    result = await _run_management(
+        service.list_import_batches, page, page_size, operator
+    )
+    return Result.succ(result)
+
+
+@router.get("/import/batches/{batch_id}", response_model=Result[ImportBatchResponse])
+async def get_import_batch(
+    batch_id: str,
+    operator: UserRequest = Depends(require_permission("USER_MANAGE")),
+    service: Service = Depends(get_auth_service),
+) -> Result[ImportBatchResponse]:
+    result = await _run_management(service.get_import_batch, batch_id, operator)
+    return Result.succ(result)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -1,0 +1,112 @@
+"""Authentication endpoints for the administration API."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from starlette.concurrency import run_in_threadpool
+
+from dbgpt.core.schema.api import Result
+from dbgpt_serve.auth.api.schemas import LoginRequest, LoginResponse, UserResponse
+from dbgpt_serve.auth.service.service import (
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+    get_auth_service,
+)
+from dbgpt_serve.utils.auth import UserRequest, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/auth/login", response_model=Result[LoginResponse])
+async def login(
+    login_request: LoginRequest,
+    request: Request,
+    response: Response,
+    service: Service = Depends(get_auth_service),
+) -> Result[LoginResponse]:
+    """Authenticate credentials and set the secure session cookie."""
+    source_ip = request.client.host if request.client else ""
+    user_agent = request.headers.get("user-agent", "")
+    try:
+        token, user = await run_in_threadpool(
+            service.login,
+            login_request.login_name,
+            login_request.password,
+            source_ip,
+            user_agent,
+        )
+    except AuthenticationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid login name or password",
+        ) from exc
+    except AuthConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from exc
+
+    response.set_cookie(
+        key="dbgpt_session",
+        value=token,
+        max_age=service.config.jwt_absolute_expire_minutes * 60,
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    return Result.succ(LoginResponse(access_token=token, user=user))
+
+
+@router.post("/auth/logout", response_model=Result[None])
+async def logout(
+    response: Response,
+    user: UserRequest = Depends(get_current_user),
+    service: Service = Depends(get_auth_service),
+) -> Result[None]:
+    """Revoke the current server-side session and clear its cookie."""
+    if not user.user_id or not user.session_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    await run_in_threadpool(service.logout, user.user_id, user.session_id)
+    response.delete_cookie(
+        key="dbgpt_session",
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return Result.succ(None)
+
+
+@router.get("/auth/me", response_model=Result[UserResponse])
+async def current_user(
+    response: Response,
+    user: UserRequest = Depends(get_current_user),
+) -> Result[UserResponse]:
+    """Return the current database-backed user identity."""
+    if (
+        not user.user_id
+        or not user.login_name
+        or not user.display_name
+        or not user.role
+        or user.gmt_created is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    response.headers["Cache-Control"] = "no-store"
+    return Result.succ(
+        UserResponse(
+            user_id=user.user_id,
+            login_name=user.login_name,
+            display_name=user.display_name,
+            role=user.role,
+            is_active=user.is_active,
+            gmt_created=user.gmt_created,
+            disabled_at=user.disabled_at,
+        )
+    )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -1,5 +1,6 @@
 """Authentication endpoints for the administration API."""
 
+from datetime import date, datetime
 from typing import Callable, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -12,6 +13,8 @@ from dbgpt_serve.auth.api.schemas import (
     AccountSetResponse,
     AccountSetUpdateRequest,
     AssignResourceAccountRequest,
+    AuditEventResponse,
+    AuditQueryRequest,
     ConfirmImpactRequest,
     ConfirmRevokeRequest,
     ImportBatchRequest,
@@ -28,6 +31,10 @@ from dbgpt_serve.auth.api.schemas import (
     RoleName,
     RoleResponse,
     SetPasswordRequest,
+    TokenDailyResponse,
+    TokenUsageQueryRequest,
+    TokenUsageResponse,
+    TokenUsageSummaryResponse,
     UserAccountGrantRequest,
     UserAccountGrantResponse,
     UserCreateRequest,
@@ -38,6 +45,7 @@ from dbgpt_serve.auth.api.schemas import (
     UserUpdateRequest,
 )
 from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.service.audit_service import AuditService, get_audit_service
 from dbgpt_serve.auth.service.errors import (
     ImpactConfirmationRequiredError,
     ImportSourceError,
@@ -52,6 +60,7 @@ from dbgpt_serve.auth.service.service import (
     Service,
     get_auth_service,
 )
+from dbgpt_serve.auth.service.token_service import TokenService, get_token_service
 from dbgpt_serve.utils.auth import UserRequest, get_current_user, require_permission
 
 
@@ -720,3 +729,100 @@ async def get_import_batch(
 ) -> Result[ImportBatchResponse]:
     result = await _run_management(service.get_import_batch, batch_id, operator)
     return Result.succ(result)
+
+
+@router.get("/token-usage/summary", response_model=Result[TokenUsageSummaryResponse])
+async def token_usage_summary(
+    stat_date: Optional[date] = None,
+    operator: UserRequest = Depends(require_permission("USAGE_READ")),
+    service: TokenService = Depends(get_token_service),
+) -> Result[TokenUsageSummaryResponse]:
+    result = await _run_management(
+        service.summary, stat_date or service.reporting_date(), operator
+    )
+    return Result.succ(result)
+
+
+@router.get("/token-usage/detail", response_model=Result[Page[TokenUsageResponse]])
+async def token_usage_detail(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    user_id: Optional[str] = Query(default=None, max_length=128),
+    account_set_id: Optional[str] = Query(default=None, max_length=128),
+    model: Optional[str] = Query(default=None, max_length=255),
+    date_from: Optional[date] = None,
+    date_to: Optional[date] = None,
+    role: Optional[RoleName] = None,
+    operator: UserRequest = Depends(require_permission("USAGE_READ")),
+    service: TokenService = Depends(get_token_service),
+) -> Result[Page[TokenUsageResponse]]:
+    filters = TokenUsageQueryRequest(
+        user_id=user_id,
+        account_set_id=account_set_id,
+        model=model,
+        date_from=date_from,
+        date_to=date_to,
+        role=role,
+    )
+    result = await _run_management(
+        service.query_usage, filters, operator, page, page_size
+    )
+    return Result.succ(result)
+
+
+@router.get("/token-usage/daily", response_model=Result[list[TokenDailyResponse]])
+async def token_usage_daily(
+    user_id: Optional[str] = Query(default=None, max_length=128),
+    account_set_id: Optional[str] = Query(default=None, max_length=128),
+    model: Optional[str] = Query(default=None, max_length=255),
+    date_from: Optional[date] = None,
+    date_to: Optional[date] = None,
+    role: Optional[RoleName] = None,
+    operator: UserRequest = Depends(require_permission("USAGE_READ")),
+    service: TokenService = Depends(get_token_service),
+) -> Result[list[TokenDailyResponse]]:
+    filters = TokenUsageQueryRequest(
+        user_id=user_id,
+        account_set_id=account_set_id,
+        model=model,
+        date_from=date_from,
+        date_to=date_to,
+        role=role,
+    )
+    result = await _run_management(service.query_daily, filters, operator)
+    return Result.succ(result)
+
+
+@router.get("/audit", response_model=Result[Page[AuditEventResponse]])
+async def query_audit_events(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    target_type: Optional[str] = Query(default=None, max_length=64),
+    action: Optional[str] = Query(default=None, max_length=64),
+    operator_user_id: Optional[str] = Query(default=None, max_length=128),
+    result: Optional[str] = Query(default=None, pattern="^(success|failed|denied)$"),
+    date_from: Optional[datetime] = None,
+    date_to: Optional[datetime] = None,
+    operator: UserRequest = Depends(require_permission("AUDIT_READ")),
+    service: AuditService = Depends(get_audit_service),
+) -> Result[Page[AuditEventResponse]]:
+    filters = AuditQueryRequest(
+        target_type=target_type,
+        action=action,
+        operator_user_id=operator_user_id,
+        result=result,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    events = await _run_management(service.query, filters, page, page_size, operator)
+    return Result.succ(events)
+
+
+@router.get("/audit/{event_id}", response_model=Result[AuditEventResponse])
+async def get_audit_event(
+    event_id: str,
+    operator: UserRequest = Depends(require_permission("AUDIT_READ")),
+    service: AuditService = Depends(get_audit_service),
+) -> Result[AuditEventResponse]:
+    event = await _run_management(service.get, event_id, operator)
+    return Result.succ(event)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/endpoints.py
@@ -54,6 +54,15 @@ async def login(
         httponly=True,
         samesite="lax",
     )
+    response.set_cookie(
+        key="dbgpt_csrf",
+        value=service.csrf_token(token),
+        max_age=service.config.jwt_absolute_expire_minutes * 60,
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=False,
+        samesite="lax",
+    )
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     return Result.succ(LoginResponse(access_token=token, user=user))
@@ -76,6 +85,13 @@ async def logout(
         path="/",
         secure=service.config.cookie_secure,
         httponly=True,
+        samesite="lax",
+    )
+    response.delete_cookie(
+        key="dbgpt_csrf",
+        path="/",
+        secure=service.config.cookie_secure,
+        httponly=False,
         samesite="lax",
     )
     response.headers["Cache-Control"] = "no-store"

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
@@ -1,0 +1,47 @@
+"""Pydantic schemas for authentication endpoints."""
+
+from datetime import datetime
+
+from dbgpt._private.pydantic import BaseModel, ConfigDict, Field, field_validator
+from dbgpt_serve.auth.models.models import UserEntity
+
+
+class LoginRequest(BaseModel):
+    """Credentials accepted by the login endpoint."""
+
+    login_name: str = Field(min_length=1, max_length=128)
+    password: str
+
+    @field_validator("login_name")
+    @classmethod
+    def normalize_login_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("login_name must not be blank")
+        return value
+
+
+class UserResponse(BaseModel):
+    """Non-sensitive user fields returned by authentication APIs."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: str
+    login_name: str
+    display_name: str
+    role: str
+    is_active: bool
+    gmt_created: datetime
+    disabled_at: datetime | None = None
+
+    @classmethod
+    def from_entity(cls, entity: UserEntity) -> "UserResponse":
+        return cls.model_validate(entity)
+
+
+class LoginResponse(BaseModel):
+    """Successful authentication response."""
+
+    access_token: str
+    token_type: str = "bearer"
+    user: UserResponse

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for authentication endpoints."""
 
 import json
-from datetime import datetime
+from datetime import date, datetime
 from typing import Generic, Literal, Optional, TypeVar
 
 from pydantic import SecretStr, model_validator
@@ -296,6 +296,152 @@ class AssignResourceAccountRequest(BaseModel):
     @classmethod
     def normalize_reason(cls, value: str) -> str:
         return _trim_required(value, "reason")
+
+
+class TokenUsageCreate(BaseModel):
+    """One physical model call to meter exactly once."""
+
+    call_id: str = Field(min_length=1, max_length=128)
+    request_id: str = Field(min_length=1, max_length=128)
+    session_id: Optional[str] = Field(default=None, max_length=128)
+    user_id: str = Field(min_length=1, max_length=128)
+    role_snapshot: RoleName
+    account_set_id: Optional[str] = Field(default=None, max_length=128)
+    account_set_snapshot: Optional[str] = Field(default=None, max_length=255)
+    entry_resource_type: Optional[ResourceTypeName] = None
+    entry_resource_id: Optional[str] = Field(default=None, max_length=128)
+    agent_id: Optional[str] = Field(default=None, max_length=128)
+    model: str = Field(min_length=1, max_length=255)
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    total_tokens: int = Field(default=0, ge=0)
+    metering_source: Literal["provider", "estimated", "unknown"]
+    duration_ms: Optional[int] = Field(default=None, ge=0)
+    status: Literal["success", "failed"]
+    error_type: Optional[str] = Field(default=None, max_length=64)
+    gmt_created: datetime
+
+    @model_validator(mode="after")
+    def validate_token_total(self):
+        if self.metering_source != "unknown" and self.total_tokens != (
+            self.input_tokens + self.output_tokens
+        ):
+            raise ValueError("total_tokens must equal input_tokens + output_tokens")
+        return self
+
+
+class TokenUsageQueryRequest(BaseModel):
+    """Supported filters for usage details and daily aggregates."""
+
+    user_id: Optional[str] = Field(default=None, max_length=128)
+    account_set_id: Optional[str] = Field(default=None, max_length=128)
+    model: Optional[str] = Field(default=None, max_length=255)
+    date_from: Optional[date] = None
+    date_to: Optional[date] = None
+    role: Optional[RoleName] = None
+
+    @model_validator(mode="after")
+    def validate_date_range(self):
+        if self.date_from and self.date_to and self.date_from > self.date_to:
+            raise ValueError("date_from must not be after date_to")
+        return self
+
+
+class TokenUsageResponse(BaseModel):
+    """Stored model-call usage detail."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    call_id: str
+    request_id: str
+    session_id: Optional[str] = None
+    user_id: str
+    role_snapshot: RoleName
+    account_set_id: Optional[str] = None
+    account_set_snapshot: Optional[str] = None
+    entry_resource_type: Optional[ResourceTypeName] = None
+    entry_resource_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    model: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    metering_source: str
+    duration_ms: Optional[int] = None
+    status: str
+    error_type: Optional[str] = None
+    gmt_created: datetime
+
+
+class TokenDailyResponse(BaseModel):
+    """Asia/Shanghai natural-day aggregate."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    stat_date: str
+    user_id: str
+    role_snapshot: RoleName
+    account_set_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    call_count: int
+
+
+class TokenUsageSummaryResponse(BaseModel):
+    """Usage totals for one reporting day and the caller's data scope."""
+
+    stat_date: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    call_count: int
+
+
+class AuditEventCreate(BaseModel):
+    """Sanitized append-only audit event payload."""
+
+    event_id: Optional[str] = Field(default=None, max_length=128)
+    event_time: datetime
+    operator_user_id: Optional[str] = Field(default=None, max_length=128)
+    operator_role_snapshot: Optional[RoleName] = None
+    target_account_set_id: Optional[str] = Field(default=None, max_length=128)
+    target_type: str = Field(min_length=1, max_length=64)
+    target_id: Optional[str] = Field(default=None, max_length=128)
+    action: str = Field(min_length=1, max_length=64)
+    result: Literal["success", "failed", "denied"]
+    source_ip: Optional[str] = Field(default=None, max_length=64)
+    user_agent: Optional[str] = Field(default=None, max_length=512)
+    request_id: Optional[str] = Field(default=None, max_length=128)
+    before_snapshot: Optional[str] = None
+    after_snapshot: Optional[str] = None
+    deny_reason: Optional[str] = Field(default=None, max_length=512)
+
+
+class AuditQueryRequest(BaseModel):
+    """Indexed audit filters plus an event-time range."""
+
+    target_type: Optional[str] = Field(default=None, max_length=64)
+    action: Optional[str] = Field(default=None, max_length=64)
+    operator_user_id: Optional[str] = Field(default=None, max_length=128)
+    result: Optional[Literal["success", "failed", "denied"]] = None
+    date_from: Optional[datetime] = None
+    date_to: Optional[datetime] = None
+
+    @model_validator(mode="after")
+    def validate_date_range(self):
+        if self.date_from and self.date_to and self.date_from > self.date_to:
+            raise ValueError("date_from must not be after date_to")
+        return self
+
+
+class AuditEventResponse(AuditEventCreate):
+    """Persisted audit event returned to a system administrator."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    event_id: str
 
 
 class ImportCandidateResponse(BaseModel):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
@@ -12,6 +12,7 @@ from dbgpt_serve.auth.models.models import UserEntity
 T = TypeVar("T")
 RoleName = Literal["system_admin", "operations_admin", "query_user"]
 CreatableRoleName = Literal["operations_admin", "query_user"]
+ResourceTypeName = Literal["DATASOURCE", "KNOWLEDGE_BASE", "AGENT"]
 
 
 def _trim_required(value: str, field_name: str) -> str:
@@ -185,6 +186,116 @@ class RoleResponse(BaseModel):
     role: RoleName
     permissions: list[str]
     user_count: int
+
+
+class UserAccountGrantRequest(BaseModel):
+    """Grant one active account set to a non-system administrator."""
+
+    account_set_id: str = Field(min_length=1, max_length=128)
+
+
+class UserAccountGrantResponse(BaseModel):
+    """Persisted user account-set grant."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    grant_id: str
+    user_id: str
+    account_set_id: str
+    is_active: bool
+    granted_by: str
+    revoked_by: Optional[str] = None
+    revoked_at: Optional[datetime] = None
+    revoke_reason: Optional[str] = None
+    gmt_created: datetime
+
+
+class UserResourceGrantRequest(BaseModel):
+    """Grant one concrete protected resource to a query user."""
+
+    resource_type: ResourceTypeName
+    resource_id: str = Field(min_length=1, max_length=128)
+
+
+class UserResourceGrantResponse(BaseModel):
+    """Persisted query-user resource grant."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    grant_id: str
+    user_id: str
+    resource_type: ResourceTypeName
+    resource_id: str
+    account_set_id: str
+    is_active: bool
+    granted_by: str
+    revoked_by: Optional[str] = None
+    revoked_at: Optional[datetime] = None
+    revoke_reason: Optional[str] = None
+    gmt_created: datetime
+
+
+class RevokeRequest(BaseModel):
+    """Reason required for an auditable grant revocation."""
+
+    reason: str = Field(min_length=1, max_length=512)
+
+    @field_validator("reason")
+    @classmethod
+    def normalize_reason(cls, value: str) -> str:
+        return _trim_required(value, "reason")
+
+
+class ConfirmRevokeRequest(RevokeRequest):
+    """Current-impact confirmation for account-set grant revocation."""
+
+    confirm_impact: bool = False
+    impact_token: str = Field(min_length=64, max_length=64)
+
+
+class RevokeImpactResponse(BaseModel):
+    """Resource grants affected by revoking a user's account-set scope."""
+
+    grant_id: str
+    affected_resource_grants: int
+    affected_grants_detail: list[dict]
+    impact_token: str
+
+
+class ResourceResponse(BaseModel):
+    """Common administration view over all protected resource types."""
+
+    resource_type: ResourceTypeName
+    resource_id: str
+    name: str
+    account_set_id: Optional[str] = None
+
+
+class ResourceImpactResponse(BaseModel):
+    """Current grant impact of changing a resource's account-set owner."""
+
+    resource_type: ResourceTypeName
+    resource_id: str
+    current_account_set_id: Optional[str] = None
+    new_account_set_id: str
+    affected_resource_grants: int
+    affected_agent_grants: int
+    affected_grants_detail: list[dict]
+    impact_token: str
+
+
+class AssignResourceAccountRequest(BaseModel):
+    """Confirmed high-risk account-set assignment for a resource."""
+
+    account_set_id: str = Field(min_length=1, max_length=128)
+    reason: str = Field(min_length=1, max_length=512)
+    confirm_impact: bool = False
+    impact_token: str = Field(min_length=64, max_length=64)
+
+    @field_validator("reason")
+    @classmethod
+    def normalize_reason(cls, value: str) -> str:
+        return _trim_required(value, "reason")
 
 
 class ImportCandidateResponse(BaseModel):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/api/schemas.py
@@ -1,9 +1,24 @@
 """Pydantic schemas for authentication endpoints."""
 
+import json
 from datetime import datetime
+from typing import Generic, Literal, Optional, TypeVar
+
+from pydantic import SecretStr, model_validator
 
 from dbgpt._private.pydantic import BaseModel, ConfigDict, Field, field_validator
 from dbgpt_serve.auth.models.models import UserEntity
+
+T = TypeVar("T")
+RoleName = Literal["system_admin", "operations_admin", "query_user"]
+CreatableRoleName = Literal["operations_admin", "query_user"]
+
+
+def _trim_required(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
 
 
 class LoginRequest(BaseModel):
@@ -37,6 +52,217 @@ class UserResponse(BaseModel):
     @classmethod
     def from_entity(cls, entity: UserEntity) -> "UserResponse":
         return cls.model_validate(entity)
+
+
+class UserCreateRequest(BaseModel):
+    """Administrator-supplied fields for a new independent DB-GPT user."""
+
+    login_name: str = Field(min_length=1, max_length=128)
+    display_name: str = Field(min_length=1, max_length=255)
+    role: CreatableRoleName
+    initial_password: Optional[SecretStr] = None
+    send_activation: bool = False
+    initial_account_set_ids: list[str] = Field(default_factory=list, max_length=100)
+
+    @field_validator("login_name", "display_name")
+    @classmethod
+    def normalize_required_text(cls, value: str, info) -> str:
+        return _trim_required(value, info.field_name)
+
+    @field_validator("login_name")
+    @classmethod
+    def reject_login_whitespace(cls, value: str) -> str:
+        if any(character.isspace() for character in value):
+            raise ValueError("login_name must not contain whitespace")
+        return value
+
+
+class UserUpdateRequest(BaseModel):
+    """Partial user update with explicit confirmation for role changes."""
+
+    display_name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    role: Optional[RoleName] = None
+    change_reason: Optional[str] = Field(default=None, max_length=512)
+    confirm_role_change: bool = False
+
+    @field_validator("display_name", "change_reason")
+    @classmethod
+    def normalize_optional_text(cls, value: Optional[str], info) -> Optional[str]:
+        if value is None:
+            return None
+        return _trim_required(value, info.field_name)
+
+    @model_validator(mode="after")
+    def require_update_field(self):
+        if self.display_name is None and self.role is None:
+            raise ValueError("At least one user field must be updated")
+        return self
+
+
+class UserListRequest(BaseModel):
+    """Supported user list filters."""
+
+    login_name_like: Optional[str] = Field(default=None, max_length=128)
+    display_name_like: Optional[str] = Field(default=None, max_length=255)
+    role: Optional[RoleName] = None
+    is_active: Optional[bool] = None
+
+
+class SetPasswordRequest(BaseModel):
+    """Administrative password replacement."""
+
+    new_password: SecretStr
+
+
+class AccountSetCreateRequest(BaseModel):
+    """Create an internal account-set directory entry."""
+
+    name: str = Field(min_length=1, max_length=255)
+    description: Optional[str] = Field(default=None, max_length=4000)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        return _trim_required(value, "name")
+
+
+class AccountSetUpdateRequest(BaseModel):
+    """Partial account-set directory update."""
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    description: Optional[str] = Field(default=None, max_length=4000)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: Optional[str]) -> Optional[str]:
+        return _trim_required(value, "name") if value is not None else None
+
+    @model_validator(mode="after")
+    def require_update_field(self):
+        if not self.model_fields_set.intersection({"name", "description"}):
+            raise ValueError("At least one account-set field must be updated")
+        return self
+
+
+class AccountSetResponse(BaseModel):
+    """Public account-set directory fields."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    account_set_id: str
+    name: str
+    description: Optional[str] = None
+    is_active: bool
+    gmt_created: datetime
+
+
+class ConfirmImpactRequest(BaseModel):
+    """Confirmation payload for a high-risk state change."""
+
+    reason: str = Field(min_length=1, max_length=512)
+    confirm_impact: bool = False
+    impact_token: str = Field(min_length=64, max_length=64)
+
+    @field_validator("reason")
+    @classmethod
+    def normalize_reason(cls, value: str) -> str:
+        return _trim_required(value, "reason")
+
+
+class AccountSetImpactResponse(BaseModel):
+    """Current impact snapshot for account-set deactivation."""
+
+    account_set_id: str
+    user_grant_count: int
+    resource_grant_count: int
+    resource_count: int
+    impact_token: str
+
+
+class RoleResponse(BaseModel):
+    """Read-only fixed role and capability group."""
+
+    role: RoleName
+    permissions: list[str]
+    user_count: int
+
+
+class ImportCandidateResponse(BaseModel):
+    """Allowed LSZYZD candidate fields only."""
+
+    employee_no: str
+    name: str
+    is_enabled: Optional[bool] = None
+    category: Optional[str] = None
+    position: Optional[str] = None
+    team: Optional[str] = None
+    role_label: Optional[str] = None
+
+
+class ImportUserRequest(BaseModel):
+    """Administrator choices for one imported independent account."""
+
+    employee_no: str = Field(min_length=1, max_length=128)
+    login_name: str = Field(min_length=1, max_length=128)
+    role: CreatableRoleName
+    initial_password: SecretStr
+    initial_account_set_ids: list[str] = Field(default_factory=list, max_length=100)
+
+    @field_validator("employee_no", "login_name")
+    @classmethod
+    def normalize_required_text(cls, value: str, info) -> str:
+        return _trim_required(value, info.field_name)
+
+
+class ImportBatchRequest(BaseModel):
+    """Commit a bounded one-time LSZYZD selection."""
+
+    users: list[ImportUserRequest] = Field(min_length=1, max_length=100)
+
+    @model_validator(mode="after")
+    def require_unique_selection(self):
+        employee_numbers = [item.employee_no for item in self.users]
+        login_names = [item.login_name for item in self.users]
+        if len(employee_numbers) != len(set(employee_numbers)):
+            raise ValueError("employee_no values must be unique within a batch")
+        if len(login_names) != len(set(login_names)):
+            raise ValueError("login_name values must be unique within a batch")
+        return self
+
+
+class ImportBatchResponse(BaseModel):
+    """Password-free result and duplicate-reminder summary."""
+
+    batch_id: str
+    source_name: str
+    selected_count: int
+    created_count: int
+    skipped_count: int
+    selected_summary: list[dict]
+    result_summary: list[dict]
+    gmt_created: datetime
+
+    @classmethod
+    def from_entity(cls, entity) -> "ImportBatchResponse":
+        return cls(
+            batch_id=entity.batch_id,
+            source_name=entity.source_name,
+            selected_count=entity.selected_count,
+            created_count=entity.created_count,
+            skipped_count=entity.skipped_count,
+            selected_summary=json.loads(entity.selected_summary or "[]"),
+            result_summary=json.loads(entity.result_summary or "[]"),
+            gmt_created=entity.gmt_created,
+        )
+
+
+class Page(BaseModel, Generic[T]):
+    """Stable administration pagination envelope."""
+
+    items: list[T]
+    total: int
+    page: int
+    page_size: int
 
 
 class LoginResponse(BaseModel):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
@@ -1,0 +1,28 @@
+"""Configuration for the authorization service."""
+
+from dataclasses import dataclass, field
+
+from dbgpt_serve.core.config import BaseServeConfig
+
+APP_NAME = "auth"
+SERVE_APP_NAME = "dbgpt_auth"
+SERVE_CONFIG_KEY_PREFIX = "dbgpt.serve.auth."
+SERVE_SERVICE_COMPONENT_NAME = f"{SERVE_APP_NAME}_service"
+
+
+@dataclass
+class ServeConfig(BaseServeConfig):
+    """Authorization service configuration."""
+
+    __type__ = APP_NAME
+
+    jwt_secret: str = field(default="", repr=False, metadata={"tags": "privacy"})
+    jwt_access_expire_minutes: int = field(default=480)
+    jwt_absolute_expire_minutes: int = field(default=1440)
+    login_fail_lock_threshold: int = field(default=5)
+    login_fail_lock_minutes: int = field(default=30)
+    initial_admin_login: str = field(default="admin")
+    initial_admin_password: str = field(
+        default="", repr=False, metadata={"tags": "privacy"}
+    )
+    cookie_secure: bool = field(default=True)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/config.py
@@ -21,6 +21,8 @@ class ServeConfig(BaseServeConfig):
     jwt_absolute_expire_minutes: int = field(default=1440)
     login_fail_lock_threshold: int = field(default=5)
     login_fail_lock_minutes: int = field(default=30)
+    lszyzd_datasource: str = field(default="LSZYZD")
+    lszyzd_table: str = field(default="LSZYZD")
     initial_admin_login: str = field(default="admin")
     initial_admin_password: str = field(
         default="", repr=False, metadata={"tags": "privacy"}

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/constants.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/constants.py
@@ -1,0 +1,46 @@
+"""Fixed roles and capability groups for the authorization center."""
+
+ROLE_PERMISSIONS: dict[str, frozenset[str]] = {
+    "system_admin": frozenset(
+        {
+            "USER_MANAGE",
+            "ROLE_READ",
+            "USER_ROLE_ASSIGN",
+            "ACCOUNT_SET_MANAGE",
+            "USER_ACCOUNT_SET_GRANT",
+            "USER_RESOURCE_GRANT",
+            "DATASOURCE_MANAGE",
+            "KNOWLEDGE_BASE_MANAGE",
+            "AGENT_MANAGE",
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+            "AUDIT_READ",
+        }
+    ),
+    "operations_admin": frozenset(
+        {
+            "DATASOURCE_MANAGE",
+            "KNOWLEDGE_BASE_MANAGE",
+            "AGENT_MANAGE",
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+        }
+    ),
+    "query_user": frozenset(
+        {
+            "DATASOURCE_USE",
+            "KNOWLEDGE_BASE_USE",
+            "AGENT_USE",
+            "CHAT_USE",
+            "USAGE_READ",
+        }
+    ),
+}
+
+FIXED_ROLES = frozenset(ROLE_PERMISSIONS)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/models/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/models/__init__.py
@@ -1,0 +1,43 @@
+"""Authentication and authorization database models."""
+
+from .models import (
+    AccountSetDao,
+    AccountSetEntity,
+    AuditEventDao,
+    AuditEventEntity,
+    ImportBatchDao,
+    ImportBatchEntity,
+    SessionDao,
+    SessionEntity,
+    TokenDailyDao,
+    TokenDailyEntity,
+    TokenUsageDao,
+    TokenUsageEntity,
+    UserAccountGrantDao,
+    UserAccountGrantEntity,
+    UserDao,
+    UserEntity,
+    UserResourceGrantDao,
+    UserResourceGrantEntity,
+)
+
+__all__ = [
+    "AccountSetDao",
+    "AccountSetEntity",
+    "AuditEventDao",
+    "AuditEventEntity",
+    "ImportBatchDao",
+    "ImportBatchEntity",
+    "SessionDao",
+    "SessionEntity",
+    "TokenDailyDao",
+    "TokenDailyEntity",
+    "TokenUsageDao",
+    "TokenUsageEntity",
+    "UserAccountGrantDao",
+    "UserAccountGrantEntity",
+    "UserDao",
+    "UserEntity",
+    "UserResourceGrantDao",
+    "UserResourceGrantEntity",
+]

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/models/models.py
@@ -1,0 +1,522 @@
+"""Database entities and DAOs for the authorization center."""
+
+from datetime import datetime
+from typing import Any, Dict, Optional, Union
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+
+from dbgpt.storage.metadata import BaseDao, Model
+from dbgpt.util.pagination_utils import PaginationResult
+
+
+class UserEntity(Model):
+    """DB-GPT user account."""
+
+    __tablename__ = "dbgpt_auth_user"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(128), nullable=False)
+    login_name = Column(String(128), nullable=False)
+    display_name = Column(String(255), nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    role = Column(String(64), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    activation_token = Column(String(255), nullable=True)
+    activation_token_exp = Column(DateTime, nullable=True)
+    reset_token = Column(String(255), nullable=True)
+    reset_token_exp = Column(DateTime, nullable=True)
+    login_fail_count = Column(Integer, nullable=False, default=0)
+    locked_until = Column(DateTime, nullable=True)
+    created_by = Column(String(128), nullable=True)
+    disabled_by = Column(String(128), nullable=True)
+    disabled_at = Column(DateTime, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uk_dbgpt_auth_user_user_id"),
+        UniqueConstraint("login_name", name="uk_dbgpt_auth_user_login_name"),
+        Index("ix_dbgpt_auth_user_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_login_name", "login_name"),
+    )
+
+
+class AccountSetEntity(Model):
+    """ERP or MES account set managed by DB-GPT."""
+
+    __tablename__ = "dbgpt_auth_account_set"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_set_id = Column(String(128), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_by = Column(String(128), nullable=False)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "account_set_id", name="uk_dbgpt_auth_account_set_business_id"
+        ),
+        UniqueConstraint("name", name="uk_dbgpt_auth_account_set_name"),
+        Index("ix_dbgpt_auth_account_set_id", "account_set_id"),
+    )
+
+
+class UserAccountGrantEntity(Model):
+    """Account-set scope granted to a user."""
+
+    __tablename__ = "dbgpt_auth_user_account_grant"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    grant_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    account_set_id = Column(String(128), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    granted_by = Column(String(128), nullable=False)
+    revoked_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+    revoke_reason = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("grant_id", name="uk_dbgpt_auth_user_account_grant_id"),
+        UniqueConstraint(
+            "user_id",
+            "account_set_id",
+            name="uk_dbgpt_auth_user_account_grant_scope",
+        ),
+        Index("ix_dbgpt_auth_user_account_grant_id", "grant_id"),
+        Index("ix_dbgpt_auth_user_account_grant_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_account_grant_account_set_id", "account_set_id"),
+    )
+
+
+class UserResourceGrantEntity(Model):
+    """Specific resource granted to a query user."""
+
+    __tablename__ = "dbgpt_auth_user_resource_grant"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    grant_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    resource_type = Column(String(64), nullable=False)
+    resource_id = Column(String(128), nullable=False)
+    account_set_id = Column(String(128), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    granted_by = Column(String(128), nullable=False)
+    revoked_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+    revoke_reason = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("grant_id", name="uk_dbgpt_auth_user_resource_grant_id"),
+        UniqueConstraint(
+            "user_id",
+            "resource_type",
+            "resource_id",
+            name="uk_dbgpt_auth_user_resource_grant_resource",
+        ),
+        Index("ix_dbgpt_auth_user_resource_grant_id", "grant_id"),
+        Index("ix_dbgpt_auth_user_resource_grant_user_id", "user_id"),
+        Index("ix_dbgpt_auth_user_resource_grant_resource_id", "resource_id"),
+    )
+
+
+class ImportBatchEntity(Model):
+    """Audit summary for a one-time external user import."""
+
+    __tablename__ = "dbgpt_auth_import_batch"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    batch_id = Column(String(128), nullable=False, unique=True)
+    operator_user_id = Column(String(128), nullable=False)
+    source_name = Column(String(255), nullable=False)
+    selected_count = Column(Integer, nullable=False)
+    created_count = Column(Integer, nullable=False, default=0)
+    skipped_count = Column(Integer, nullable=False, default=0)
+    selected_summary = Column(Text, nullable=True)
+    result_summary = Column(Text, nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+
+
+class TokenUsageEntity(Model):
+    """One physical model call and its metering result."""
+
+    __tablename__ = "dbgpt_auth_token_usage"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    call_id = Column(String(128), nullable=False)
+    request_id = Column(String(128), nullable=False)
+    session_id = Column(String(128), nullable=True)
+    user_id = Column(String(128), nullable=False)
+    role_snapshot = Column(String(64), nullable=False)
+    account_set_id = Column(String(128), nullable=True)
+    account_set_snapshot = Column(String(255), nullable=True)
+    entry_resource_type = Column(String(64), nullable=True)
+    entry_resource_id = Column(String(128), nullable=True)
+    agent_id = Column(String(128), nullable=True)
+    model = Column(String(255), nullable=False)
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    metering_source = Column(String(64), nullable=False)
+    duration_ms = Column(Integer, nullable=True)
+    status = Column(String(32), nullable=False)
+    error_type = Column(String(64), nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint("call_id", name="uk_dbgpt_auth_token_usage_call_id"),
+        Index("ix_dbgpt_auth_token_usage_call_id", "call_id"),
+        Index("ix_dbgpt_auth_token_usage_request_id", "request_id"),
+        Index("ix_dbgpt_auth_token_usage_session_id", "session_id"),
+        Index("ix_dbgpt_auth_token_usage_user_id", "user_id"),
+        Index("ix_dbgpt_auth_token_usage_account_set_id", "account_set_id"),
+        Index("ix_dbgpt_auth_token_usage_gmt_created", "gmt_created"),
+    )
+
+
+class TokenDailyEntity(Model):
+    """Daily token aggregation in the Asia/Shanghai reporting timezone."""
+
+    __tablename__ = "dbgpt_auth_token_daily"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    stat_date = Column(String(10), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    role_snapshot = Column(String(64), nullable=False)
+    account_set_id = Column(String(128), nullable=False, default="")
+    model = Column(String(255), nullable=False)
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    call_count = Column(Integer, nullable=False, default=0)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "stat_date",
+            "user_id",
+            "role_snapshot",
+            "account_set_id",
+            "model",
+            name="uk_dbgpt_auth_token_daily_dimensions",
+        ),
+        Index("ix_dbgpt_auth_token_daily_stat_date", "stat_date"),
+        Index("ix_dbgpt_auth_token_daily_user_id", "user_id"),
+        Index("ix_dbgpt_auth_token_daily_account_set_id", "account_set_id"),
+    )
+
+
+class AuditEventEntity(Model):
+    """Append-only security and administrative audit event."""
+
+    __tablename__ = "dbgpt_auth_audit_event"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_id = Column(String(128), nullable=False)
+    event_time = Column(DateTime, nullable=False, default=datetime.now)
+    operator_user_id = Column(String(128), nullable=True)
+    operator_role_snapshot = Column(String(64), nullable=True)
+    target_account_set_id = Column(String(128), nullable=True)
+    target_type = Column(String(64), nullable=False)
+    target_id = Column(String(128), nullable=True)
+    action = Column(String(64), nullable=False)
+    result = Column(String(32), nullable=False)
+    source_ip = Column(String(64), nullable=True)
+    user_agent = Column(String(512), nullable=True)
+    request_id = Column(String(128), nullable=True)
+    before_snapshot = Column(Text, nullable=True)
+    after_snapshot = Column(Text, nullable=True)
+    deny_reason = Column(String(512), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("event_id", name="uk_dbgpt_auth_audit_event_id"),
+        Index("ix_dbgpt_auth_audit_event_event_id", "event_id"),
+        Index("ix_dbgpt_auth_audit_event_event_time", "event_time"),
+        Index("ix_dbgpt_auth_audit_event_operator_user_id", "operator_user_id"),
+        Index(
+            "ix_dbgpt_auth_audit_event_target_account_set_id",
+            "target_account_set_id",
+        ),
+        Index("ix_dbgpt_auth_audit_event_target_type", "target_type"),
+        Index("ix_dbgpt_auth_audit_event_target_id", "target_id"),
+        Index("ix_dbgpt_auth_audit_event_request_id", "request_id"),
+    )
+
+
+class SessionEntity(Model):
+    """Server-side state for a revocable authenticated session."""
+
+    __tablename__ = "dbgpt_auth_session"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(128), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    issued_at = Column(DateTime, nullable=False, default=datetime.now)
+    last_seen_at = Column(DateTime, nullable=False, default=datetime.now)
+    idle_expires_at = Column(DateTime, nullable=False)
+    absolute_expires_at = Column(DateTime, nullable=False)
+    revoked_at = Column(DateTime, nullable=True)
+    revoked_by = Column(String(128), nullable=True)
+    revoke_reason = Column(String(512), nullable=True)
+    source_ip = Column(String(64), nullable=True)
+    user_agent = Column(String(512), nullable=True)
+    gmt_created = Column(DateTime, nullable=False, default=datetime.now)
+    gmt_modified = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("session_id", name="uk_dbgpt_auth_session_id"),
+        Index("ix_dbgpt_auth_session_id", "session_id"),
+        Index("ix_dbgpt_auth_session_user_id", "user_id"),
+        Index("ix_dbgpt_auth_session_idle_expires_at", "idle_expires_at"),
+        Index("ix_dbgpt_auth_session_absolute_expires_at", "absolute_expires_at"),
+    )
+
+
+class _EntityDao(BaseDao):
+    """Common private helpers for entity-specific DAOs."""
+
+    entity_type: Any
+
+    def _get_one(self, **filters: Any) -> Any:
+        with self.session(commit=False) as session:
+            return session.query(self.entity_type).filter_by(**filters).first()
+
+
+class UserDao(_EntityDao):
+    """Persistence operations for DB-GPT users."""
+
+    entity_type = UserEntity
+
+    def get_by_user_id(self, user_id: str) -> Optional[UserEntity]:
+        return self._get_one(user_id=user_id)
+
+    def get_by_login_name(self, login_name: str) -> Optional[UserEntity]:
+        return self._get_one(login_name=login_name)
+
+    def count_active_admins(self) -> int:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.role == "system_admin",
+                    UserEntity.is_active.is_(True),
+                )
+                .count()
+            )
+
+
+class AccountSetDao(_EntityDao):
+    """Persistence operations for account sets."""
+
+    entity_type = AccountSetEntity
+
+    def get_by_account_set_id(self, account_set_id: str) -> Optional[AccountSetEntity]:
+        return self._get_one(account_set_id=account_set_id)
+
+
+class UserAccountGrantDao(_EntityDao):
+    """Persistence operations for user account-set grants."""
+
+    entity_type = UserAccountGrantEntity
+
+    def get_by_grant_id(self, grant_id: str) -> Optional[UserAccountGrantEntity]:
+        return self._get_one(grant_id=grant_id)
+
+    def has_active_grant(self, user_id: str, account_set_id: str) -> bool:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserAccountGrantEntity.id)
+                .filter(
+                    UserAccountGrantEntity.user_id == user_id,
+                    UserAccountGrantEntity.account_set_id == account_set_id,
+                    UserAccountGrantEntity.is_active.is_(True),
+                )
+                .first()
+                is not None
+            )
+
+
+class UserResourceGrantDao(_EntityDao):
+    """Persistence operations for query-user resource grants."""
+
+    entity_type = UserResourceGrantEntity
+
+    def get_by_grant_id(self, grant_id: str) -> Optional[UserResourceGrantEntity]:
+        return self._get_one(grant_id=grant_id)
+
+    def has_active_grant(
+        self, user_id: str, resource_type: str, resource_id: str
+    ) -> bool:
+        with self.session(commit=False) as session:
+            return (
+                session.query(UserResourceGrantEntity.id)
+                .filter(
+                    UserResourceGrantEntity.user_id == user_id,
+                    UserResourceGrantEntity.resource_type == resource_type,
+                    UserResourceGrantEntity.resource_id == resource_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .first()
+                is not None
+            )
+
+
+class ImportBatchDao(_EntityDao):
+    """Persistence operations for account import batches."""
+
+    entity_type = ImportBatchEntity
+
+    def get_by_batch_id(self, batch_id: str) -> Optional[ImportBatchEntity]:
+        return self._get_one(batch_id=batch_id)
+
+
+class TokenUsageDao(_EntityDao):
+    """Persistence operations for model call usage details."""
+
+    entity_type = TokenUsageEntity
+
+    def get_by_call_id(self, call_id: str) -> Optional[TokenUsageEntity]:
+        return self._get_one(call_id=call_id)
+
+
+class TokenDailyDao(_EntityDao):
+    """Persistence operations for daily token aggregations."""
+
+    entity_type = TokenDailyEntity
+
+    def get_by_dimensions(
+        self,
+        stat_date: str,
+        user_id: str,
+        role_snapshot: str,
+        account_set_id: Optional[str],
+        model: str,
+    ) -> Optional[TokenDailyEntity]:
+        with self.session(commit=False) as session:
+            return (
+                session.query(TokenDailyEntity)
+                .filter(
+                    TokenDailyEntity.stat_date == stat_date,
+                    TokenDailyEntity.user_id == user_id,
+                    TokenDailyEntity.role_snapshot == role_snapshot,
+                    TokenDailyEntity.account_set_id == (account_set_id or ""),
+                    TokenDailyEntity.model == model,
+                )
+                .first()
+            )
+
+
+class SessionDao(_EntityDao):
+    """Persistence operations for authenticated sessions."""
+
+    entity_type = SessionEntity
+
+    def get_by_session_id(self, session_id: str) -> Optional[SessionEntity]:
+        return self._get_one(session_id=session_id)
+
+    def get_active_session(
+        self, session_id: str, user_id: str, now: Optional[datetime] = None
+    ) -> Optional[SessionEntity]:
+        current_time = now or datetime.now()
+        with self.session(commit=False) as session:
+            return (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                    SessionEntity.revoked_at.is_(None),
+                    SessionEntity.idle_expires_at > current_time,
+                    SessionEntity.absolute_expires_at > current_time,
+                )
+                .first()
+            )
+
+
+class AuditEventDao(BaseDao):
+    """Append-only persistence operations for audit events."""
+
+    _FILTER_FIELDS = {
+        "operator_user_id",
+        "target_account_set_id",
+        "target_type",
+        "target_id",
+        "action",
+        "result",
+        "request_id",
+    }
+
+    def append(
+        self, event: Union[AuditEventEntity, Dict[str, Any]]
+    ) -> AuditEventEntity:
+        entity = (
+            event if isinstance(event, AuditEventEntity) else AuditEventEntity(**event)
+        )
+        with self.session() as session:
+            session.add(entity)
+            session.flush()
+            session.expunge(entity)
+        return entity
+
+    def query(
+        self, filters: Dict[str, Any], page: int, page_size: int
+    ) -> PaginationResult[AuditEventEntity]:
+        unknown_fields = set(filters) - self._FILTER_FIELDS
+        if unknown_fields:
+            raise ValueError(f"Unsupported audit filters: {sorted(unknown_fields)}")
+        with self.session(commit=False) as session:
+            query = session.query(AuditEventEntity)
+            for field, value in filters.items():
+                if value is not None:
+                    query = query.filter(getattr(AuditEventEntity, field) == value)
+            total_count = query.count()
+            items = (
+                query.order_by(AuditEventEntity.event_time.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            return PaginationResult(
+                items=items,
+                total_count=total_count,
+                total_pages=(total_count + page_size - 1) // page_size,
+                page=page,
+                page_size=page_size,
+            )
+
+    def create(self, request: Any) -> Any:
+        raise TypeError("Audit events must be written with append()")
+
+    def update(self, query_request: Any, update_request: Any) -> Any:
+        raise TypeError("Audit events are append-only")
+
+    def delete(self, query_request: Any) -> None:
+        raise TypeError("Audit events are append-only")

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/__init__.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/__init__.py
@@ -1,0 +1,5 @@
+"""Authorization service layer."""
+
+from .service import AuthenticationError, Service
+
+__all__ = ["AuthenticationError", "Service"]

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/access.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/access.py
@@ -1,0 +1,446 @@
+"""Runtime capability, account-set, and concrete-resource authorization."""
+
+import uuid
+from typing import Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy import column, select, table
+
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventEntity,
+    UserAccountGrantEntity,
+    UserDao,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.resources import (
+    ResourceLookupError,
+    ResourceRecord,
+    agent_dependencies,
+    get_resource_by_id_or_name,
+    resolve_agent_dependency,
+)
+from dbgpt_serve.utils.auth import UserRequest
+
+_USE_PERMISSIONS = {
+    "DATASOURCE": "DATASOURCE_USE",
+    "KNOWLEDGE_BASE": "KNOWLEDGE_BASE_USE",
+    "AGENT": "AGENT_USE",
+}
+
+
+class AccessService:
+    """Fail-closed runtime authorization using only server-side state."""
+
+    def __init__(self, dao: Optional[UserDao] = None) -> None:
+        self._dao = dao or UserDao()
+
+    def require_capability(self, user: UserRequest, permission: str) -> None:
+        if permission not in ROLE_PERMISSIONS.get(user.role or "", set()):
+            self._deny(
+                user,
+                "CAPABILITY_MISSING",
+                target_type="CAPABILITY",
+                target_id=permission,
+            )
+
+    def require_account_access(
+        self, user: UserRequest, account_set_id: str, permission: str
+    ) -> None:
+        self.require_capability(user, permission)
+        if user.role == "system_admin":
+            self._require_active_account_set(account_set_id, user)
+            return
+        if not user.user_id:
+            self._deny(
+                user,
+                "USER_ID_MISSING",
+                target_type="ACCOUNT_SET",
+                target_id=account_set_id,
+            )
+        with self._dao.session(commit=False) as session:
+            account_set = (
+                session.query(AccountSetEntity.id)
+                .filter(
+                    AccountSetEntity.account_set_id == account_set_id,
+                    AccountSetEntity.is_active.is_(True),
+                )
+                .first()
+            )
+            grant = (
+                session.query(UserAccountGrantEntity.id)
+                .filter(
+                    UserAccountGrantEntity.user_id == user.user_id,
+                    UserAccountGrantEntity.account_set_id == account_set_id,
+                    UserAccountGrantEntity.is_active.is_(True),
+                )
+                .first()
+            )
+        if account_set is None:
+            self._deny(
+                user,
+                "ACCOUNT_SET_INACTIVE",
+                target_type="ACCOUNT_SET",
+                target_id=account_set_id,
+            )
+        if grant is None:
+            self._deny(
+                user,
+                "ACCOUNT_SET_SCOPE_MISSING",
+                target_type="ACCOUNT_SET",
+                target_id=account_set_id,
+            )
+
+    def require_resource_access(
+        self,
+        user: UserRequest,
+        resource_type: str,
+        resource_id_or_name: str,
+        *,
+        manage: bool = False,
+    ) -> ResourceRecord:
+        permission = (
+            _USE_PERMISSIONS[resource_type]
+            if not manage
+            else _USE_PERMISSIONS[resource_type].replace("_USE", "_MANAGE")
+        )
+        self.require_capability(user, permission)
+        with self._dao.session(commit=False) as session:
+            try:
+                resource = get_resource_by_id_or_name(
+                    session, resource_type, resource_id_or_name
+                )
+            except ResourceLookupError:
+                resource = None
+            if resource is None:
+                self._deny(
+                    user,
+                    "RESOURCE_NOT_FOUND",
+                    target_type=resource_type,
+                    target_id=resource_id_or_name,
+                )
+            if user.role == "system_admin":
+                if resource.account_set_id:
+                    account_set = (
+                        session.query(AccountSetEntity.id)
+                        .filter(
+                            AccountSetEntity.account_set_id == resource.account_set_id,
+                            AccountSetEntity.is_active.is_(True),
+                        )
+                        .first()
+                    )
+                    if account_set is None:
+                        self._deny(
+                            user,
+                            "ACCOUNT_SET_INACTIVE",
+                            target_type=resource_type,
+                            target_id=resource.resource_id,
+                        )
+                return resource
+            if not resource.account_set_id:
+                self._deny(
+                    user,
+                    "RESOURCE_UNASSIGNED",
+                    target_type=resource_type,
+                    target_id=resource.resource_id,
+                )
+            account_set = (
+                session.query(AccountSetEntity.id)
+                .filter(
+                    AccountSetEntity.account_set_id == resource.account_set_id,
+                    AccountSetEntity.is_active.is_(True),
+                )
+                .first()
+            )
+            account_grant = (
+                session.query(UserAccountGrantEntity.id)
+                .filter(
+                    UserAccountGrantEntity.user_id == user.user_id,
+                    UserAccountGrantEntity.account_set_id == resource.account_set_id,
+                    UserAccountGrantEntity.is_active.is_(True),
+                )
+                .first()
+            )
+            if account_set is None:
+                self._deny(
+                    user,
+                    "ACCOUNT_SET_INACTIVE",
+                    target_type=resource_type,
+                    target_id=resource.resource_id,
+                )
+            if account_grant is None:
+                self._deny(
+                    user,
+                    "ACCOUNT_SET_SCOPE_MISSING",
+                    target_type=resource_type,
+                    target_id=resource.resource_id,
+                )
+            if user.role == "query_user":
+                resource_grant = (
+                    session.query(UserResourceGrantEntity.id)
+                    .filter(
+                        UserResourceGrantEntity.user_id == user.user_id,
+                        UserResourceGrantEntity.resource_type == resource_type,
+                        UserResourceGrantEntity.resource_id == resource.resource_id,
+                        UserResourceGrantEntity.account_set_id
+                        == resource.account_set_id,
+                        UserResourceGrantEntity.is_active.is_(True),
+                    )
+                    .first()
+                )
+                if resource_grant is None:
+                    self._deny(
+                        user,
+                        "RESOURCE_GRANT_MISSING",
+                        target_type=resource_type,
+                        target_id=resource.resource_id,
+                    )
+                if resource_type == "AGENT":
+                    self._require_agent_dependencies(session, user, resource)
+            return resource
+
+    def allowed_resource_ids(
+        self, user: UserRequest, resource_type: str, *, manage: bool = False
+    ) -> Optional[set[str]]:
+        permission = (
+            _USE_PERMISSIONS[resource_type]
+            if not manage
+            else _USE_PERMISSIONS[resource_type].replace("_USE", "_MANAGE")
+        )
+        self.require_capability(user, permission)
+        if user.role == "system_admin":
+            return None
+        with self._dao.session(commit=False) as session:
+            account_ids = {
+                value
+                for (value,) in session.query(UserAccountGrantEntity.account_set_id)
+                .join(
+                    AccountSetEntity,
+                    AccountSetEntity.account_set_id
+                    == UserAccountGrantEntity.account_set_id,
+                )
+                .filter(
+                    UserAccountGrantEntity.user_id == user.user_id,
+                    UserAccountGrantEntity.is_active.is_(True),
+                    AccountSetEntity.is_active.is_(True),
+                )
+                .all()
+            }
+            if user.role != "query_user":
+                from dbgpt_serve.auth.service.resources import list_resources
+
+                return {
+                    item.resource_id
+                    for item in list_resources(
+                        session, resource_type, account_set_ids=account_ids
+                    )
+                }
+            return {
+                resource_id
+                for (resource_id,) in session.query(UserResourceGrantEntity.resource_id)
+                .filter(
+                    UserResourceGrantEntity.user_id == user.user_id,
+                    UserResourceGrantEntity.resource_type == resource_type,
+                    UserResourceGrantEntity.account_set_id.in_(account_ids),
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .all()
+            }
+
+    def require_document_access(
+        self, user: UserRequest, document_id: str, *, manage: bool = False
+    ) -> ResourceRecord:
+        try:
+            numeric_document_id = int(document_id)
+        except (TypeError, ValueError):
+            self._deny(
+                user,
+                "DOCUMENT_ID_INVALID",
+                target_type="KNOWLEDGE_DOCUMENT",
+                target_id=str(document_id),
+            )
+        document_table = table("knowledge_document", column("id"), column("space"))
+        with self._dao.session(commit=False) as session:
+            space_name = session.execute(
+                select(document_table.c.space).where(
+                    document_table.c.id == numeric_document_id
+                )
+            ).scalar_one_or_none()
+        if not space_name:
+            self._deny(
+                user,
+                "DOCUMENT_NOT_FOUND",
+                target_type="KNOWLEDGE_DOCUMENT",
+                target_id=document_id,
+            )
+        return self.require_resource_access(
+            user, "KNOWLEDGE_BASE", str(space_name), manage=manage
+        )
+
+    def require_chat_access(
+        self,
+        user: UserRequest,
+        chat_mode: Optional[str],
+        chat_param: Optional[str],
+        app_code: Optional[str] = None,
+    ) -> None:
+        self.require_capability(user, "CHAT_USE")
+        normalized_mode = (chat_mode or "").lower()
+        if "agent" in normalized_mode or "app" in normalized_mode:
+            target = app_code or chat_param
+            if target:
+                self.require_resource_access(user, "AGENT", str(target))
+        elif "knowledge" in normalized_mode:
+            if chat_param:
+                self.require_resource_access(user, "KNOWLEDGE_BASE", str(chat_param))
+        elif any(marker in normalized_mode for marker in ("data", "db", "dashboard")):
+            if chat_param:
+                self.require_resource_access(user, "DATASOURCE", str(chat_param))
+
+    def require_agent_definition_access(
+        self, user: UserRequest, account_set_id: str, details
+    ) -> None:
+        self.require_account_access(user, account_set_id, "AGENT_MANAGE")
+        dependencies: dict[tuple[str, str], ResourceRecord] = {}
+        with self._dao.session(commit=False) as session:
+            for detail in details or []:
+                for resource in detail.resources or []:
+                    try:
+                        dependency = resolve_agent_dependency(
+                            session, "pending-agent", resource.to_dict()
+                        )
+                    except ResourceLookupError:
+                        self._deny(
+                            user,
+                            "AGENT_DEPENDENCY_INVALID",
+                            target_type="AGENT",
+                            target_id=None,
+                        )
+                    if dependency is not None:
+                        dependencies[
+                            (dependency.resource_type, dependency.resource_id)
+                        ] = dependency
+        for dependency in dependencies.values():
+            if dependency.account_set_id != account_set_id:
+                self._deny(
+                    user,
+                    "AGENT_DEPENDENCY_SCOPE_MISMATCH",
+                    target_type="AGENT",
+                    target_id=None,
+                )
+            self.require_resource_access(
+                user,
+                dependency.resource_type,
+                dependency.resource_id,
+                manage=True,
+            )
+
+    def allowed_resource_names(
+        self, user: UserRequest, resource_type: str, *, manage: bool = False
+    ) -> Optional[set[str]]:
+        allowed_ids = self.allowed_resource_ids(user, resource_type, manage=manage)
+        if allowed_ids is None:
+            return None
+        from dbgpt_serve.auth.service.resources import list_resources
+
+        with self._dao.session(commit=False) as session:
+            return {
+                item.name
+                for item in list_resources(session, resource_type)
+                if item.resource_id in allowed_ids
+            }
+
+    def _require_agent_dependencies(
+        self, session, user: UserRequest, agent: ResourceRecord
+    ) -> None:
+        try:
+            dependencies = agent_dependencies(session, agent.resource_id)
+        except ResourceLookupError:
+            self._deny(
+                user,
+                "AGENT_DEPENDENCY_INVALID",
+                target_type="AGENT",
+                target_id=agent.resource_id,
+            )
+        for dependency in dependencies:
+            if dependency.account_set_id != agent.account_set_id:
+                self._deny(
+                    user,
+                    "AGENT_DEPENDENCY_SCOPE_MISMATCH",
+                    target_type="AGENT",
+                    target_id=agent.resource_id,
+                )
+            grant = (
+                session.query(UserResourceGrantEntity.id)
+                .filter(
+                    UserResourceGrantEntity.user_id == user.user_id,
+                    UserResourceGrantEntity.resource_type == dependency.resource_type,
+                    UserResourceGrantEntity.resource_id == dependency.resource_id,
+                    UserResourceGrantEntity.account_set_id == dependency.account_set_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .first()
+            )
+            if grant is None:
+                self._deny(
+                    user,
+                    "AGENT_DEPENDENCY_GRANT_MISSING",
+                    target_type="AGENT",
+                    target_id=agent.resource_id,
+                )
+
+    def _require_active_account_set(
+        self, account_set_id: str, user: UserRequest
+    ) -> None:
+        with self._dao.session(commit=False) as session:
+            exists = (
+                session.query(AccountSetEntity.id)
+                .filter(
+                    AccountSetEntity.account_set_id == account_set_id,
+                    AccountSetEntity.is_active.is_(True),
+                )
+                .first()
+            )
+        if exists is None:
+            self._deny(
+                user,
+                "ACCOUNT_SET_INACTIVE",
+                target_type="ACCOUNT_SET",
+                target_id=account_set_id,
+            )
+
+    def _deny(
+        self,
+        user: UserRequest,
+        reason: str,
+        *,
+        target_type: str,
+        target_id: Optional[str],
+    ) -> None:
+        with self._dao.session() as session:
+            event = AuditEventEntity(
+                event_id=str(uuid.uuid4()),
+                operator_user_id=user.user_id,
+                operator_role_snapshot=user.role,
+                target_type=target_type,
+                target_id=target_id,
+                action="AUTHZ.CHECK",
+                result="denied",
+                source_ip=user.source_ip,
+                user_agent=user.user_agent,
+                request_id=user.request_id,
+                deny_reason=reason,
+            )
+            session.add(event)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": reason, "message": "Access denied"},
+        )
+
+
+_access_service = AccessService()
+
+
+def get_access_service() -> AccessService:
+    return _access_service

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/audit_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/audit_service.py
@@ -1,0 +1,128 @@
+"""Append-only audit recording and administrator queries."""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from dbgpt_serve.auth.api.schemas import (
+    AuditEventCreate,
+    AuditEventResponse,
+    AuditQueryRequest,
+    Page,
+)
+from dbgpt_serve.auth.models.models import (
+    AuditEventDao,
+    AuditEventEntity,
+)
+from dbgpt_serve.auth.service.errors import (
+    ManagementNotFoundError,
+    ManagementValidationError,
+)
+from dbgpt_serve.auth.service.management import Operator
+
+_SENSITIVE_MARKERS = ("password", "cookie", "token", "prompt")
+
+
+class AuditService:
+    """Expose append and read operations without update or delete APIs."""
+
+    def __init__(self, dao: Optional[AuditEventDao] = None) -> None:
+        self._dao = dao or AuditEventDao()
+
+    def record(self, event: AuditEventCreate) -> AuditEventResponse:
+        self._reject_sensitive_snapshot(event.before_snapshot)
+        self._reject_sensitive_snapshot(event.after_snapshot)
+        entity = AuditEventEntity(
+            **event.model_dump(exclude={"event_id", "event_time"}),
+            event_id=event.event_id or str(uuid.uuid4()),
+            event_time=self._as_naive_utc(event.event_time),
+        )
+        return AuditEventResponse.model_validate(self._dao.append(entity))
+
+    def query(
+        self,
+        filters: AuditQueryRequest,
+        page: int,
+        page_size: int,
+        operator: Operator,
+    ) -> Page[AuditEventResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            query = session.query(AuditEventEntity)
+            if filters.target_type:
+                query = query.filter(
+                    AuditEventEntity.target_type == filters.target_type
+                )
+            if filters.action:
+                query = query.filter(AuditEventEntity.action == filters.action)
+            if filters.operator_user_id:
+                query = query.filter(
+                    AuditEventEntity.operator_user_id == filters.operator_user_id
+                )
+            if filters.result:
+                query = query.filter(AuditEventEntity.result == filters.result)
+            if filters.date_from:
+                query = query.filter(
+                    AuditEventEntity.event_time >= self._as_naive_utc(filters.date_from)
+                )
+            if filters.date_to:
+                query = query.filter(
+                    AuditEventEntity.event_time <= self._as_naive_utc(filters.date_to)
+                )
+            total = query.count()
+            entities = (
+                query.order_by(
+                    AuditEventEntity.event_time.desc(), AuditEventEntity.id.desc()
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [AuditEventResponse.model_validate(item) for item in entities]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def get(self, event_id: str, operator: Operator) -> AuditEventResponse:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            entity = (
+                session.query(AuditEventEntity)
+                .filter(AuditEventEntity.event_id == event_id)
+                .first()
+            )
+            if entity is None:
+                raise ManagementNotFoundError("Audit event does not exist")
+            return AuditEventResponse.model_validate(entity)
+
+    @staticmethod
+    def _require_system_admin(operator: Operator) -> None:
+        if operator.role != "system_admin" or not operator.user_id:
+            raise ManagementValidationError("A system administrator is required")
+
+    @staticmethod
+    def _validate_page(page: int, page_size: int) -> None:
+        if page < 1 or page_size < 1 or page_size > 100:
+            raise ManagementValidationError(
+                "page must be at least 1 and page_size must be between 1 and 100"
+            )
+
+    @staticmethod
+    def _reject_sensitive_snapshot(snapshot: Optional[str]) -> None:
+        normalized = (snapshot or "").lower()
+        if any(marker in normalized for marker in _SENSITIVE_MARKERS):
+            raise ManagementValidationError(
+                "Sensitive fields are not permitted in audit snapshots"
+            )
+
+    @staticmethod
+    def _as_naive_utc(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+_audit_service = AuditService()
+
+
+def get_audit_service() -> AuditService:
+    return _audit_service

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/authorization.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/authorization.py
@@ -1,0 +1,943 @@
+"""Transactional account-set and protected-resource authorization management."""
+
+import hashlib
+import uuid
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+
+from dbgpt_serve.auth.api.schemas import (
+    AssignResourceAccountRequest,
+    ConfirmRevokeRequest,
+    Page,
+    ResourceImpactResponse,
+    ResourceResponse,
+    RevokeImpactResponse,
+    RevokeRequest,
+    UserAccountGrantResponse,
+    UserResourceGrantResponse,
+)
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.errors import (
+    ImpactConfirmationRequiredError,
+    ManagementConflictError,
+    ManagementNotFoundError,
+    ManagementValidationError,
+)
+from dbgpt_serve.auth.service.management import Operator, _json_summary, _utcnow
+from dbgpt_serve.auth.service.resources import (
+    RESOURCE_DEFINITIONS,
+    ResourceLookupError,
+    ResourceRecord,
+    agent_dependencies,
+    count_resources,
+    dependent_agent_ids,
+    get_resource,
+    list_resources,
+)
+from dbgpt_serve.auth.service.resources import (
+    assign_resource_account as persist_resource_account,
+)
+
+_RESOURCE_MANAGE_PERMISSIONS = {
+    "DATASOURCE": "DATASOURCE_MANAGE",
+    "KNOWLEDGE_BASE": "KNOWLEDGE_BASE_MANAGE",
+    "AGENT": "AGENT_MANAGE",
+}
+
+
+class AuthorizationMixin:
+    """Authorization administration methods mixed into the auth service."""
+
+    def grant_user_account(
+        self, user_id: str, account_set_id: str, operator: Operator
+    ) -> UserAccountGrantResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        try:
+            with self._dao.session() as session:
+                user = self._locked_user(session, user_id)
+                if user.role == "system_admin":
+                    raise ManagementValidationError(
+                        "System administrators do not require account-set grants"
+                    )
+                account_set = self._active_account_set(session, account_set_id)
+                grant = (
+                    session.query(UserAccountGrantEntity)
+                    .filter(
+                        UserAccountGrantEntity.user_id == user.user_id,
+                        UserAccountGrantEntity.account_set_id
+                        == account_set.account_set_id,
+                    )
+                    .with_for_update()
+                    .first()
+                )
+                before = self._account_grant_snapshot(grant) if grant else None
+                if grant is not None and grant.is_active:
+                    raise ManagementConflictError(
+                        "The user already has this account-set grant"
+                    )
+                if grant is None:
+                    grant = UserAccountGrantEntity(
+                        grant_id=str(uuid.uuid4()),
+                        user_id=user.user_id,
+                        account_set_id=account_set.account_set_id,
+                        is_active=True,
+                        granted_by=operator_id,
+                        gmt_created=now,
+                        gmt_modified=now,
+                    )
+                    session.add(grant)
+                else:
+                    grant.is_active = True
+                    grant.granted_by = operator_id
+                    grant.revoked_by = None
+                    grant.revoked_at = None
+                    grant.revoke_reason = None
+                    grant.gmt_modified = now
+                session.flush()
+                self._append_audit(
+                    session,
+                    action="USER_ACCOUNT_GRANT.GRANT",
+                    operator=operator,
+                    target_type="USER_ACCOUNT_GRANT",
+                    target_id=grant.grant_id,
+                    target_account_set_id=grant.account_set_id,
+                    before=before,
+                    after=self._account_grant_snapshot(grant),
+                )
+                response = UserAccountGrantResponse.model_validate(grant)
+        except IntegrityError as exc:
+            raise ManagementConflictError(
+                "The user already has this account-set grant"
+            ) from exc
+        return response
+
+    def list_user_account_grants(
+        self,
+        user_id: str,
+        page: int,
+        page_size: int,
+        operator: Operator,
+        is_active: Optional[bool] = None,
+    ) -> Page[UserAccountGrantResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            self._existing_user(session, user_id)
+            query = session.query(UserAccountGrantEntity).filter(
+                UserAccountGrantEntity.user_id == user_id
+            )
+            if is_active is not None:
+                query = query.filter(UserAccountGrantEntity.is_active.is_(is_active))
+            total = query.count()
+            entities = (
+                query.order_by(
+                    UserAccountGrantEntity.gmt_created.desc(),
+                    UserAccountGrantEntity.id.desc(),
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [
+                UserAccountGrantResponse.model_validate(entity) for entity in entities
+            ]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def get_user_account_revoke_impact(
+        self, user_id: str, grant_id: str, operator: Operator
+    ) -> RevokeImpactResponse:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            grant = self._account_grant(session, user_id, grant_id)
+            return self._account_grant_impact(session, grant)
+
+    def revoke_user_account(
+        self,
+        user_id: str,
+        grant_id: str,
+        request: ConfirmRevokeRequest,
+        operator: Operator,
+    ) -> RevokeImpactResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        with self._dao.session() as session:
+            grant = self._account_grant(session, user_id, grant_id, for_update=True)
+            if not grant.is_active:
+                raise ManagementConflictError("The account-set grant is not active")
+            impact = self._account_grant_impact(session, grant)
+            if (
+                not request.confirm_impact
+                or request.impact_token != impact.impact_token
+            ):
+                raise ImpactConfirmationRequiredError(
+                    "Account-set grant revocation requires current impact confirmation"
+                )
+            before = self._account_grant_snapshot(grant)
+            grants = (
+                session.query(UserResourceGrantEntity)
+                .filter(
+                    UserResourceGrantEntity.user_id == user_id,
+                    UserResourceGrantEntity.account_set_id == grant.account_set_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .with_for_update()
+                .all()
+            )
+            grant.is_active = False
+            grant.revoked_by = operator_id
+            grant.revoked_at = now
+            grant.revoke_reason = request.reason
+            grant.gmt_modified = now
+            for resource_grant in grants:
+                self._mark_resource_grant_revoked(
+                    resource_grant,
+                    operator_id,
+                    now,
+                    "ACCOUNT_SET_GRANT_REVOKED",
+                )
+            self._append_audit(
+                session,
+                action="USER_ACCOUNT_GRANT.REVOKE",
+                operator=operator,
+                target_type="USER_ACCOUNT_GRANT",
+                target_id=grant.grant_id,
+                target_account_set_id=grant.account_set_id,
+                before=before,
+                after={
+                    **self._account_grant_snapshot(grant),
+                    "reason": request.reason,
+                    "revoked_resource_grants": len(grants),
+                },
+            )
+        return impact
+
+    def grant_user_resource(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        operator: Operator,
+    ) -> UserResourceGrantResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        try:
+            with self._dao.session() as session:
+                user = self._locked_user(session, user_id)
+                if user.role != "query_user" or not user.is_active:
+                    raise ManagementValidationError(
+                        "Resource grants require an active query user"
+                    )
+                resource = self._required_resource(session, resource_type, resource_id)
+                if not resource.account_set_id:
+                    raise ManagementValidationError(
+                        "The resource is not assigned to an account set"
+                    )
+                self._active_account_set(session, resource.account_set_id)
+                self._require_active_account_grant(
+                    session, user.user_id, resource.account_set_id
+                )
+                if resource.resource_type == "AGENT":
+                    self._validate_agent_grant(session, user.user_id, resource)
+
+                grant = (
+                    session.query(UserResourceGrantEntity)
+                    .filter(
+                        UserResourceGrantEntity.user_id == user.user_id,
+                        UserResourceGrantEntity.resource_type == resource.resource_type,
+                        UserResourceGrantEntity.resource_id == resource.resource_id,
+                    )
+                    .with_for_update()
+                    .first()
+                )
+                before = self._resource_grant_snapshot(grant) if grant else None
+                if grant is not None and grant.is_active:
+                    raise ManagementConflictError(
+                        "The user already has this resource grant"
+                    )
+                if grant is None:
+                    grant = UserResourceGrantEntity(
+                        grant_id=str(uuid.uuid4()),
+                        user_id=user.user_id,
+                        resource_type=resource.resource_type,
+                        resource_id=resource.resource_id,
+                        account_set_id=resource.account_set_id,
+                        is_active=True,
+                        granted_by=operator_id,
+                        gmt_created=now,
+                        gmt_modified=now,
+                    )
+                    session.add(grant)
+                else:
+                    grant.account_set_id = resource.account_set_id
+                    grant.is_active = True
+                    grant.granted_by = operator_id
+                    grant.revoked_by = None
+                    grant.revoked_at = None
+                    grant.revoke_reason = None
+                    grant.gmt_modified = now
+                session.flush()
+                self._append_audit(
+                    session,
+                    action="USER_RESOURCE_GRANT.GRANT",
+                    operator=operator,
+                    target_type="USER_RESOURCE_GRANT",
+                    target_id=grant.grant_id,
+                    target_account_set_id=grant.account_set_id,
+                    before=before,
+                    after=self._resource_grant_snapshot(grant),
+                )
+                response = UserResourceGrantResponse.model_validate(grant)
+        except IntegrityError as exc:
+            raise ManagementConflictError(
+                "The user already has this resource grant"
+            ) from exc
+        return response
+
+    def list_user_resource_grants(
+        self,
+        user_id: str,
+        page: int,
+        page_size: int,
+        operator: Operator,
+        resource_type: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Page[UserResourceGrantResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            self._existing_user(session, user_id)
+            query = session.query(UserResourceGrantEntity).filter(
+                UserResourceGrantEntity.user_id == user_id
+            )
+            if resource_type is not None:
+                self._validate_resource_type(resource_type)
+                query = query.filter(
+                    UserResourceGrantEntity.resource_type == resource_type
+                )
+            if is_active is not None:
+                query = query.filter(UserResourceGrantEntity.is_active.is_(is_active))
+            total = query.count()
+            entities = (
+                query.order_by(
+                    UserResourceGrantEntity.gmt_created.desc(),
+                    UserResourceGrantEntity.id.desc(),
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [
+                UserResourceGrantResponse.model_validate(entity) for entity in entities
+            ]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def list_available_user_resources(
+        self, user_id: str, operator: Operator
+    ) -> list[ResourceResponse]:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            user = self._existing_user(session, user_id)
+            if user.role != "query_user" or not user.is_active:
+                raise ManagementValidationError(
+                    "Available resources require an active query user"
+                )
+            account_set_ids = self._active_user_account_set_ids(session, user_id)
+            active_grants = {
+                (grant.resource_type, grant.resource_id)
+                for grant in session.query(UserResourceGrantEntity)
+                .filter(
+                    UserResourceGrantEntity.user_id == user_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .all()
+            }
+            available: list[ResourceResponse] = []
+            for resource_type in RESOURCE_DEFINITIONS:
+                for resource in list_resources(
+                    session,
+                    resource_type,
+                    account_set_ids=account_set_ids,
+                ):
+                    if (resource_type, resource.resource_id) in active_grants:
+                        continue
+                    if resource_type == "AGENT":
+                        try:
+                            self._validate_agent_grant(session, user_id, resource)
+                        except ManagementValidationError:
+                            continue
+                    available.append(self._resource_response(resource))
+        return available
+
+    def revoke_user_resource(
+        self,
+        user_id: str,
+        grant_id: str,
+        request: RevokeRequest,
+        operator: Operator,
+    ) -> UserResourceGrantResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        with self._dao.session() as session:
+            grant = self._resource_grant(session, user_id, grant_id, for_update=True)
+            if not grant.is_active:
+                raise ManagementConflictError("The resource grant is not active")
+            before = self._resource_grant_snapshot(grant)
+            self._mark_resource_grant_revoked(grant, operator_id, now, request.reason)
+            revoked_agent_grants = []
+            if grant.resource_type != "AGENT":
+                try:
+                    affected_agent_ids = dependent_agent_ids(
+                        session, grant.resource_type, grant.resource_id
+                    )
+                except ResourceLookupError as exc:
+                    raise ManagementValidationError(str(exc)) from exc
+                if affected_agent_ids:
+                    revoked_agent_grants = (
+                        session.query(UserResourceGrantEntity)
+                        .filter(
+                            UserResourceGrantEntity.user_id == user_id,
+                            UserResourceGrantEntity.resource_type == "AGENT",
+                            UserResourceGrantEntity.resource_id.in_(affected_agent_ids),
+                            UserResourceGrantEntity.is_active.is_(True),
+                        )
+                        .with_for_update()
+                        .all()
+                    )
+                    for agent_grant in revoked_agent_grants:
+                        self._mark_resource_grant_revoked(
+                            agent_grant,
+                            operator_id,
+                            now,
+                            "DEPENDENCY_GRANT_REVOKED",
+                        )
+            self._append_audit(
+                session,
+                action="USER_RESOURCE_GRANT.REVOKE",
+                operator=operator,
+                target_type="USER_RESOURCE_GRANT",
+                target_id=grant.grant_id,
+                target_account_set_id=grant.account_set_id,
+                before=before,
+                after={
+                    **self._resource_grant_snapshot(grant),
+                    "revoked_agent_grants": len(revoked_agent_grants),
+                },
+            )
+            response = UserResourceGrantResponse.model_validate(grant)
+        return response
+
+    def list_managed_resources(
+        self,
+        page: int,
+        page_size: int,
+        operator: Operator,
+        resource_type: Optional[str] = None,
+        account_set_id: Optional[str] = None,
+        unassigned: bool = False,
+    ) -> Page[ResourceResponse]:
+        self._validate_page(page, page_size)
+        if account_set_id is not None and unassigned:
+            raise ManagementValidationError(
+                "account_set_id and unassigned cannot be combined"
+            )
+        resource_types = (
+            [resource_type] if resource_type is not None else list(RESOURCE_DEFINITIONS)
+        )
+        with self._dao.session(commit=False) as session:
+            scoped_account_sets = self._resource_manager_scope(
+                session, operator, resource_types
+            )
+            counts = {
+                current_type: count_resources(
+                    session,
+                    current_type,
+                    account_set_ids=scoped_account_sets,
+                    account_set_id=account_set_id,
+                    unassigned=unassigned,
+                )
+                for current_type in resource_types
+            }
+            total = sum(counts.values())
+            remaining_offset = (page - 1) * page_size
+            remaining_limit = page_size
+            records: list[ResourceRecord] = []
+            for current_type in resource_types:
+                current_count = counts[current_type]
+                if remaining_offset >= current_count:
+                    remaining_offset -= current_count
+                    continue
+                if remaining_limit == 0:
+                    break
+                records.extend(
+                    list_resources(
+                        session,
+                        current_type,
+                        account_set_ids=scoped_account_sets,
+                        account_set_id=account_set_id,
+                        unassigned=unassigned,
+                        offset=remaining_offset,
+                        limit=remaining_limit,
+                    )
+                )
+                remaining_limit = page_size - len(records)
+                remaining_offset = 0
+            items = [self._resource_response(item) for item in records]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def get_resource_impact(
+        self,
+        resource_type: str,
+        resource_id: str,
+        new_account_set_id: str,
+        operator: Operator,
+    ) -> ResourceImpactResponse:
+        with self._dao.session(commit=False) as session:
+            resource = self._required_resource(session, resource_type, resource_id)
+            self._authorize_resource_change(
+                session, operator, resource, new_account_set_id
+            )
+            self._active_account_set(session, new_account_set_id)
+            return self._resource_impact(session, resource, new_account_set_id)
+
+    def assign_resource_account(
+        self,
+        resource_type: str,
+        resource_id: str,
+        request: AssignResourceAccountRequest,
+        operator: Operator,
+    ) -> ResourceResponse:
+        now = _utcnow()
+        with self._dao.session() as session:
+            resource = self._required_resource(
+                session, resource_type, resource_id, for_update=True
+            )
+            operator_id = self._authorize_resource_change(
+                session, operator, resource, request.account_set_id
+            )
+            self._active_account_set(session, request.account_set_id)
+            impact = self._resource_impact(session, resource, request.account_set_id)
+            if (
+                not request.confirm_impact
+                or request.impact_token != impact.impact_token
+            ):
+                raise ImpactConfirmationRequiredError(
+                    "Resource account-set change requires current impact confirmation"
+                )
+            if resource.account_set_id == request.account_set_id:
+                raise ManagementConflictError(
+                    "The resource already belongs to this account set"
+                )
+            affected_agent_ids = dependent_agent_ids(
+                session, resource.resource_type, resource.resource_id
+            )
+            direct_grants = (
+                session.query(UserResourceGrantEntity)
+                .filter(
+                    UserResourceGrantEntity.resource_type == resource.resource_type,
+                    UserResourceGrantEntity.resource_id == resource.resource_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .with_for_update()
+                .all()
+            )
+            agent_grants = []
+            if affected_agent_ids:
+                agent_grants = (
+                    session.query(UserResourceGrantEntity)
+                    .filter(
+                        UserResourceGrantEntity.resource_type == "AGENT",
+                        UserResourceGrantEntity.resource_id.in_(affected_agent_ids),
+                        UserResourceGrantEntity.is_active.is_(True),
+                    )
+                    .with_for_update()
+                    .all()
+                )
+            for grant in [*direct_grants, *agent_grants]:
+                self._mark_resource_grant_revoked(
+                    grant, operator_id, now, "RESOURCE_ACCOUNT_SET_CHANGED"
+                )
+            persist_resource_account(
+                session,
+                resource.resource_type,
+                resource.resource_id,
+                request.account_set_id,
+            )
+            after = ResourceRecord(
+                resource_type=resource.resource_type,
+                resource_id=resource.resource_id,
+                name=resource.name,
+                account_set_id=request.account_set_id,
+            )
+            self._append_audit(
+                session,
+                action="RESOURCE.ACCOUNT_SET_CHANGE",
+                operator=operator,
+                target_type=resource.resource_type,
+                target_id=resource.resource_id,
+                target_account_set_id=request.account_set_id,
+                before=self._resource_response(resource).model_dump(),
+                after={
+                    **self._resource_response(after).model_dump(),
+                    "reason": request.reason,
+                    "revoked_resource_grants": len(direct_grants),
+                    "revoked_agent_grants": len(agent_grants),
+                },
+            )
+        return self._resource_response(after)
+
+    @staticmethod
+    def _existing_user(session, user_id: str) -> UserEntity:
+        user = session.query(UserEntity).filter(UserEntity.user_id == user_id).first()
+        if user is None:
+            raise ManagementNotFoundError("User does not exist")
+        return user
+
+    @staticmethod
+    def _active_account_set(session, account_set_id: str) -> AccountSetEntity:
+        account_set = (
+            session.query(AccountSetEntity)
+            .filter(
+                AccountSetEntity.account_set_id == account_set_id,
+                AccountSetEntity.is_active.is_(True),
+            )
+            .with_for_update()
+            .first()
+        )
+        if account_set is None:
+            raise ManagementValidationError("Account set is missing or inactive")
+        return account_set
+
+    @staticmethod
+    def _account_grant(
+        session, user_id: str, grant_id: str, *, for_update: bool = False
+    ) -> UserAccountGrantEntity:
+        query = session.query(UserAccountGrantEntity).filter(
+            UserAccountGrantEntity.grant_id == grant_id,
+            UserAccountGrantEntity.user_id == user_id,
+        )
+        if for_update:
+            query = query.with_for_update()
+        grant = query.first()
+        if grant is None:
+            raise ManagementNotFoundError("User account-set grant does not exist")
+        return grant
+
+    @staticmethod
+    def _resource_grant(
+        session, user_id: str, grant_id: str, *, for_update: bool = False
+    ) -> UserResourceGrantEntity:
+        query = session.query(UserResourceGrantEntity).filter(
+            UserResourceGrantEntity.grant_id == grant_id,
+            UserResourceGrantEntity.user_id == user_id,
+        )
+        if for_update:
+            query = query.with_for_update()
+        grant = query.first()
+        if grant is None:
+            raise ManagementNotFoundError("User resource grant does not exist")
+        return grant
+
+    @staticmethod
+    def _require_active_account_grant(
+        session, user_id: str, account_set_id: str
+    ) -> None:
+        exists = (
+            session.query(UserAccountGrantEntity.id)
+            .filter(
+                UserAccountGrantEntity.user_id == user_id,
+                UserAccountGrantEntity.account_set_id == account_set_id,
+                UserAccountGrantEntity.is_active.is_(True),
+            )
+            .first()
+        )
+        if exists is None:
+            raise ManagementValidationError(
+                "The user does not have the resource's account-set scope"
+            )
+
+    @staticmethod
+    def _active_user_account_set_ids(session, user_id: str) -> set[str]:
+        active_account_sets = (
+            session.query(AccountSetEntity.account_set_id)
+            .join(
+                UserAccountGrantEntity,
+                UserAccountGrantEntity.account_set_id
+                == AccountSetEntity.account_set_id,
+            )
+            .filter(
+                UserAccountGrantEntity.user_id == user_id,
+                UserAccountGrantEntity.is_active.is_(True),
+                AccountSetEntity.is_active.is_(True),
+            )
+            .all()
+        )
+        return {account_set_id for (account_set_id,) in active_account_sets}
+
+    def _validate_agent_grant(
+        self, session, user_id: str, agent: ResourceRecord
+    ) -> None:
+        try:
+            dependencies = agent_dependencies(session, agent.resource_id)
+        except ResourceLookupError as exc:
+            raise ManagementValidationError(str(exc)) from exc
+        for dependency in dependencies:
+            if (
+                not dependency.account_set_id
+                or dependency.account_set_id != agent.account_set_id
+            ):
+                raise ManagementValidationError(
+                    "All protected agent dependencies must belong to the agent's "
+                    "account set"
+                )
+            grant_exists = (
+                session.query(UserResourceGrantEntity.id)
+                .filter(
+                    UserResourceGrantEntity.user_id == user_id,
+                    UserResourceGrantEntity.resource_type == dependency.resource_type,
+                    UserResourceGrantEntity.resource_id == dependency.resource_id,
+                    UserResourceGrantEntity.account_set_id == dependency.account_set_id,
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .first()
+            )
+            if grant_exists is None:
+                raise ManagementValidationError(
+                    "The query user must be granted every protected agent dependency"
+                )
+
+    def _account_grant_impact(
+        self, session, grant: UserAccountGrantEntity
+    ) -> RevokeImpactResponse:
+        affected = (
+            session.query(UserResourceGrantEntity)
+            .filter(
+                UserResourceGrantEntity.user_id == grant.user_id,
+                UserResourceGrantEntity.account_set_id == grant.account_set_id,
+                UserResourceGrantEntity.is_active.is_(True),
+            )
+            .order_by(UserResourceGrantEntity.grant_id)
+            .all()
+        )
+        details = [self._resource_grant_snapshot(item) for item in affected]
+        token_data = {
+            "grant_id": grant.grant_id,
+            "is_active": grant.is_active,
+            "gmt_modified": grant.gmt_modified.isoformat(),
+            "affected_grant_ids": [item.grant_id for item in affected],
+        }
+        return RevokeImpactResponse(
+            grant_id=grant.grant_id,
+            affected_resource_grants=len(affected),
+            affected_grants_detail=details,
+            impact_token=hashlib.sha256(
+                _json_summary(token_data).encode("utf-8")
+            ).hexdigest(),
+        )
+
+    def _resource_impact(
+        self,
+        session,
+        resource: ResourceRecord,
+        new_account_set_id: str,
+    ) -> ResourceImpactResponse:
+        if resource.resource_type == "AGENT":
+            try:
+                dependencies = agent_dependencies(session, resource.resource_id)
+            except ResourceLookupError as exc:
+                raise ManagementValidationError(str(exc)) from exc
+            if any(
+                dependency.account_set_id != new_account_set_id
+                for dependency in dependencies
+            ):
+                raise ManagementValidationError(
+                    "An agent must belong to the same account set as all protected "
+                    "dependencies"
+                )
+        try:
+            affected_agent_ids = dependent_agent_ids(
+                session, resource.resource_type, resource.resource_id
+            )
+        except ResourceLookupError as exc:
+            raise ManagementValidationError(str(exc)) from exc
+        direct_grants = (
+            session.query(UserResourceGrantEntity)
+            .filter(
+                UserResourceGrantEntity.resource_type == resource.resource_type,
+                UserResourceGrantEntity.resource_id == resource.resource_id,
+                UserResourceGrantEntity.is_active.is_(True),
+            )
+            .order_by(UserResourceGrantEntity.grant_id)
+            .all()
+        )
+        agent_grants = []
+        if affected_agent_ids:
+            agent_grants = (
+                session.query(UserResourceGrantEntity)
+                .filter(
+                    UserResourceGrantEntity.resource_type == "AGENT",
+                    UserResourceGrantEntity.resource_id.in_(affected_agent_ids),
+                    UserResourceGrantEntity.is_active.is_(True),
+                )
+                .order_by(UserResourceGrantEntity.grant_id)
+                .all()
+            )
+        details = [
+            self._resource_grant_snapshot(item)
+            for item in [*direct_grants, *agent_grants]
+        ]
+        token_data = {
+            "resource_type": resource.resource_type,
+            "resource_id": resource.resource_id,
+            "current_account_set_id": resource.account_set_id,
+            "new_account_set_id": new_account_set_id,
+            "affected_grant_ids": [item["grant_id"] for item in details],
+        }
+        return ResourceImpactResponse(
+            resource_type=resource.resource_type,
+            resource_id=resource.resource_id,
+            current_account_set_id=resource.account_set_id,
+            new_account_set_id=new_account_set_id,
+            affected_resource_grants=len(direct_grants),
+            affected_agent_grants=len(agent_grants),
+            affected_grants_detail=details,
+            impact_token=hashlib.sha256(
+                _json_summary(token_data).encode("utf-8")
+            ).hexdigest(),
+        )
+
+    def _authorize_resource_change(
+        self,
+        session,
+        operator: Operator,
+        resource: ResourceRecord,
+        new_account_set_id: str,
+    ) -> str:
+        operator_id = self._require_resource_permission(
+            operator, resource.resource_type
+        )
+        if operator.role == "system_admin":
+            return operator_id
+        if resource.account_set_id is None:
+            raise ManagementValidationError(
+                "Only system administrators may assign unowned resources"
+            )
+        scope = self._active_user_account_set_ids(session, operator_id)
+        required_scopes = {new_account_set_id}
+        if resource.account_set_id:
+            required_scopes.add(resource.account_set_id)
+        if not required_scopes.issubset(scope):
+            raise ManagementValidationError(
+                "Operations administrators may only move resources within their "
+                "account-set scope"
+            )
+        return operator_id
+
+    def _resource_manager_scope(
+        self, session, operator: Operator, resource_types: list[str]
+    ) -> Optional[set[str]]:
+        for resource_type in resource_types:
+            self._require_resource_permission(operator, resource_type)
+        if operator.role == "system_admin":
+            return None
+        if not operator.user_id:
+            raise ManagementValidationError("An authenticated operator is required")
+        return self._active_user_account_set_ids(session, operator.user_id)
+
+    @staticmethod
+    def _require_resource_permission(operator: Operator, resource_type: str) -> str:
+        AuthorizationMixin._validate_resource_type(resource_type)
+        if not operator.user_id or not operator.role:
+            raise ManagementValidationError("An authenticated operator is required")
+        permission = _RESOURCE_MANAGE_PERMISSIONS[resource_type]
+        if permission not in ROLE_PERMISSIONS.get(operator.role, set()):
+            raise ManagementValidationError(
+                f"The operator lacks {permission} capability"
+            )
+        return operator.user_id
+
+    @staticmethod
+    def _required_resource(
+        session,
+        resource_type: str,
+        resource_id: str,
+        *,
+        for_update: bool = False,
+    ) -> ResourceRecord:
+        try:
+            resource = get_resource(
+                session, resource_type, resource_id, for_update=for_update
+            )
+        except ResourceLookupError as exc:
+            raise ManagementValidationError(str(exc)) from exc
+        if resource is None:
+            raise ManagementNotFoundError("Resource does not exist")
+        return resource
+
+    @staticmethod
+    def _validate_resource_type(resource_type: str) -> None:
+        if resource_type not in RESOURCE_DEFINITIONS:
+            raise ManagementValidationError(
+                f"Unsupported resource type: {resource_type}"
+            )
+
+    @staticmethod
+    def _mark_resource_grant_revoked(
+        grant: UserResourceGrantEntity,
+        operator_id: str,
+        now,
+        reason: str,
+    ) -> None:
+        grant.is_active = False
+        grant.revoked_by = operator_id
+        grant.revoked_at = now
+        grant.revoke_reason = reason
+        grant.gmt_modified = now
+
+    @staticmethod
+    def _resource_response(resource: ResourceRecord) -> ResourceResponse:
+        return ResourceResponse(
+            resource_type=resource.resource_type,
+            resource_id=resource.resource_id,
+            name=resource.name,
+            account_set_id=resource.account_set_id,
+        )
+
+    @staticmethod
+    def _account_grant_snapshot(
+        grant: UserAccountGrantEntity,
+    ) -> dict:
+        return {
+            "grant_id": grant.grant_id,
+            "user_id": grant.user_id,
+            "account_set_id": grant.account_set_id,
+            "is_active": grant.is_active,
+            "granted_by": grant.granted_by,
+            "revoked_by": grant.revoked_by,
+            "revoked_at": grant.revoked_at.isoformat() if grant.revoked_at else None,
+            "revoke_reason": grant.revoke_reason,
+        }
+
+    @staticmethod
+    def _resource_grant_snapshot(
+        grant: UserResourceGrantEntity,
+    ) -> dict:
+        return {
+            "grant_id": grant.grant_id,
+            "user_id": grant.user_id,
+            "resource_type": grant.resource_type,
+            "resource_id": grant.resource_id,
+            "account_set_id": grant.account_set_id,
+            "is_active": grant.is_active,
+            "granted_by": grant.granted_by,
+            "revoked_by": grant.revoked_by,
+            "revoked_at": grant.revoked_at.isoformat() if grant.revoked_at else None,
+            "revoke_reason": grant.revoke_reason,
+        }

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/errors.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/errors.py
@@ -1,0 +1,37 @@
+"""Stable business errors for authorization administration APIs."""
+
+
+class ManagementError(Exception):
+    """Base class for expected administration failures."""
+
+    code = "MANAGEMENT_ERROR"
+
+
+class ManagementNotFoundError(ManagementError):
+    """Raised when a managed authorization object does not exist."""
+
+    code = "NOT_FOUND"
+
+
+class ManagementConflictError(ManagementError):
+    """Raised when a requested state conflicts with current persisted state."""
+
+    code = "CONFLICT"
+
+
+class ManagementValidationError(ManagementError):
+    """Raised when a cross-field business rule rejects a request."""
+
+    code = "VALIDATION_ERROR"
+
+
+class ImpactConfirmationRequiredError(ManagementConflictError):
+    """Raised when a high-risk change lacks current impact confirmation."""
+
+    code = "IMPACT_CONFIRMATION_REQUIRED"
+
+
+class ImportSourceError(ManagementError):
+    """Raised when the configured one-time import source cannot be read safely."""
+
+    code = "IMPORT_SOURCE_UNAVAILABLE"

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/importer.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/importer.py
@@ -1,0 +1,130 @@
+"""Read-only LSZYZD candidate adapter."""
+
+from typing import Any, Optional
+
+from sqlalchemy import column, select, table
+
+from dbgpt_serve.auth.api.schemas import ImportCandidateResponse
+from dbgpt_serve.auth.service.errors import ImportSourceError
+
+LSZYZD_ALLOWED_FIELDS = {
+    "employee_no": "LSZYZD_BH",
+    "name": "LSZYZD_MC",
+    "is_enabled": "LSZYZD_YXBZ",
+    "category": "LSZYZD_LBBH",
+    "position": "LSZYZD_ZW",
+    "team": "LSZYZD_BANZU",
+    "role_label": "LSZYZD_ROLE",
+}
+LSZYZD_REQUIRED_FIELDS = frozenset({"LSZYZD_BH", "LSZYZD_MC"})
+
+
+def _optional_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    return text_value or None
+
+
+def _optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y", "enabled", "启用"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "disabled", "停用"}:
+        return False
+    return None
+
+
+class LszyzdImporter:
+    """Read only configured LSZYZD fields through a DB-GPT connector."""
+
+    def __init__(
+        self,
+        connector_manager: Any,
+        datasource_name: str,
+        table_name: str = "LSZYZD",
+    ) -> None:
+        self._connector_manager = connector_manager
+        self._datasource_name = datasource_name
+        self._table_name = table_name
+
+    @property
+    def source_name(self) -> str:
+        return self._datasource_name
+
+    def preview(self, limit: int = 100) -> list[ImportCandidateResponse]:
+        """Return bounded candidates without ever selecting password fields."""
+        if limit < 1 or limit > 100:
+            raise ValueError("Import preview limit must be between 1 and 100")
+        try:
+            connector = self._connector_manager.get_connector(self._datasource_name)
+            actual_table_name = self._resolve_table_name(connector)
+            columns_by_upper = {
+                str(item["name"]).upper(): str(item["name"])
+                for item in connector.get_columns(actual_table_name)
+                if item.get("name")
+            }
+            missing = LSZYZD_REQUIRED_FIELDS - set(columns_by_upper)
+            if missing:
+                raise ImportSourceError(
+                    f"LSZYZD is missing required fields: {sorted(missing)}"
+                )
+
+            selected_fields = {
+                alias: columns_by_upper[column_name]
+                for alias, column_name in LSZYZD_ALLOWED_FIELDS.items()
+                if column_name in columns_by_upper
+            }
+            source_table = table(
+                actual_table_name,
+                *(column(name) for name in selected_fields.values()),
+            )
+            statement = (
+                select(
+                    *(
+                        source_table.c[name].label(alias)
+                        for alias, name in selected_fields.items()
+                    )
+                )
+                .order_by(source_table.c[selected_fields["employee_no"]])
+                .limit(limit)
+            )
+            with connector.session_scope(commit=False) as session:
+                rows = session.execute(statement).mappings().all()
+        except ImportSourceError:
+            raise
+        except Exception as exc:
+            raise ImportSourceError("Configured LSZYZD source is unavailable") from exc
+
+        return [self._to_candidate(dict(row)) for row in rows]
+
+    def _resolve_table_name(self, connector: Any) -> str:
+        table_names = {
+            str(name).upper(): str(name) for name in connector.get_table_names()
+        }
+        actual_name = table_names.get(self._table_name.upper())
+        if actual_name is None:
+            raise ImportSourceError("Configured LSZYZD table does not exist")
+        return actual_name
+
+    @staticmethod
+    def _to_candidate(row: dict[str, Any]) -> ImportCandidateResponse:
+        employee_no = _optional_text(row.get("employee_no"))
+        name = _optional_text(row.get("name"))
+        if not employee_no or not name:
+            raise ImportSourceError("LSZYZD contains a record without number or name")
+        return ImportCandidateResponse(
+            employee_no=employee_no,
+            name=name,
+            is_enabled=_optional_bool(row.get("is_enabled")),
+            category=_optional_text(row.get("category")),
+            position=_optional_text(row.get("position")),
+            team=_optional_text(row.get("team")),
+            role_label=_optional_text(row.get("role_label")),
+        )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/management.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/management.py
@@ -1,0 +1,975 @@
+"""Transactional user, account-set, role, and import administration."""
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional, Protocol
+
+from sqlalchemy import column, func, select, table
+from sqlalchemy.exc import IntegrityError
+
+from dbgpt_serve.auth.api.schemas import (
+    AccountSetCreateRequest,
+    AccountSetImpactResponse,
+    AccountSetResponse,
+    AccountSetUpdateRequest,
+    ConfirmImpactRequest,
+    ImportBatchRequest,
+    ImportBatchResponse,
+    ImportCandidateResponse,
+    Page,
+    RoleResponse,
+    UserCreateRequest,
+    UserListRequest,
+    UserResponse,
+    UserUpdateRequest,
+)
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.errors import (
+    ImpactConfirmationRequiredError,
+    ImportSourceError,
+    ManagementConflictError,
+    ManagementNotFoundError,
+    ManagementValidationError,
+)
+from dbgpt_serve.auth.service.importer import LszyzdImporter
+
+
+class Operator(Protocol):
+    """Minimum authenticated operator fields used by management transactions."""
+
+    user_id: Optional[str]
+    role: Optional[str]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _json_summary(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+class ManagementMixin:
+    """Administration methods mixed into the authentication service."""
+
+    _importer: Optional[LszyzdImporter]
+
+    def create_user(
+        self, request: UserCreateRequest, operator: Operator
+    ) -> UserResponse:
+        operator_id = self._require_system_admin(operator)
+        password_hash = self._password_hash_for_create(request)
+        now = _utcnow()
+        try:
+            with self._dao.session() as session:
+                if (
+                    session.query(UserEntity.id)
+                    .filter(UserEntity.login_name == request.login_name)
+                    .first()
+                    is not None
+                ):
+                    raise ManagementConflictError("Login name already exists")
+                account_sets = self._active_account_sets(
+                    session, request.initial_account_set_ids
+                )
+                user = UserEntity(
+                    user_id=str(uuid.uuid4()),
+                    login_name=request.login_name,
+                    display_name=request.display_name,
+                    password_hash=password_hash,
+                    role=request.role,
+                    is_active=True,
+                    created_by=operator_id,
+                    gmt_created=now,
+                    gmt_modified=now,
+                )
+                session.add(user)
+                session.flush()
+                self._add_account_grants(
+                    session, user.user_id, account_sets, operator_id
+                )
+                self._append_audit(
+                    session,
+                    action="USER.CREATE",
+                    operator=operator,
+                    target_type="USER",
+                    target_id=user.user_id,
+                    after={
+                        **self._user_snapshot(user),
+                        "initial_account_set_ids": sorted(account_sets),
+                    },
+                )
+                response = UserResponse.from_entity(user)
+        except IntegrityError as exc:
+            raise ManagementConflictError("Login name already exists") from exc
+        return response
+
+    def update_user(
+        self, user_id: str, request: UserUpdateRequest, operator: Operator
+    ) -> UserResponse:
+        self._require_system_admin(operator)
+        now = _utcnow()
+        with self._dao.session() as session:
+            user = self._locked_user(session, user_id)
+            before = self._user_snapshot(user)
+            revoked_resource_grants = 0
+            revoked_account_grants = 0
+
+            if request.role is not None and request.role != user.role:
+                if not request.confirm_role_change or not request.change_reason:
+                    raise ImpactConfirmationRequiredError(
+                        "Role changes require confirmation and a reason"
+                    )
+                if user.role == "system_admin" and request.role != "system_admin":
+                    self._assert_admin_can_be_removed(session, user.user_id)
+                if user.role == "query_user" and request.role != "query_user":
+                    revoked_resource_grants = self._revoke_resource_grants(
+                        session, user.user_id, operator.user_id, "ROLE_CHANGED", now
+                    )
+                if request.role == "system_admin":
+                    revoked_account_grants = self._revoke_account_grants(
+                        session, user.user_id, operator.user_id, "ROLE_CHANGED", now
+                    )
+                user.role = request.role
+
+            if request.display_name is not None:
+                user.display_name = request.display_name
+            user.gmt_modified = now
+            after = {
+                **self._user_snapshot(user),
+                "change_reason": request.change_reason,
+                "revoked_resource_grants": revoked_resource_grants,
+                "revoked_account_grants": revoked_account_grants,
+            }
+            self._append_audit(
+                session,
+                action="USER.ROLE_CHANGE"
+                if before["role"] != user.role
+                else "USER.UPDATE",
+                operator=operator,
+                target_type="USER",
+                target_id=user.user_id,
+                before=before,
+                after=after,
+            )
+            response = UserResponse.from_entity(user)
+        return response
+
+    def toggle_user_active(
+        self, user_id: str, is_active: bool, operator: Operator
+    ) -> UserResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        with self._dao.session() as session:
+            user = self._locked_user(session, user_id)
+            if user.is_active == is_active:
+                return UserResponse.from_entity(user)
+            before = self._user_snapshot(user)
+            revoked_sessions = 0
+            if is_active:
+                user.is_active = True
+                user.disabled_by = None
+                user.disabled_at = None
+            else:
+                if user.role == "system_admin":
+                    self._assert_admin_can_be_removed(session, user.user_id)
+                user.is_active = False
+                user.disabled_by = operator_id
+                user.disabled_at = now
+                revoked_sessions = self._revoke_sessions(
+                    session, user.user_id, operator_id, "USER_DISABLED", now
+                )
+            user.gmt_modified = now
+            self._append_audit(
+                session,
+                action="USER.ACTIVATE" if is_active else "USER.DEACTIVATE",
+                operator=operator,
+                target_type="USER",
+                target_id=user.user_id,
+                before=before,
+                after={
+                    **self._user_snapshot(user),
+                    "revoked_sessions": revoked_sessions,
+                },
+            )
+            response = UserResponse.from_entity(user)
+        return response
+
+    def set_password(self, user_id: str, new_password: str, operator: Operator) -> None:
+        operator_id = self._require_system_admin(operator)
+        try:
+            password_hash = self.hash_password(new_password)
+        except ValueError as exc:
+            raise ManagementValidationError(str(exc)) from exc
+        now = _utcnow()
+        with self._dao.session() as session:
+            user = self._locked_user(session, user_id)
+            user.password_hash = password_hash
+            user.activation_token = None
+            user.activation_token_exp = None
+            user.reset_token = None
+            user.reset_token_exp = None
+            user.login_fail_count = 0
+            user.locked_until = None
+            user.gmt_modified = now
+            revoked_sessions = self._revoke_sessions(
+                session, user.user_id, operator_id, "PASSWORD_CHANGED", now
+            )
+            self._append_audit(
+                session,
+                action="USER.SET_PASSWORD",
+                operator=operator,
+                target_type="USER",
+                target_id=user.user_id,
+                after={"password_changed": True, "revoked_sessions": revoked_sessions},
+            )
+
+    def get_managed_user(self, user_id: str, operator: Operator) -> UserResponse:
+        self._require_system_admin(operator)
+        user = self._dao.get_by_user_id(user_id)
+        if user is None:
+            raise ManagementNotFoundError("User does not exist")
+        return UserResponse.from_entity(user)
+
+    def list_users(
+        self,
+        filters: UserListRequest,
+        page: int,
+        page_size: int,
+        operator: Operator,
+    ) -> Page[UserResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            query = session.query(UserEntity)
+            if filters.login_name_like:
+                query = query.filter(
+                    UserEntity.login_name.contains(
+                        filters.login_name_like, autoescape=True
+                    )
+                )
+            if filters.display_name_like:
+                query = query.filter(
+                    UserEntity.display_name.contains(
+                        filters.display_name_like, autoescape=True
+                    )
+                )
+            if filters.role:
+                query = query.filter(UserEntity.role == filters.role)
+            if filters.is_active is not None:
+                query = query.filter(UserEntity.is_active.is_(filters.is_active))
+            total = query.count()
+            entities = (
+                query.order_by(UserEntity.gmt_created.desc(), UserEntity.id.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [UserResponse.from_entity(entity) for entity in entities]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def list_roles(self, operator: Operator) -> list[RoleResponse]:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            counts = dict(
+                session.query(UserEntity.role, func.count())
+                .group_by(UserEntity.role)
+                .all()
+            )
+        return [
+            RoleResponse(
+                role=role,
+                permissions=sorted(permissions),
+                user_count=counts.get(role, 0),
+            )
+            for role, permissions in ROLE_PERMISSIONS.items()
+        ]
+
+    def create_account_set(
+        self, request: AccountSetCreateRequest, operator: Operator
+    ) -> AccountSetResponse:
+        operator_id = self._require_system_admin(operator)
+        now = _utcnow()
+        try:
+            with self._dao.session() as session:
+                if (
+                    session.query(AccountSetEntity.id)
+                    .filter(AccountSetEntity.name == request.name)
+                    .first()
+                    is not None
+                ):
+                    raise ManagementConflictError("Account-set name already exists")
+                account_set = AccountSetEntity(
+                    account_set_id=str(uuid.uuid4()),
+                    name=request.name,
+                    description=request.description,
+                    is_active=True,
+                    created_by=operator_id,
+                    gmt_created=now,
+                    gmt_modified=now,
+                )
+                session.add(account_set)
+                session.flush()
+                self._append_audit(
+                    session,
+                    action="ACCOUNT_SET.CREATE",
+                    operator=operator,
+                    target_type="ACCOUNT_SET",
+                    target_id=account_set.account_set_id,
+                    target_account_set_id=account_set.account_set_id,
+                    after=self._account_set_snapshot(account_set),
+                )
+                response = AccountSetResponse.model_validate(account_set)
+        except IntegrityError as exc:
+            raise ManagementConflictError("Account-set name already exists") from exc
+        return response
+
+    def update_account_set(
+        self,
+        account_set_id: str,
+        request: AccountSetUpdateRequest,
+        operator: Operator,
+    ) -> AccountSetResponse:
+        self._require_system_admin(operator)
+        now = _utcnow()
+        try:
+            with self._dao.session() as session:
+                account_set = self._locked_account_set(session, account_set_id)
+                before = self._account_set_snapshot(account_set)
+                if request.name is not None and request.name != account_set.name:
+                    if (
+                        session.query(AccountSetEntity.id)
+                        .filter(
+                            AccountSetEntity.name == request.name,
+                            AccountSetEntity.id != account_set.id,
+                        )
+                        .first()
+                        is not None
+                    ):
+                        raise ManagementConflictError("Account-set name already exists")
+                    account_set.name = request.name
+                if "description" in request.model_fields_set:
+                    account_set.description = request.description
+                account_set.gmt_modified = now
+                self._append_audit(
+                    session,
+                    action="ACCOUNT_SET.UPDATE",
+                    operator=operator,
+                    target_type="ACCOUNT_SET",
+                    target_id=account_set.account_set_id,
+                    target_account_set_id=account_set.account_set_id,
+                    before=before,
+                    after=self._account_set_snapshot(account_set),
+                )
+                response = AccountSetResponse.model_validate(account_set)
+        except IntegrityError as exc:
+            raise ManagementConflictError("Account-set name already exists") from exc
+        return response
+
+    def get_account_set(
+        self, account_set_id: str, operator: Operator
+    ) -> AccountSetResponse:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            account_set = (
+                session.query(AccountSetEntity)
+                .filter(AccountSetEntity.account_set_id == account_set_id)
+                .first()
+            )
+            if account_set is None:
+                raise ManagementNotFoundError("Account set does not exist")
+            return AccountSetResponse.model_validate(account_set)
+
+    def list_account_sets(
+        self,
+        page: int,
+        page_size: int,
+        operator: Operator,
+        name_like: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Page[AccountSetResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            query = session.query(AccountSetEntity)
+            if name_like:
+                query = query.filter(
+                    AccountSetEntity.name.contains(name_like, autoescape=True)
+                )
+            if is_active is not None:
+                query = query.filter(AccountSetEntity.is_active.is_(is_active))
+            total = query.count()
+            entities = (
+                query.order_by(
+                    AccountSetEntity.gmt_created.desc(), AccountSetEntity.id.desc()
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [AccountSetResponse.model_validate(entity) for entity in entities]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def get_account_set_impact(
+        self, account_set_id: str, operator: Operator
+    ) -> AccountSetImpactResponse:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            account_set = (
+                session.query(AccountSetEntity)
+                .filter(AccountSetEntity.account_set_id == account_set_id)
+                .first()
+            )
+            if account_set is None:
+                raise ManagementNotFoundError("Account set does not exist")
+            return self._account_set_impact(session, account_set)
+
+    def toggle_account_set_active(
+        self,
+        account_set_id: str,
+        is_active: bool,
+        operator: Operator,
+        confirmation: Optional[ConfirmImpactRequest] = None,
+    ) -> AccountSetResponse:
+        self._require_system_admin(operator)
+        now = _utcnow()
+        with self._dao.session() as session:
+            account_set = self._locked_account_set(session, account_set_id)
+            if account_set.is_active == is_active:
+                return AccountSetResponse.model_validate(account_set)
+            before = self._account_set_snapshot(account_set)
+            after_extra: dict[str, Any] = {}
+            if not is_active:
+                impact = self._account_set_impact(session, account_set)
+                if (
+                    confirmation is None
+                    or not confirmation.confirm_impact
+                    or confirmation.impact_token != impact.impact_token
+                ):
+                    raise ImpactConfirmationRequiredError(
+                        "Account-set deactivation requires current impact confirmation"
+                    )
+                after_extra = {
+                    "reason": confirmation.reason,
+                    "impact": impact.model_dump(exclude={"impact_token"}),
+                }
+            account_set.is_active = is_active
+            account_set.gmt_modified = now
+            self._append_audit(
+                session,
+                action="ACCOUNT_SET.ACTIVATE"
+                if is_active
+                else "ACCOUNT_SET.DEACTIVATE",
+                operator=operator,
+                target_type="ACCOUNT_SET",
+                target_id=account_set.account_set_id,
+                target_account_set_id=account_set.account_set_id,
+                before=before,
+                after={**self._account_set_snapshot(account_set), **after_extra},
+            )
+            response = AccountSetResponse.model_validate(account_set)
+        return response
+
+    def preview_import_candidates(
+        self, operator: Operator, limit: int = 100
+    ) -> list[ImportCandidateResponse]:
+        self._require_system_admin(operator)
+        return self._get_importer().preview(limit=limit)
+
+    def create_from_import(
+        self, request: ImportBatchRequest, operator: Operator
+    ) -> ImportBatchResponse:
+        operator_id = self._require_system_admin(operator)
+        importer = self._get_importer()
+        candidates = {item.employee_no: item for item in importer.preview(limit=100)}
+        password_hashes: dict[str, str] = {}
+        for item in request.users:
+            try:
+                password_hashes[item.employee_no] = self.hash_password(
+                    item.initial_password.get_secret_value()
+                )
+            except ValueError as exc:
+                raise ManagementValidationError(str(exc)) from exc
+
+        now = _utcnow()
+        batch_id = str(uuid.uuid4())
+        selected_summary: list[dict] = []
+        result_summary: list[dict] = []
+        created_count = 0
+        skipped_count = 0
+        try:
+            with self._dao.session() as session:
+                previous_employee_numbers = self._previous_import_employee_numbers(
+                    session
+                )
+                for item in request.users:
+                    candidate = candidates.get(item.employee_no)
+                    selected_summary.append(
+                        {
+                            **(candidate.model_dump() if candidate else {}),
+                            "employee_no": item.employee_no,
+                            "login_name": item.login_name,
+                            "role": item.role,
+                            "initial_account_set_ids": sorted(
+                                set(item.initial_account_set_ids)
+                            ),
+                            "duplicate_import": item.employee_no
+                            in previous_employee_numbers,
+                        }
+                    )
+                    skip_reason: Optional[str] = None
+                    if candidate is None:
+                        skip_reason = "SOURCE_RECORD_MISSING"
+                    elif item.employee_no in previous_employee_numbers:
+                        skip_reason = "SOURCE_RECORD_ALREADY_IMPORTED"
+                    elif (
+                        session.query(UserEntity.id)
+                        .filter(UserEntity.login_name == item.login_name)
+                        .first()
+                        is not None
+                    ):
+                        skip_reason = "LOGIN_NAME_EXISTS"
+
+                    if skip_reason:
+                        skipped_count += 1
+                        result_summary.append(
+                            {
+                                "employee_no": item.employee_no,
+                                "login_name": item.login_name,
+                                "result": "skipped",
+                                "reason": skip_reason,
+                            }
+                        )
+                        continue
+
+                    account_sets = self._active_account_sets(
+                        session, item.initial_account_set_ids
+                    )
+                    user = UserEntity(
+                        user_id=str(uuid.uuid4()),
+                        login_name=item.login_name,
+                        display_name=candidate.name,
+                        password_hash=password_hashes[item.employee_no],
+                        role=item.role,
+                        is_active=True,
+                        created_by=operator_id,
+                        gmt_created=now,
+                        gmt_modified=now,
+                    )
+                    session.add(user)
+                    session.flush()
+                    self._add_account_grants(
+                        session, user.user_id, account_sets, operator_id
+                    )
+                    self._append_audit(
+                        session,
+                        action="USER.IMPORT_CREATE",
+                        operator=operator,
+                        target_type="USER",
+                        target_id=user.user_id,
+                        after={
+                            **self._user_snapshot(user),
+                            "source": importer.source_name,
+                            "source_employee_no": item.employee_no,
+                        },
+                    )
+                    created_count += 1
+                    result_summary.append(
+                        {
+                            "employee_no": item.employee_no,
+                            "login_name": item.login_name,
+                            "user_id": user.user_id,
+                            "result": "created",
+                        }
+                    )
+
+                batch = ImportBatchEntity(
+                    batch_id=batch_id,
+                    operator_user_id=operator_id,
+                    source_name=importer.source_name,
+                    selected_count=len(request.users),
+                    created_count=created_count,
+                    skipped_count=skipped_count,
+                    selected_summary=_json_summary(selected_summary),
+                    result_summary=_json_summary(result_summary),
+                    gmt_created=now,
+                )
+                session.add(batch)
+                session.flush()
+                self._append_audit(
+                    session,
+                    action="IMPORT.BATCH_CREATE",
+                    operator=operator,
+                    target_type="IMPORT_BATCH",
+                    target_id=batch.batch_id,
+                    after={
+                        "source_name": batch.source_name,
+                        "selected_count": batch.selected_count,
+                        "created_count": batch.created_count,
+                        "skipped_count": batch.skipped_count,
+                    },
+                )
+                response = ImportBatchResponse.from_entity(batch)
+        except IntegrityError as exc:
+            raise ManagementConflictError(
+                "Import conflicted with a concurrently created account"
+            ) from exc
+        return response
+
+    def list_import_batches(
+        self, page: int, page_size: int, operator: Operator
+    ) -> Page[ImportBatchResponse]:
+        self._require_system_admin(operator)
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            query = session.query(ImportBatchEntity)
+            total = query.count()
+            entities = (
+                query.order_by(
+                    ImportBatchEntity.gmt_created.desc(), ImportBatchEntity.id.desc()
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [ImportBatchResponse.from_entity(entity) for entity in entities]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def get_import_batch(
+        self, batch_id: str, operator: Operator
+    ) -> ImportBatchResponse:
+        self._require_system_admin(operator)
+        with self._dao.session(commit=False) as session:
+            entity = (
+                session.query(ImportBatchEntity)
+                .filter(ImportBatchEntity.batch_id == batch_id)
+                .first()
+            )
+            if entity is None:
+                raise ManagementNotFoundError("Import batch does not exist")
+            return ImportBatchResponse.from_entity(entity)
+
+    def _get_importer(self) -> LszyzdImporter:
+        if self._importer is not None:
+            return self._importer
+        if self.system_app is None:
+            raise ImportSourceError("SystemApp is not initialized")
+        from dbgpt_serve.datasource.manages.connector_manager import ConnectorManager
+
+        manager = ConnectorManager.get_instance(self.system_app)
+        self._importer = LszyzdImporter(
+            manager,
+            datasource_name=self._config.lszyzd_datasource,
+            table_name=self._config.lszyzd_table,
+        )
+        return self._importer
+
+    @staticmethod
+    def _validate_page(page: int, page_size: int) -> None:
+        if page < 1 or page_size < 1 or page_size > 100:
+            raise ManagementValidationError(
+                "page must be at least 1 and page_size must be between 1 and 100"
+            )
+
+    @staticmethod
+    def _require_system_admin(operator: Operator) -> str:
+        if operator.role != "system_admin" or not operator.user_id:
+            raise ManagementValidationError("A system administrator is required")
+        return operator.user_id
+
+    @staticmethod
+    def _locked_user(session, user_id: str) -> UserEntity:
+        user = (
+            session.query(UserEntity)
+            .filter(UserEntity.user_id == user_id)
+            .with_for_update()
+            .first()
+        )
+        if user is None:
+            raise ManagementNotFoundError("User does not exist")
+        return user
+
+    @staticmethod
+    def _locked_account_set(session, account_set_id: str) -> AccountSetEntity:
+        account_set = (
+            session.query(AccountSetEntity)
+            .filter(AccountSetEntity.account_set_id == account_set_id)
+            .with_for_update()
+            .first()
+        )
+        if account_set is None:
+            raise ManagementNotFoundError("Account set does not exist")
+        return account_set
+
+    @staticmethod
+    def _assert_admin_can_be_removed(session, target_user_id: str) -> None:
+        active_admins = (
+            session.query(UserEntity)
+            .filter(
+                UserEntity.role == "system_admin",
+                UserEntity.is_active.is_(True),
+            )
+            .order_by(UserEntity.id)
+            .with_for_update()
+            .all()
+        )
+        if len(active_admins) <= 1 and any(
+            user.user_id == target_user_id for user in active_admins
+        ):
+            raise ManagementConflictError(
+                "The last active system administrator cannot be disabled or demoted"
+            )
+
+    def _password_hash_for_create(self, request: UserCreateRequest) -> str:
+        if request.send_activation:
+            raise ManagementValidationError(
+                "Activation delivery is not configured; provide an initial password"
+            )
+        if request.initial_password is None:
+            raise ManagementValidationError("An initial password is required")
+        try:
+            return self.hash_password(request.initial_password.get_secret_value())
+        except ValueError as exc:
+            raise ManagementValidationError(str(exc)) from exc
+
+    @staticmethod
+    def _active_account_sets(session, account_set_ids: list[str]) -> dict[str, Any]:
+        normalized_ids = list(dict.fromkeys(account_set_ids))
+        if len(normalized_ids) != len(account_set_ids) or any(
+            not account_set_id.strip() for account_set_id in normalized_ids
+        ):
+            raise ManagementValidationError(
+                "Initial account-set IDs must be non-blank and unique"
+            )
+        if not normalized_ids:
+            return {}
+        entities = (
+            session.query(AccountSetEntity)
+            .filter(
+                AccountSetEntity.account_set_id.in_(normalized_ids),
+                AccountSetEntity.is_active.is_(True),
+            )
+            .all()
+        )
+        by_id = {entity.account_set_id: entity for entity in entities}
+        missing = set(normalized_ids) - set(by_id)
+        if missing:
+            raise ManagementValidationError(
+                f"Account sets are missing or inactive: {sorted(missing)}"
+            )
+        return by_id
+
+    @staticmethod
+    def _add_account_grants(
+        session,
+        user_id: str,
+        account_sets: dict[str, AccountSetEntity],
+        operator_id: str,
+    ) -> None:
+        now = _utcnow()
+        for account_set_id in account_sets:
+            session.add(
+                UserAccountGrantEntity(
+                    grant_id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    account_set_id=account_set_id,
+                    is_active=True,
+                    granted_by=operator_id,
+                    gmt_created=now,
+                    gmt_modified=now,
+                )
+            )
+
+    @staticmethod
+    def _revoke_resource_grants(
+        session,
+        user_id: str,
+        operator_id: Optional[str],
+        reason: str,
+        now: datetime,
+    ) -> int:
+        grants = (
+            session.query(UserResourceGrantEntity)
+            .filter(
+                UserResourceGrantEntity.user_id == user_id,
+                UserResourceGrantEntity.is_active.is_(True),
+            )
+            .with_for_update()
+            .all()
+        )
+        for grant in grants:
+            grant.is_active = False
+            grant.revoked_by = operator_id
+            grant.revoked_at = now
+            grant.revoke_reason = reason
+            grant.gmt_modified = now
+        return len(grants)
+
+    @staticmethod
+    def _revoke_account_grants(
+        session,
+        user_id: str,
+        operator_id: Optional[str],
+        reason: str,
+        now: datetime,
+    ) -> int:
+        grants = (
+            session.query(UserAccountGrantEntity)
+            .filter(
+                UserAccountGrantEntity.user_id == user_id,
+                UserAccountGrantEntity.is_active.is_(True),
+            )
+            .with_for_update()
+            .all()
+        )
+        for grant in grants:
+            grant.is_active = False
+            grant.revoked_by = operator_id
+            grant.revoked_at = now
+            grant.revoke_reason = reason
+            grant.gmt_modified = now
+        return len(grants)
+
+    @staticmethod
+    def _revoke_sessions(
+        session,
+        user_id: str,
+        operator_id: str,
+        reason: str,
+        now: datetime,
+    ) -> int:
+        sessions = (
+            session.query(SessionEntity)
+            .filter(
+                SessionEntity.user_id == user_id,
+                SessionEntity.revoked_at.is_(None),
+            )
+            .with_for_update()
+            .all()
+        )
+        for auth_session in sessions:
+            auth_session.revoked_at = now
+            auth_session.revoked_by = operator_id
+            auth_session.revoke_reason = reason
+            auth_session.gmt_modified = now
+        return len(sessions)
+
+    @staticmethod
+    def _previous_import_employee_numbers(session) -> set[str]:
+        employee_numbers: set[str] = set()
+        summaries = session.query(ImportBatchEntity.result_summary).all()
+        for (summary,) in summaries:
+            try:
+                items = json.loads(summary or "[]")
+            except (TypeError, json.JSONDecodeError):
+                continue
+            for item in items if isinstance(items, list) else []:
+                if (
+                    isinstance(item, dict)
+                    and item.get("result") == "created"
+                    and item.get("employee_no")
+                ):
+                    employee_numbers.add(str(item["employee_no"]))
+        return employee_numbers
+
+    def _account_set_impact(
+        self, session, account_set: AccountSetEntity
+    ) -> AccountSetImpactResponse:
+        user_grant_count = (
+            session.query(UserAccountGrantEntity.id)
+            .filter(
+                UserAccountGrantEntity.account_set_id == account_set.account_set_id,
+                UserAccountGrantEntity.is_active.is_(True),
+            )
+            .count()
+        )
+        resource_grant_count = (
+            session.query(UserResourceGrantEntity.id)
+            .filter(
+                UserResourceGrantEntity.account_set_id == account_set.account_set_id,
+                UserResourceGrantEntity.is_active.is_(True),
+            )
+            .count()
+        )
+        resource_count = 0
+        for table_name in ("connect_config", "knowledge_space", "gpts_app"):
+            resource_table = table(table_name, column("account_set_id"))
+            resource_count += session.execute(
+                select(func.count())
+                .select_from(resource_table)
+                .where(resource_table.c.account_set_id == account_set.account_set_id)
+            ).scalar_one()
+        token_data = {
+            "account_set_id": account_set.account_set_id,
+            "is_active": account_set.is_active,
+            "gmt_modified": account_set.gmt_modified.isoformat(),
+            "user_grant_count": user_grant_count,
+            "resource_grant_count": resource_grant_count,
+            "resource_count": resource_count,
+        }
+        impact_token = hashlib.sha256(_json_summary(token_data).encode()).hexdigest()
+        return AccountSetImpactResponse(
+            account_set_id=account_set.account_set_id,
+            user_grant_count=user_grant_count,
+            resource_grant_count=resource_grant_count,
+            resource_count=resource_count,
+            impact_token=impact_token,
+        )
+
+    def _append_audit(
+        self,
+        session,
+        action: str,
+        operator: Operator,
+        target_type: str,
+        target_id: Optional[str],
+        before: Optional[dict] = None,
+        after: Optional[dict] = None,
+        target_account_set_id: Optional[str] = None,
+    ) -> None:
+        event: AuditEventEntity = self._audit_event(
+            action=action,
+            result="success",
+            operator_user_id=operator.user_id,
+            operator_role=operator.role,
+            target_type=target_type,
+            target_id=target_id,
+            source_ip=getattr(operator, "source_ip", "") or "",
+            user_agent=getattr(operator, "user_agent", "") or "",
+        )
+        event.request_id = getattr(operator, "request_id", None)
+        event.target_account_set_id = target_account_set_id
+        event.before_snapshot = _json_summary(before) if before is not None else None
+        event.after_snapshot = _json_summary(after) if after is not None else None
+        session.add(event)
+
+    @staticmethod
+    def _user_snapshot(user: UserEntity) -> dict[str, Any]:
+        return {
+            "user_id": user.user_id,
+            "login_name": user.login_name,
+            "display_name": user.display_name,
+            "role": user.role,
+            "is_active": user.is_active,
+            "disabled_at": user.disabled_at.isoformat() if user.disabled_at else None,
+        }
+
+    @staticmethod
+    def _account_set_snapshot(account_set: AccountSetEntity) -> dict[str, Any]:
+        return {
+            "account_set_id": account_set.account_set_id,
+            "name": account_set.name,
+            "description": account_set.description,
+            "is_active": account_set.is_active,
+        }

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/resources.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/resources.py
@@ -206,7 +206,7 @@ def agent_dependencies(session, agent_id: str) -> list[ResourceRecord]:
                 f"Agent {agent_id} contains invalid dependency metadata"
             )
         for item in items:
-            dependency = _resolve_dependency(session, agent_id, item)
+            dependency = resolve_agent_dependency(session, agent_id, item)
             if dependency is not None:
                 dependencies[(dependency.resource_type, dependency.resource_id)] = (
                     dependency
@@ -233,7 +233,9 @@ def dependent_agent_ids(session, dependency_type: str, dependency_id: str) -> se
     return matches
 
 
-def _resolve_dependency(session, agent_id: str, item: Any) -> Optional[ResourceRecord]:
+def resolve_agent_dependency(
+    session, agent_id: str, item: Any
+) -> Optional[ResourceRecord]:
     if not isinstance(item, dict):
         raise ResourceLookupError(
             f"Agent {agent_id} contains invalid dependency metadata"
@@ -254,7 +256,7 @@ def _resolve_dependency(session, agent_id: str, item: Any) -> Optional[ResourceR
         raise ResourceLookupError(
             f"Agent {agent_id} has an unresolved {resource_type} dependency"
         )
-    dependency = _get_resource_by_id_or_name(session, resource_type, lookup_value)
+    dependency = get_resource_by_id_or_name(session, resource_type, lookup_value)
     if dependency is None:
         raise ResourceLookupError(
             f"Agent {agent_id} references a missing {resource_type} dependency"
@@ -280,7 +282,7 @@ def _dependency_lookup_value(resource_type: str, value: Any) -> Optional[str]:
     return None
 
 
-def _get_resource_by_id_or_name(
+def get_resource_by_id_or_name(
     session, resource_type: str, lookup_value: str
 ) -> Optional[ResourceRecord]:
     definition = resource_definition(resource_type)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/resources.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/resources.py
@@ -1,0 +1,312 @@
+"""Uniform SQLAlchemy access to protected DB-GPT resource tables."""
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sqlalchemy import column, func, select, table, update
+
+
+class ResourceLookupError(ValueError):
+    """Raised when a resource identifier or dependency cannot be resolved."""
+
+
+@dataclass(frozen=True)
+class ResourceDefinition:
+    resource_type: str
+    table_name: str
+    id_column: str
+    name_column: str
+    numeric_id: bool = True
+
+    @property
+    def table(self):
+        return table(
+            self.table_name,
+            column(self.id_column),
+            column(self.name_column),
+            column("account_set_id"),
+        )
+
+
+@dataclass(frozen=True)
+class ResourceRecord:
+    resource_type: str
+    resource_id: str
+    name: str
+    account_set_id: Optional[str]
+
+
+RESOURCE_DEFINITIONS = {
+    "DATASOURCE": ResourceDefinition("DATASOURCE", "connect_config", "id", "db_name"),
+    "KNOWLEDGE_BASE": ResourceDefinition(
+        "KNOWLEDGE_BASE", "knowledge_space", "id", "name"
+    ),
+    "AGENT": ResourceDefinition(
+        "AGENT", "gpts_app", "app_code", "app_name", numeric_id=False
+    ),
+}
+
+_DEPENDENCY_TYPES = {
+    "database": "DATASOURCE",
+    "db": "DATASOURCE",
+    "datasource": "DATASOURCE",
+    "knowledge": "KNOWLEDGE_BASE",
+    "knowledge_base": "KNOWLEDGE_BASE",
+}
+
+
+def resource_definition(resource_type: str) -> ResourceDefinition:
+    try:
+        return RESOURCE_DEFINITIONS[resource_type]
+    except KeyError as exc:
+        raise ResourceLookupError(
+            f"Unsupported resource type: {resource_type}"
+        ) from exc
+
+
+def _storage_id(definition: ResourceDefinition, resource_id: str) -> Any:
+    normalized = str(resource_id).strip()
+    if not normalized:
+        raise ResourceLookupError("Resource ID must not be blank")
+    if not definition.numeric_id:
+        return normalized
+    try:
+        return int(normalized)
+    except ValueError as exc:
+        raise ResourceLookupError(
+            f"{definition.resource_type} resource ID must be an integer"
+        ) from exc
+
+
+def get_resource(
+    session, resource_type: str, resource_id: str, *, for_update: bool = False
+) -> Optional[ResourceRecord]:
+    definition = resource_definition(resource_type)
+    resource_table = definition.table
+    statement = select(
+        resource_table.c[definition.id_column].label("resource_id"),
+        resource_table.c[definition.name_column].label("name"),
+        resource_table.c.account_set_id,
+    ).where(
+        resource_table.c[definition.id_column] == _storage_id(definition, resource_id)
+    )
+    if for_update:
+        statement = statement.with_for_update()
+    row = session.execute(statement).mappings().first()
+    if row is None:
+        return None
+    return ResourceRecord(
+        resource_type=resource_type,
+        resource_id=str(row["resource_id"]),
+        name=str(row["name"]),
+        account_set_id=row["account_set_id"],
+    )
+
+
+def list_resources(
+    session,
+    resource_type: str,
+    *,
+    account_set_ids: Optional[set[str]] = None,
+    account_set_id: Optional[str] = None,
+    unassigned: bool = False,
+    offset: int = 0,
+    limit: Optional[int] = None,
+) -> list[ResourceRecord]:
+    definition = resource_definition(resource_type)
+    resource_table = definition.table
+    statement = select(
+        resource_table.c[definition.id_column].label("resource_id"),
+        resource_table.c[definition.name_column].label("name"),
+        resource_table.c.account_set_id,
+    )
+    if account_set_ids is not None:
+        if not account_set_ids:
+            return []
+        statement = statement.where(
+            resource_table.c.account_set_id.in_(sorted(account_set_ids))
+        )
+    if account_set_id is not None:
+        statement = statement.where(resource_table.c.account_set_id == account_set_id)
+    if unassigned:
+        statement = statement.where(resource_table.c.account_set_id.is_(None))
+    statement = statement.order_by(resource_table.c[definition.name_column])
+    statement = statement.offset(offset)
+    if limit is not None:
+        statement = statement.limit(limit)
+    return [
+        ResourceRecord(
+            resource_type=resource_type,
+            resource_id=str(row["resource_id"]),
+            name=str(row["name"]),
+            account_set_id=row["account_set_id"],
+        )
+        for row in session.execute(statement).mappings().all()
+    ]
+
+
+def count_resources(
+    session,
+    resource_type: str,
+    *,
+    account_set_ids: Optional[set[str]] = None,
+    account_set_id: Optional[str] = None,
+    unassigned: bool = False,
+) -> int:
+    definition = resource_definition(resource_type)
+    resource_table = definition.table
+    if account_set_ids is not None and not account_set_ids:
+        return 0
+    statement = select(func.count()).select_from(resource_table)
+    if account_set_ids is not None:
+        statement = statement.where(
+            resource_table.c.account_set_id.in_(sorted(account_set_ids))
+        )
+    if account_set_id is not None:
+        statement = statement.where(resource_table.c.account_set_id == account_set_id)
+    if unassigned:
+        statement = statement.where(resource_table.c.account_set_id.is_(None))
+    return session.execute(statement).scalar_one()
+
+
+def assign_resource_account(
+    session, resource_type: str, resource_id: str, account_set_id: str
+) -> None:
+    definition = resource_definition(resource_type)
+    resource_table = definition.table
+    session.execute(
+        update(resource_table)
+        .where(
+            resource_table.c[definition.id_column]
+            == _storage_id(definition, resource_id)
+        )
+        .values(account_set_id=account_set_id)
+    )
+
+
+def agent_dependencies(session, agent_id: str) -> list[ResourceRecord]:
+    """Resolve datasource and knowledge dependencies stored on an agent."""
+    detail_table = table("gpts_app_detail", column("app_code"), column("resources"))
+    rows = session.execute(
+        select(detail_table.c.resources).where(detail_table.c.app_code == agent_id)
+    ).all()
+    dependencies: dict[tuple[str, str], ResourceRecord] = {}
+    for (serialized,) in rows:
+        if not serialized:
+            continue
+        try:
+            items = json.loads(serialized)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ResourceLookupError(
+                f"Agent {agent_id} contains invalid dependency metadata"
+            ) from exc
+        if not isinstance(items, list):
+            raise ResourceLookupError(
+                f"Agent {agent_id} contains invalid dependency metadata"
+            )
+        for item in items:
+            dependency = _resolve_dependency(session, agent_id, item)
+            if dependency is not None:
+                dependencies[(dependency.resource_type, dependency.resource_id)] = (
+                    dependency
+                )
+    return list(dependencies.values())
+
+
+def dependent_agent_ids(session, dependency_type: str, dependency_id: str) -> set[str]:
+    """Find agents whose stored configuration references a protected resource."""
+    app_table = RESOURCE_DEFINITIONS["AGENT"].table
+    agent_ids = {
+        str(value)
+        for value in session.execute(select(app_table.c.app_code)).scalars().all()
+    }
+    matches: set[str] = set()
+    for agent_id in agent_ids:
+        for dependency in agent_dependencies(session, agent_id):
+            if (
+                dependency.resource_type == dependency_type
+                and dependency.resource_id == str(dependency_id)
+            ):
+                matches.add(agent_id)
+                break
+    return matches
+
+
+def _resolve_dependency(session, agent_id: str, item: Any) -> Optional[ResourceRecord]:
+    if not isinstance(item, dict):
+        raise ResourceLookupError(
+            f"Agent {agent_id} contains invalid dependency metadata"
+        )
+    resource_type = _DEPENDENCY_TYPES.get(str(item.get("type", "")).lower())
+    if resource_type is None:
+        return None
+    raw_value = item.get("value")
+    if isinstance(raw_value, str):
+        try:
+            decoded_value = json.loads(raw_value)
+        except json.JSONDecodeError:
+            decoded_value = raw_value
+    else:
+        decoded_value = raw_value
+    lookup_value = _dependency_lookup_value(resource_type, decoded_value)
+    if lookup_value is None:
+        raise ResourceLookupError(
+            f"Agent {agent_id} has an unresolved {resource_type} dependency"
+        )
+    dependency = _get_resource_by_id_or_name(session, resource_type, lookup_value)
+    if dependency is None:
+        raise ResourceLookupError(
+            f"Agent {agent_id} references a missing {resource_type} dependency"
+        )
+    return dependency
+
+
+def _dependency_lookup_value(resource_type: str, value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    if not isinstance(value, dict):
+        return None
+    preferred_keys = (
+        ("resource_id", "db_name", "id", "value", "name")
+        if resource_type == "DATASOURCE"
+        else ("resource_id", "space_name", "id", "value", "name")
+    )
+    for key in preferred_keys:
+        candidate = value.get(key)
+        if candidate is not None and str(candidate).strip():
+            return str(candidate).strip()
+    return None
+
+
+def _get_resource_by_id_or_name(
+    session, resource_type: str, lookup_value: str
+) -> Optional[ResourceRecord]:
+    definition = resource_definition(resource_type)
+    try:
+        by_id = get_resource(session, resource_type, lookup_value)
+    except ResourceLookupError:
+        by_id = None
+    if by_id is not None:
+        return by_id
+    resource_table = definition.table
+    row = (
+        session.execute(
+            select(
+                resource_table.c[definition.id_column].label("resource_id"),
+                resource_table.c[definition.name_column].label("name"),
+                resource_table.c.account_set_id,
+            ).where(resource_table.c[definition.name_column] == lookup_value)
+        )
+        .mappings()
+        .first()
+    )
+    if row is None:
+        return None
+    return ResourceRecord(
+        resource_type=resource_type,
+        resource_id=str(row["resource_id"]),
+        name=str(row["name"]),
+        account_set_id=row["account_set_id"],
+    )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -24,6 +24,8 @@ from dbgpt_serve.auth.models.models import (
     UserDao,
     UserEntity,
 )
+from dbgpt_serve.auth.service.importer import LszyzdImporter
+from dbgpt_serve.auth.service.management import ManagementMixin
 from dbgpt_serve.core import BaseService
 
 logger = logging.getLogger(__name__)
@@ -46,7 +48,7 @@ class AuthConfigurationError(RuntimeError):
     """Raised when authentication cannot operate securely."""
 
 
-class Service(BaseService[UserEntity, object, UserResponse]):
+class Service(ManagementMixin, BaseService[UserEntity, object, UserResponse]):
     """Password authentication and revocable session management."""
 
     name = SERVE_SERVICE_COMPONENT_NAME
@@ -57,12 +59,14 @@ class Service(BaseService[UserEntity, object, UserResponse]):
         config: ServeConfig,
         user_dao: Optional[UserDao] = None,
         session_dao: Optional[SessionDao] = None,
+        importer: Optional[LszyzdImporter] = None,
     ) -> None:
         super().__init__(system_app)
         self._config = config
         self._validate_config()
         self._dao = user_dao or UserDao()
         self._session_dao = session_dao or SessionDao()
+        self._importer = importer
         self._dummy_password = secrets.token_urlsafe(32)
         self._dummy_password_hash = self.hash_password(self._dummy_password)
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -1,5 +1,7 @@
 """Core authentication service."""
 
+import hashlib
+import hmac
 import logging
 import secrets
 import uuid
@@ -253,6 +255,21 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             user_response = UserResponse.from_entity(user)
 
         return user_response, session_id
+
+    def csrf_token(self, token: str) -> str:
+        """Derive a CSRF token without exposing the session cookie value."""
+        self._require_jwt_secret()
+        return hmac.new(
+            self._config.jwt_secret.encode("utf-8"),
+            token.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def validate_csrf_token(self, token: str, candidate: str) -> bool:
+        """Compare a submitted CSRF token using constant-time equality."""
+        if not candidate:
+            return False
+        return hmac.compare_digest(self.csrf_token(token), candidate)
 
     def logout(self, user_id: str, session_id: str) -> None:
         """Idempotently revoke the current authenticated session."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -8,8 +8,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+import bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 
 from dbgpt._private.config import Config
 from dbgpt.component import SystemApp
@@ -63,11 +63,8 @@ class Service(BaseService[UserEntity, object, UserResponse]):
         self._validate_config()
         self._dao = user_dao or UserDao()
         self._session_dao = session_dao or SessionDao()
-        self._password_context = CryptContext(
-            schemes=["bcrypt"], bcrypt__rounds=12, deprecated="auto"
-        )
         self._dummy_password = secrets.token_urlsafe(32)
-        self._dummy_password_hash = self._password_context.hash(self._dummy_password)
+        self._dummy_password_hash = self.hash_password(self._dummy_password)
 
     @property
     def dao(self) -> BaseDao:
@@ -83,7 +80,21 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             raise ValueError("Password must not be empty")
         if len(password.encode("utf-8")) > 72:
             raise ValueError("Password must not exceed 72 bytes")
-        return self._password_context.hash(password)
+        return bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt(rounds=12)
+        ).decode("ascii")
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str) -> bool:
+        """Verify a supported plaintext password against a bcrypt hash."""
+        if not password or len(password.encode("utf-8")) > 72:
+            return False
+        try:
+            return bcrypt.checkpw(
+                password.encode("utf-8"), password_hash.encode("ascii")
+            )
+        except (TypeError, ValueError, UnicodeError):
+            return False
 
     def login(
         self, login_name: str, password: str, ip: str, user_agent: str
@@ -116,12 +127,7 @@ class Service(BaseService[UserEntity, object, UserResponse]):
             candidate_password = (
                 password if password_is_supported else self._dummy_password
             )
-            try:
-                password_matches = self._password_context.verify(
-                    candidate_password, candidate_hash
-                )
-            except (TypeError, ValueError):
-                password_matches = False
+            password_matches = self.verify_password(candidate_password, candidate_hash)
             password_matches = password_matches and password_is_supported
 
             is_locked = bool(user and user.locked_until and user.locked_until > now)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -1,0 +1,427 @@
+"""Core authentication service."""
+
+import logging
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from dbgpt._private.config import Config
+from dbgpt.component import SystemApp
+from dbgpt.storage.metadata import BaseDao
+from dbgpt_serve.auth.api.schemas import UserResponse
+from dbgpt_serve.auth.config import SERVE_SERVICE_COMPONENT_NAME, ServeConfig
+from dbgpt_serve.auth.constants import FIXED_ROLES
+from dbgpt_serve.auth.models.models import (
+    AuditEventEntity,
+    SessionDao,
+    SessionEntity,
+    UserDao,
+    UserEntity,
+)
+from dbgpt_serve.core import BaseService
+
+logger = logging.getLogger(__name__)
+
+JWT_ALGORITHM = "HS256"
+JWT_AUDIENCE = "dbgpt-admin"
+JWT_ISSUER = "dbgpt"
+GENERIC_LOGIN_ERROR = "Invalid login name or password"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class AuthenticationError(Exception):
+    """Raised when credentials or session state are invalid."""
+
+
+class AuthConfigurationError(RuntimeError):
+    """Raised when authentication cannot operate securely."""
+
+
+class Service(BaseService[UserEntity, object, UserResponse]):
+    """Password authentication and revocable session management."""
+
+    name = SERVE_SERVICE_COMPONENT_NAME
+
+    def __init__(
+        self,
+        system_app: Optional[SystemApp],
+        config: ServeConfig,
+        user_dao: Optional[UserDao] = None,
+        session_dao: Optional[SessionDao] = None,
+    ) -> None:
+        super().__init__(system_app)
+        self._config = config
+        self._validate_config()
+        self._dao = user_dao or UserDao()
+        self._session_dao = session_dao or SessionDao()
+        self._password_context = CryptContext(
+            schemes=["bcrypt"], bcrypt__rounds=12, deprecated="auto"
+        )
+        self._dummy_password = secrets.token_urlsafe(32)
+        self._dummy_password_hash = self._password_context.hash(self._dummy_password)
+
+    @property
+    def dao(self) -> BaseDao:
+        return self._dao
+
+    @property
+    def config(self) -> ServeConfig:
+        return self._config
+
+    def hash_password(self, password: str) -> str:
+        """Hash a password using the configured adaptive password scheme."""
+        if not password:
+            raise ValueError("Password must not be empty")
+        if len(password.encode("utf-8")) > 72:
+            raise ValueError("Password must not exceed 72 bytes")
+        return self._password_context.hash(password)
+
+    def login(
+        self, login_name: str, password: str, ip: str, user_agent: str
+    ) -> tuple[str, UserResponse]:
+        """Authenticate credentials and create a revocable session."""
+        self._require_jwt_secret()
+        ip = (ip or "")[:64]
+        user_agent = (user_agent or "")[:512]
+        now = _utcnow()
+        session_id = str(uuid.uuid4())
+        absolute_expires_at = now + timedelta(
+            minutes=self._config.jwt_absolute_expire_minutes
+        )
+        idle_expires_at = min(
+            now + timedelta(minutes=self._config.jwt_access_expire_minutes),
+            absolute_expires_at,
+        )
+        login_error: Optional[AuthenticationError] = None
+        user_response: Optional[UserResponse] = None
+
+        with self._dao.session() as session:
+            user = (
+                session.query(UserEntity)
+                .filter(UserEntity.login_name == login_name)
+                .with_for_update()
+                .first()
+            )
+            password_is_supported = 0 < len(password.encode("utf-8")) <= 72
+            candidate_hash = user.password_hash if user else self._dummy_password_hash
+            candidate_password = (
+                password if password_is_supported else self._dummy_password
+            )
+            try:
+                password_matches = self._password_context.verify(
+                    candidate_password, candidate_hash
+                )
+            except (TypeError, ValueError):
+                password_matches = False
+            password_matches = password_matches and password_is_supported
+
+            is_locked = bool(user and user.locked_until and user.locked_until > now)
+            is_allowed = bool(
+                user
+                and user.is_active
+                and user.role in FIXED_ROLES
+                and not is_locked
+                and password_matches
+            )
+            if not is_allowed:
+                if user and user.is_active and not is_locked and not password_matches:
+                    user.login_fail_count += 1
+                    if user.login_fail_count >= self._config.login_fail_lock_threshold:
+                        user.locked_until = now + timedelta(
+                            minutes=self._config.login_fail_lock_minutes
+                        )
+                if is_locked:
+                    deny_reason = "ACCOUNT_LOCKED"
+                elif user and not user.is_active:
+                    deny_reason = "ACCOUNT_DISABLED"
+                elif user and user.role not in FIXED_ROLES:
+                    deny_reason = "INVALID_ROLE"
+                else:
+                    deny_reason = "INVALID_CREDENTIALS"
+                session.add(
+                    self._audit_event(
+                        action="AUTH.LOGIN",
+                        result="denied",
+                        operator_user_id=user.user_id if user else None,
+                        operator_role=user.role if user else None,
+                        target_id=user.user_id if user else None,
+                        source_ip=ip,
+                        user_agent=user_agent,
+                        deny_reason=deny_reason,
+                    )
+                )
+                login_error = AuthenticationError(GENERIC_LOGIN_ERROR)
+            else:
+                user.login_fail_count = 0
+                user.locked_until = None
+                session.add(
+                    SessionEntity(
+                        session_id=session_id,
+                        user_id=user.user_id,
+                        issued_at=now,
+                        last_seen_at=now,
+                        idle_expires_at=idle_expires_at,
+                        absolute_expires_at=absolute_expires_at,
+                        source_ip=ip or None,
+                        user_agent=(user_agent or "")[:512] or None,
+                    )
+                )
+                session.add(
+                    self._audit_event(
+                        action="AUTH.LOGIN",
+                        result="success",
+                        operator_user_id=user.user_id,
+                        operator_role=user.role,
+                        target_id=user.user_id,
+                        source_ip=ip,
+                        user_agent=user_agent,
+                    )
+                )
+                user_response = UserResponse.from_entity(user)
+
+        if login_error:
+            raise login_error
+        if user_response is None:
+            raise AuthenticationError(GENERIC_LOGIN_ERROR)
+
+        token = jwt.encode(
+            {
+                "sub": user_response.user_id,
+                "jti": session_id,
+                "iat": now,
+                "exp": absolute_expires_at,
+                "iss": JWT_ISSUER,
+                "aud": JWT_AUDIENCE,
+            },
+            self._config.jwt_secret,
+            algorithm=JWT_ALGORITHM,
+        )
+        return token, user_response
+
+    def authenticate_token(self, token: str) -> tuple[UserResponse, str]:
+        """Validate a JWT, its server-side session, and current user state."""
+        self._require_jwt_secret()
+        try:
+            payload = jwt.decode(
+                token,
+                self._config.jwt_secret,
+                algorithms=[JWT_ALGORITHM],
+                audience=JWT_AUDIENCE,
+                issuer=JWT_ISSUER,
+            )
+        except JWTError as exc:
+            raise AuthenticationError("Invalid or expired session") from exc
+
+        user_id = payload.get("sub")
+        session_id = payload.get("jti")
+        if not isinstance(user_id, str) or not isinstance(session_id, str):
+            raise AuthenticationError("Invalid or expired session")
+
+        now = _utcnow()
+        with self._session_dao.session() as session:
+            auth_session = (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                    SessionEntity.revoked_at.is_(None),
+                    SessionEntity.idle_expires_at > now,
+                    SessionEntity.absolute_expires_at > now,
+                )
+                .first()
+            )
+            user = (
+                session.query(UserEntity)
+                .filter(UserEntity.user_id == user_id, UserEntity.is_active.is_(True))
+                .first()
+            )
+            if auth_session is None or user is None or user.role not in FIXED_ROLES:
+                raise AuthenticationError("Invalid or expired session")
+
+            auth_session.last_seen_at = now
+            auth_session.idle_expires_at = min(
+                now + timedelta(minutes=self._config.jwt_access_expire_minutes),
+                auth_session.absolute_expires_at,
+            )
+            user_response = UserResponse.from_entity(user)
+
+        return user_response, session_id
+
+    def logout(self, user_id: str, session_id: str) -> None:
+        """Idempotently revoke the current authenticated session."""
+        now = _utcnow()
+        with self._session_dao.session() as session:
+            auth_session = (
+                session.query(SessionEntity)
+                .filter(
+                    SessionEntity.session_id == session_id,
+                    SessionEntity.user_id == user_id,
+                )
+                .first()
+            )
+            if auth_session is not None and auth_session.revoked_at is None:
+                auth_session.revoked_at = now
+                auth_session.revoked_by = user_id
+                auth_session.revoke_reason = "LOGOUT"
+            user = (
+                session.query(UserEntity).filter(UserEntity.user_id == user_id).first()
+            )
+            session.add(
+                self._audit_event(
+                    action="AUTH.LOGOUT",
+                    result="success",
+                    operator_user_id=user_id,
+                    operator_role=user.role if user else None,
+                    target_type="SESSION",
+                    target_id=session_id,
+                )
+            )
+
+    def get_user(self, user_id: str) -> UserResponse:
+        """Return the current non-sensitive user representation."""
+        user = self._dao.get_by_user_id(user_id)
+        if user is None or not user.is_active or user.role not in FIXED_ROLES:
+            raise AuthenticationError("User is not active")
+        return UserResponse.from_entity(user)
+
+    def ensure_initial_admin(self) -> Optional[UserResponse]:
+        """Create the configured first administrator when no active admin exists."""
+        if self._dao.count_active_admins() > 0:
+            return None
+        if not isinstance(self._config.initial_admin_password, str):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_password must be a string"
+            )
+        if not self._config.initial_admin_password:
+            logger.warning(
+                "No initial administrator exists and initial_admin_password is empty"
+            )
+            return None
+
+        if not isinstance(self._config.initial_admin_login, str):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_login must be a string"
+            )
+        login_name = self._config.initial_admin_login.strip()
+        if not login_name or len(login_name) > 128:
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_login must contain 1 to 128 characters"
+            )
+        try:
+            password_hash = self.hash_password(self._config.initial_admin_password)
+        except ValueError as exc:
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.initial_admin_password is invalid"
+            ) from exc
+
+        now = _utcnow()
+        with self._dao.session() as session:
+            if (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.role == "system_admin",
+                    UserEntity.is_active.is_(True),
+                )
+                .count()
+                > 0
+            ):
+                return None
+            if (
+                session.query(UserEntity)
+                .filter(UserEntity.login_name == login_name)
+                .first()
+                is not None
+            ):
+                raise AuthConfigurationError(
+                    "dbgpt.serve.auth.initial_admin_login already exists"
+                )
+            user = UserEntity(
+                user_id=str(uuid.uuid4()),
+                login_name=login_name,
+                display_name=login_name,
+                password_hash=password_hash,
+                role="system_admin",
+                is_active=True,
+                gmt_created=now,
+                gmt_modified=now,
+            )
+            session.add(user)
+            session.flush()
+            session.add(
+                self._audit_event(
+                    action="SYSTEM.INIT_ADMIN",
+                    result="success",
+                    operator_user_id=user.user_id,
+                    operator_role=user.role,
+                    target_id=user.user_id,
+                )
+            )
+            return UserResponse.from_entity(user)
+
+    def _require_jwt_secret(self) -> None:
+        if (
+            not isinstance(self._config.jwt_secret, str)
+            or len(self._config.jwt_secret.encode("utf-8")) < 32
+        ):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.jwt_secret must contain at least 32 bytes"
+            )
+
+    def _validate_config(self) -> None:
+        if not isinstance(self._config.cookie_secure, bool):
+            raise AuthConfigurationError(
+                "dbgpt.serve.auth.cookie_secure must be a boolean"
+            )
+        positive_integer_fields = (
+            "jwt_access_expire_minutes",
+            "jwt_absolute_expire_minutes",
+            "login_fail_lock_threshold",
+            "login_fail_lock_minutes",
+        )
+        for field_name in positive_integer_fields:
+            value = getattr(self._config, field_name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise AuthConfigurationError(
+                    f"dbgpt.serve.auth.{field_name} must be a positive integer"
+                )
+
+    @staticmethod
+    def _audit_event(
+        action: str,
+        result: str,
+        operator_user_id: Optional[str],
+        operator_role: Optional[str],
+        target_id: Optional[str],
+        target_type: str = "USER",
+        source_ip: str = "",
+        user_agent: str = "",
+        deny_reason: Optional[str] = None,
+    ) -> AuditEventEntity:
+        return AuditEventEntity(
+            event_id=str(uuid.uuid4()),
+            event_time=_utcnow(),
+            operator_user_id=operator_user_id,
+            operator_role_snapshot=operator_role,
+            target_type=target_type,
+            target_id=target_id,
+            action=action,
+            result=result,
+            source_ip=(source_ip or "")[:64] or None,
+            user_agent=(user_agent or "")[:512] or None,
+            deny_reason=deny_reason,
+        )
+
+
+def get_auth_service() -> Service:
+    """Resolve the initialized authorization service from the application."""
+    system_app = Config().SYSTEM_APP
+    if system_app is None:
+        raise AuthConfigurationError("SystemApp is not initialized")
+    return system_app.get_component(SERVE_SERVICE_COMPONENT_NAME, Service)

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/service.py
@@ -24,6 +24,7 @@ from dbgpt_serve.auth.models.models import (
     UserDao,
     UserEntity,
 )
+from dbgpt_serve.auth.service.authorization import AuthorizationMixin
 from dbgpt_serve.auth.service.importer import LszyzdImporter
 from dbgpt_serve.auth.service.management import ManagementMixin
 from dbgpt_serve.core import BaseService
@@ -48,7 +49,11 @@ class AuthConfigurationError(RuntimeError):
     """Raised when authentication cannot operate securely."""
 
 
-class Service(ManagementMixin, BaseService[UserEntity, object, UserResponse]):
+class Service(
+    AuthorizationMixin,
+    ManagementMixin,
+    BaseService[UserEntity, object, UserResponse],
+):
     """Password authentication and revocable session management."""
 
     name = SERVE_SERVICE_COMPONENT_NAME

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/service/token_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/service/token_service.py
@@ -1,0 +1,250 @@
+"""Idempotent model-call metering and scoped usage queries."""
+
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.exc import IntegrityError
+
+from dbgpt_serve.auth.api.schemas import (
+    Page,
+    TokenDailyResponse,
+    TokenUsageCreate,
+    TokenUsageQueryRequest,
+    TokenUsageResponse,
+    TokenUsageSummaryResponse,
+)
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    TokenDailyEntity,
+    TokenUsageDao,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+)
+from dbgpt_serve.auth.service.errors import ManagementValidationError
+from dbgpt_serve.auth.service.management import Operator, _utcnow
+
+SHANGHAI = ZoneInfo("Asia/Shanghai")
+
+
+class TokenService:
+    """Store every physical model call and maintain reproducible daily totals."""
+
+    def __init__(self, dao: Optional[TokenUsageDao] = None) -> None:
+        self._dao = dao or TokenUsageDao()
+
+    def record_usage(self, usage: TokenUsageCreate) -> bool:
+        """Return true only when a new call ID was metered."""
+        created_at = self._as_naive_utc(usage.gmt_created)
+        stat_date = (
+            created_at.replace(tzinfo=timezone.utc).astimezone(SHANGHAI).date()
+        ).isoformat()
+        for attempt in range(2):
+            try:
+                with self._dao.session() as session:
+                    if (
+                        session.query(TokenUsageEntity.id)
+                        .filter(TokenUsageEntity.call_id == usage.call_id)
+                        .first()
+                        is not None
+                    ):
+                        return False
+                    entity_data = usage.model_dump(exclude={"gmt_created"})
+                    session.add(
+                        TokenUsageEntity(
+                            **entity_data,
+                            gmt_created=created_at,
+                        )
+                    )
+                    session.flush()
+                    account_set_id = usage.account_set_id or ""
+                    daily = (
+                        session.query(TokenDailyEntity)
+                        .filter(
+                            TokenDailyEntity.stat_date == stat_date,
+                            TokenDailyEntity.user_id == usage.user_id,
+                            TokenDailyEntity.role_snapshot == usage.role_snapshot,
+                            TokenDailyEntity.account_set_id == account_set_id,
+                            TokenDailyEntity.model == usage.model,
+                        )
+                        .with_for_update()
+                        .first()
+                    )
+                    now = _utcnow()
+                    if daily is None:
+                        daily = TokenDailyEntity(
+                            stat_date=stat_date,
+                            user_id=usage.user_id,
+                            role_snapshot=usage.role_snapshot,
+                            account_set_id=account_set_id,
+                            model=usage.model,
+                            input_tokens=usage.input_tokens,
+                            output_tokens=usage.output_tokens,
+                            total_tokens=usage.total_tokens,
+                            call_count=1,
+                            gmt_created=now,
+                            gmt_modified=now,
+                        )
+                        session.add(daily)
+                    else:
+                        daily.input_tokens += usage.input_tokens
+                        daily.output_tokens += usage.output_tokens
+                        daily.total_tokens += usage.total_tokens
+                        daily.call_count += 1
+                        daily.gmt_modified = now
+                    session.flush()
+                return True
+            except IntegrityError:
+                if self._dao.get_by_call_id(usage.call_id) is not None:
+                    return False
+                if attempt == 1:
+                    raise
+        return False
+
+    def query_usage(
+        self,
+        filters: TokenUsageQueryRequest,
+        operator: Operator,
+        page: int,
+        page_size: int,
+    ) -> Page[TokenUsageResponse]:
+        self._validate_page(page, page_size)
+        with self._dao.session(commit=False) as session:
+            query = session.query(TokenUsageEntity)
+            query = self._scope_query(query, TokenUsageEntity, session, operator)
+            query = self._apply_usage_filters(query, filters)
+            total = query.count()
+            entities = (
+                query.order_by(
+                    TokenUsageEntity.gmt_created.desc(), TokenUsageEntity.id.desc()
+                )
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            items = [TokenUsageResponse.model_validate(item) for item in entities]
+        return Page(items=items, total=total, page=page, page_size=page_size)
+
+    def query_daily(
+        self, filters: TokenUsageQueryRequest, operator: Operator
+    ) -> list[TokenDailyResponse]:
+        date_to = filters.date_to or self.reporting_date()
+        date_from = filters.date_from or (date_to - timedelta(days=29))
+        if (date_to - date_from).days > 365:
+            raise ManagementValidationError(
+                "Daily usage queries may span at most 366 days"
+            )
+        with self._dao.session(commit=False) as session:
+            query = session.query(TokenDailyEntity)
+            query = self._scope_query(query, TokenDailyEntity, session, operator)
+            if filters.user_id:
+                query = query.filter(TokenDailyEntity.user_id == filters.user_id)
+            if filters.account_set_id is not None:
+                query = query.filter(
+                    TokenDailyEntity.account_set_id == filters.account_set_id
+                )
+            if filters.model:
+                query = query.filter(TokenDailyEntity.model == filters.model)
+            if filters.role:
+                query = query.filter(TokenDailyEntity.role_snapshot == filters.role)
+            query = query.filter(
+                TokenDailyEntity.stat_date >= date_from.isoformat(),
+                TokenDailyEntity.stat_date <= date_to.isoformat(),
+            )
+            entities = query.order_by(
+                TokenDailyEntity.stat_date.desc(), TokenDailyEntity.id.desc()
+            ).all()
+            return [TokenDailyResponse.model_validate(item) for item in entities]
+
+    def summary(self, stat_date: date, operator: Operator) -> TokenUsageSummaryResponse:
+        daily = self.query_daily(
+            TokenUsageQueryRequest(date_from=stat_date, date_to=stat_date),
+            operator,
+        )
+        return TokenUsageSummaryResponse(
+            stat_date=stat_date.isoformat(),
+            input_tokens=sum(item.input_tokens for item in daily),
+            output_tokens=sum(item.output_tokens for item in daily),
+            total_tokens=sum(item.total_tokens for item in daily),
+            call_count=sum(item.call_count for item in daily),
+        )
+
+    @staticmethod
+    def reporting_date() -> date:
+        return datetime.now(timezone.utc).astimezone(SHANGHAI).date()
+
+    @staticmethod
+    def _validate_page(page: int, page_size: int) -> None:
+        if page < 1 or page_size < 1 or page_size > 100:
+            raise ManagementValidationError(
+                "page must be at least 1 and page_size must be between 1 and 100"
+            )
+
+    @staticmethod
+    def _scope_query(query, entity_type, session, operator: Operator):
+        if not operator.user_id or not operator.role:
+            raise ManagementValidationError("An authenticated user is required")
+        if operator.role == "system_admin":
+            return query
+        if operator.role == "query_user":
+            return query.filter(entity_type.user_id == operator.user_id)
+        if operator.role != "operations_admin":
+            raise ManagementValidationError("The user role cannot read usage")
+        account_set_ids = (
+            session.query(UserAccountGrantEntity.account_set_id)
+            .join(
+                AccountSetEntity,
+                AccountSetEntity.account_set_id
+                == UserAccountGrantEntity.account_set_id,
+            )
+            .filter(
+                UserAccountGrantEntity.user_id == operator.user_id,
+                UserAccountGrantEntity.is_active.is_(True),
+                AccountSetEntity.is_active.is_(True),
+            )
+        )
+        return query.filter(entity_type.account_set_id.in_(account_set_ids))
+
+    @classmethod
+    def _apply_usage_filters(cls, query, filters: TokenUsageQueryRequest):
+        if filters.user_id:
+            query = query.filter(TokenUsageEntity.user_id == filters.user_id)
+        if filters.account_set_id is not None:
+            query = query.filter(
+                TokenUsageEntity.account_set_id == filters.account_set_id
+            )
+        if filters.model:
+            query = query.filter(TokenUsageEntity.model == filters.model)
+        if filters.role:
+            query = query.filter(TokenUsageEntity.role_snapshot == filters.role)
+        if filters.date_from:
+            query = query.filter(
+                TokenUsageEntity.gmt_created >= cls._local_day_start(filters.date_from)
+            )
+        if filters.date_to:
+            query = query.filter(
+                TokenUsageEntity.gmt_created
+                < cls._local_day_start(filters.date_to + timedelta(days=1))
+            )
+        return query
+
+    @staticmethod
+    def _local_day_start(value: date) -> datetime:
+        return (
+            datetime.combine(value, time.min, SHANGHAI)
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+        )
+
+    @staticmethod
+    def _as_naive_utc(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+_token_service = TokenService()
+
+
+def get_token_service() -> TokenService:
+    return _token_service

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_alembic_migration.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_alembic_migration.py
@@ -1,0 +1,136 @@
+"""Integration test for the dynamic Alembic migration flow."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Column, Index, Integer, MetaData, String, Table, create_engine
+from sqlalchemy import inspect as sqlalchemy_inspect
+
+from dbgpt.storage.metadata import Model
+from dbgpt_serve.auth.models.models import (  # noqa: F401
+    AccountSetEntity,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
+
+AUTH_TABLES = {
+    "dbgpt_auth_user",
+    "dbgpt_auth_account_set",
+    "dbgpt_auth_user_account_grant",
+    "dbgpt_auth_user_resource_grant",
+    "dbgpt_auth_import_batch",
+    "dbgpt_auth_token_usage",
+    "dbgpt_auth_token_daily",
+    "dbgpt_auth_audit_event",
+    "dbgpt_auth_session",
+}
+
+RESOURCE_INDEXES = {
+    "connect_config": "idx_connect_account_set",
+    "knowledge_space": "idx_ks_account_set",
+    "gpts_app": "idx_app_account_set",
+}
+
+ALEMBIC_ENV = """from alembic import context
+
+config = context.config
+connection = config.attributes["connection"]
+target_metadata = config.attributes["target_metadata"]
+
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_as_batch=connection.dialect.name == "sqlite",
+    compare_type=True,
+)
+
+with context.begin_transaction():
+    context.run_migrations()
+"""
+
+
+def _create_baseline(engine) -> None:
+    metadata = MetaData()
+    for table_name in RESOURCE_INDEXES:
+        Table(table_name, metadata, Column("id", Integer, primary_key=True))
+    metadata.create_all(engine)
+
+
+def _build_target_metadata() -> MetaData:
+    metadata = MetaData()
+    for table_name in AUTH_TABLES:
+        Model.metadata.tables[table_name].to_metadata(metadata)
+    for table_name, index_name in RESOURCE_INDEXES.items():
+        table = Table(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("account_set_id", String(128), nullable=True),
+        )
+        Index(index_name, table.c.account_set_id)
+    return metadata
+
+
+def _create_alembic_config(tmp_path: Path, target_metadata: MetaData) -> Config:
+    script_location = tmp_path / "alembic"
+    versions = script_location / "versions"
+    versions.mkdir(parents=True)
+    (script_location / "env.py").write_text(ALEMBIC_ENV, encoding="utf-8")
+
+    repository_root = Path(__file__).parents[6]
+    template = repository_root / "pilot" / "meta_data" / "alembic" / "script.py.mako"
+    (script_location / "script.py.mako").write_text(
+        template.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    ini_path = tmp_path / "alembic.ini"
+    ini_path.write_text("[alembic]\n", encoding="utf-8")
+    config = Config(str(ini_path))
+    config.set_main_option("script_location", str(script_location))
+    config.attributes["target_metadata"] = target_metadata
+    return config
+
+
+def test_alembic_upgrade_and_downgrade_auth_schema(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+    _create_baseline(engine)
+    config = _create_alembic_config(tmp_path, _build_target_metadata())
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        revision = command.revision(
+            config, message="add authorization center tables", autogenerate=True
+        )
+    assert revision is not None
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, "head")
+
+    inspector = sqlalchemy_inspect(engine)
+    assert AUTH_TABLES <= set(inspector.get_table_names())
+    for table_name, index_name in RESOURCE_INDEXES.items():
+        assert "account_set_id" in {
+            column["name"] for column in inspector.get_columns(table_name)
+        }
+        assert index_name in {
+            index["name"] for index in inspector.get_indexes(table_name)
+        }
+
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, "base")
+
+    inspector = sqlalchemy_inspect(engine)
+    assert AUTH_TABLES.isdisjoint(inspector.get_table_names())
+    for table_name in RESOURCE_INDEXES:
+        assert "account_set_id" not in {
+            column["name"] for column in inspector.get_columns(table_name)
+        }

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
@@ -1,0 +1,192 @@
+"""HTTP contract tests for authentication endpoints."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.endpoints import router
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import UserEntity
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.utils.auth import (
+    UserRequest,
+    get_current_user,
+    get_user_from_headers,
+    require_permission,
+)
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    auth_service = Service(
+        None,
+        ServeConfig(
+            jwt_secret=TEST_SECRET,
+            cookie_secure=True,
+            jwt_access_expire_minutes=30,
+            jwt_absolute_expire_minutes=120,
+        ),
+    )
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash=auth_service.hash_password("correct-password"),
+                role="query_user",
+                is_active=True,
+            )
+        )
+    return auth_service
+
+
+@pytest.fixture
+def app(service):
+    api = FastAPI()
+    api.include_router(router, prefix="/api/v1/admin")
+    api.dependency_overrides[get_auth_service] = lambda: service
+    return api
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, base_url="https://testserver")
+
+
+def test_login_cookie_me_and_logout(client):
+    login_response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "correct-password"},
+    )
+
+    assert login_response.status_code == 200
+    assert login_response.json()["data"]["user"]["user_id"] == "user-1"
+    assert login_response.headers["cache-control"] == "no-store"
+    assert login_response.headers["pragma"] == "no-cache"
+    set_cookie = login_response.headers["set-cookie"].lower()
+    assert "httponly" in set_cookie
+    assert "secure" in set_cookie
+    assert "samesite=lax" in set_cookie
+
+    me_response = client.get("/api/v1/admin/auth/me")
+    assert me_response.status_code == 200
+    assert me_response.json()["data"]["role"] == "query_user"
+    assert me_response.headers["cache-control"] == "no-store"
+
+    logout_response = client.post("/api/v1/admin/auth/logout")
+    assert logout_response.status_code == 200
+    assert logout_response.headers["cache-control"] == "no-store"
+    assert client.get("/api/v1/admin/auth/me").status_code == 401
+
+
+def test_login_failure_does_not_reveal_account_state(client):
+    existing = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "wrong-password"},
+    )
+    missing = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "missing", "password": "wrong-password"},
+    )
+
+    assert existing.status_code == missing.status_code == 401
+    assert existing.json()["detail"] == missing.json()["detail"]
+
+
+def test_login_handles_password_beyond_bcrypt_limit_as_invalid_credentials(client):
+    response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "密" * 25},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid login name or password"
+    assert "密" * 25 not in response.text
+
+
+def test_bearer_token_authentication(client):
+    login_response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": "alice", "password": "correct-password"},
+    )
+    token = login_response.json()["data"]["access_token"]
+    client.cookies.clear()
+
+    response = client.get(
+        "/api/v1/admin/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+
+
+def test_legacy_dependency_name_remains_overridable():
+    api = FastAPI()
+
+    @api.get("/legacy")
+    async def legacy(user: UserRequest = Depends(get_user_from_headers)):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_user_from_headers] = lambda: UserRequest(
+        user_id="test-user"
+    )
+    with TestClient(api) as test_client:
+        response = test_client.get("/legacy")
+
+    assert response.status_code == 200
+    assert response.json() == {"user_id": "test-user"}
+
+
+def test_legacy_dependency_no_longer_accepts_mock_user_headers(service):
+    api = FastAPI()
+
+    @api.get("/legacy")
+    async def legacy(user: UserRequest = Depends(get_user_from_headers)):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_auth_service] = lambda: service
+    with TestClient(api) as test_client:
+        response = test_client.get("/legacy", headers={"user-id": "admin"})
+
+    assert response.status_code == 401
+
+
+def test_permission_dependency_uses_fixed_role_capabilities():
+    api = FastAPI()
+
+    @api.get("/chat")
+    async def chat(
+        user: UserRequest = Depends(require_permission("CHAT_USE")),
+    ):
+        return {"user_id": user.user_id}
+
+    @api.get("/users")
+    async def users(
+        user: UserRequest = Depends(require_permission("USER_MANAGE")),
+    ):
+        return {"user_id": user.user_id}
+
+    api.dependency_overrides[get_current_user] = lambda: UserRequest(
+        user_id="query-user", role="query_user"
+    )
+    with TestClient(api) as test_client:
+        assert test_client.get("/chat").status_code == 200
+        assert test_client.get("/users").status_code == 403

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_endpoints.py
@@ -86,13 +86,28 @@ def test_login_cookie_me_and_logout(client):
     assert "httponly" in set_cookie
     assert "secure" in set_cookie
     assert "samesite=lax" in set_cookie
+    csrf_token = client.cookies["dbgpt_csrf"]
+    csrf_cookie_header = next(
+        header
+        for header in login_response.headers.get_list("set-cookie")
+        if header.startswith("dbgpt_csrf=")
+    ).lower()
+    assert "secure" in csrf_cookie_header
+    assert "samesite=lax" in csrf_cookie_header
+    assert "httponly" not in csrf_cookie_header
 
     me_response = client.get("/api/v1/admin/auth/me")
     assert me_response.status_code == 200
     assert me_response.json()["data"]["role"] == "query_user"
     assert me_response.headers["cache-control"] == "no-store"
 
-    logout_response = client.post("/api/v1/admin/auth/logout")
+    csrf_failure = client.post("/api/v1/admin/auth/logout")
+    assert csrf_failure.status_code == 403
+
+    logout_response = client.post(
+        "/api/v1/admin/auth/logout",
+        headers={"X-CSRF-Token": csrf_token},
+    )
     assert logout_response.status_code == 200
     assert logout_response.headers["cache-control"] == "no-store"
     assert client.get("/api/v1/admin/auth/me").status_code == 401
@@ -136,6 +151,12 @@ def test_bearer_token_authentication(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
+
+    logout_response = client.post(
+        "/api/v1/admin/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert logout_response.status_code == 200
 
 
 def test_legacy_dependency_name_remains_overridable():

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
@@ -180,7 +180,7 @@ def test_initial_admin_is_created_once(service):
     with db.session(commit=False) as session:
         user = session.query(UserEntity).one()
         assert user.password_hash != "initial-password"
-        assert service._password_context.verify("initial-password", user.password_hash)
+        assert service.verify_password("initial-password", user.password_hash)
 
 
 def test_initial_admin_rejects_invalid_bootstrap_credentials(service):

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_auth_service.py
@@ -1,0 +1,228 @@
+"""Tests for password authentication and server-side sessions."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from jose import jwt
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import (
+    AuditEventEntity,
+    SessionEntity,
+    UserEntity,
+)
+from dbgpt_serve.auth.service.service import (
+    JWT_ALGORITHM,
+    JWT_AUDIENCE,
+    JWT_ISSUER,
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+)
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+def utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    return Service(
+        None,
+        ServeConfig(
+            jwt_secret=TEST_SECRET,
+            jwt_access_expire_minutes=30,
+            jwt_absolute_expire_minutes=120,
+            login_fail_lock_threshold=2,
+            login_fail_lock_minutes=15,
+            cookie_secure=True,
+        ),
+    )
+
+
+def create_user(service, role="query_user", is_active=True):
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash=service.hash_password("correct-password"),
+                role=role,
+                is_active=is_active,
+            )
+        )
+
+
+def test_login_creates_audited_revocable_session(service):
+    create_user(service)
+
+    token, user = service.login("alice", "correct-password", "x" * 100, "test")
+    authenticated_user, session_id = service.authenticate_token(token)
+
+    assert user.user_id == "user-1"
+    assert authenticated_user.role == "query_user"
+    claims = jwt.decode(
+        token,
+        TEST_SECRET,
+        algorithms=[JWT_ALGORITHM],
+        audience=JWT_AUDIENCE,
+        issuer=JWT_ISSUER,
+    )
+    assert "role" not in claims
+    with db.session(commit=False) as session:
+        auth_session = session.query(SessionEntity).one()
+        events = session.query(AuditEventEntity).all()
+        assert auth_session.session_id == session_id
+        assert auth_session.source_ip == "x" * 64
+        assert [event.action for event in events] == ["AUTH.LOGIN"]
+        assert events[0].result == "success"
+        assert events[0].source_ip == "x" * 64
+
+    service.logout("user-1", session_id)
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+    with db.session(commit=False) as session:
+        assert [
+            event.action
+            for event in session.query(AuditEventEntity)
+            .order_by(AuditEventEntity.id)
+            .all()
+        ] == ["AUTH.LOGIN", "AUTH.LOGOUT"]
+
+
+def test_login_failure_is_generic_and_locks_account(service):
+    create_user(service)
+
+    for password in ["wrong-one", "wrong-two"]:
+        with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+            service.login("alice", password, "127.0.0.1", "test")
+
+    with db.session(commit=False) as session:
+        user = session.query(UserEntity).one()
+        assert user.login_fail_count == 2
+        assert user.locked_until is not None
+        assert session.query(AuditEventEntity).count() == 2
+
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("missing", "wrong-two", "127.0.0.1", "test")
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "correct-password", "127.0.0.1", "test")
+    with db.session(commit=False) as session:
+        assert (
+            session.query(AuditEventEntity)
+            .order_by(AuditEventEntity.id.desc())
+            .first()
+            .deny_reason
+            == "ACCOUNT_LOCKED"
+        )
+
+
+def test_authentication_reads_current_role_and_active_state(service):
+    create_user(service)
+    token, _ = service.login("alice", "correct-password", "", "")
+
+    with db.session() as session:
+        user = session.query(UserEntity).one()
+        user.role = "operations_admin"
+    authenticated_user, _ = service.authenticate_token(token)
+    assert authenticated_user.role == "operations_admin"
+
+    with db.session() as session:
+        user = session.query(UserEntity).one()
+        user.is_active = False
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+
+
+def test_invalid_database_role_fails_closed(service):
+    create_user(service, role="invalid_role")
+
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "correct-password", "", "")
+    with db.session(commit=False) as session:
+        assert session.query(AuditEventEntity).one().deny_reason == "INVALID_ROLE"
+
+
+def test_expired_server_session_rejects_otherwise_valid_jwt(service):
+    create_user(service)
+    token, _ = service.login("alice", "correct-password", "", "")
+
+    with db.session() as session:
+        auth_session = session.query(SessionEntity).one()
+        auth_session.idle_expires_at = utcnow() - timedelta(seconds=1)
+
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+
+
+def test_initial_admin_is_created_once(service):
+    service.config.initial_admin_login = "admin"
+    service.config.initial_admin_password = "initial-password"
+
+    created = service.ensure_initial_admin()
+    duplicate = service.ensure_initial_admin()
+
+    assert created is not None
+    assert created.role == "system_admin"
+    assert duplicate is None
+    with db.session(commit=False) as session:
+        user = session.query(UserEntity).one()
+        assert user.password_hash != "initial-password"
+        assert service._password_context.verify("initial-password", user.password_hash)
+
+
+def test_initial_admin_rejects_invalid_bootstrap_credentials(service):
+    service.config.initial_admin_login = " "
+    service.config.initial_admin_password = "initial-password"
+
+    with pytest.raises(AuthConfigurationError, match="initial_admin_login"):
+        service.ensure_initial_admin()
+
+
+def test_invalid_session_or_lock_configuration_fails_closed():
+    with pytest.raises(AuthConfigurationError, match="login_fail_lock_minutes"):
+        Service(None, ServeConfig(login_fail_lock_minutes=0))
+    with pytest.raises(AuthConfigurationError, match="cookie_secure"):
+        Service(None, ServeConfig(cookie_secure="false"))
+
+
+def test_auth_config_masks_secrets_when_printed():
+    config = ServeConfig(
+        jwt_secret="jwt-secret-that-must-not-be-printed",
+        initial_admin_password="admin-password-that-must-not-be-printed",
+    )
+
+    printed_config = str(config)
+    represented_config = repr(config)
+    assert config.jwt_secret not in printed_config
+    assert config.initial_admin_password not in printed_config
+    assert config.jwt_secret not in represented_config
+    assert config.initial_admin_password not in represented_config
+
+
+def test_short_jwt_secret_fails_closed():
+    service = Service(None, ServeConfig(jwt_secret="too-short"))
+
+    with pytest.raises(AuthConfigurationError):
+        service.login("alice", "password", "", "")
+
+
+def test_bcrypt_password_length_is_enforced(service):
+    with pytest.raises(ValueError, match="72 bytes"):
+        service.hash_password("密" * 25)
+
+    create_user(service)
+    with pytest.raises(AuthenticationError, match="Invalid login name or password"):
+        service.login("alice", "密" * 25, "", "")

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_endpoints.py
@@ -1,0 +1,231 @@
+"""HTTP contract tests for account-set and resource authorization APIs."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.endpoints import router
+from dbgpt_serve.auth.api.schemas import AccountSetCreateRequest, UserCreateRequest
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import UserEntity
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.utils.auth import UserRequest
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    with db.engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE connect_config ("
+                "id INTEGER PRIMARY KEY, db_name VARCHAR(255), "
+                "account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE knowledge_space ("
+                "id INTEGER PRIMARY KEY, name VARCHAR(255), "
+                "account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE gpts_app ("
+                "id INTEGER PRIMARY KEY, app_code VARCHAR(255), "
+                "app_name VARCHAR(255), account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE gpts_app_detail ("
+                "id INTEGER PRIMARY KEY, app_code VARCHAR(255), resources TEXT)"
+            )
+        )
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    auth_service = Service(None, ServeConfig(jwt_secret=TEST_SECRET))
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="admin-1",
+                login_name="admin",
+                display_name="Administrator",
+                password_hash=auth_service.hash_password("admin-password"),
+                role="system_admin",
+                is_active=True,
+            )
+        )
+    return auth_service
+
+
+@pytest.fixture
+def client(service):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/admin")
+    app.dependency_overrides[get_auth_service] = lambda: service
+    return TestClient(app, base_url="https://testserver")
+
+
+def login_headers(client, login_name="admin", password="admin-password"):
+    response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": login_name, "password": password},
+    )
+    assert response.status_code == 200, response.text
+    return {"X-CSRF-Token": client.cookies["dbgpt_csrf"]}
+
+
+def setup_scope(service):
+    admin = UserRequest(user_id="admin-1", role="system_admin")
+    source = service.create_account_set(
+        AccountSetCreateRequest(name="Account A"), admin
+    )
+    target = service.create_account_set(
+        AccountSetCreateRequest(name="Account B"), admin
+    )
+    user = service.create_user(
+        UserCreateRequest(
+            login_name="alice",
+            display_name="Alice",
+            role="query_user",
+            initial_password="query-password",
+        ),
+        admin,
+    )
+    with db.session() as session:
+        session.execute(
+            text(
+                "INSERT INTO connect_config (id, db_name, account_set_id) "
+                "VALUES (1, 'sales', :account_set_id)"
+            ),
+            {"account_set_id": source.account_set_id},
+        )
+    return source, target, user
+
+
+def test_grant_and_revoke_contract(client, service):
+    source, _, user = setup_scope(service)
+    headers = login_headers(client)
+
+    account_response = client.post(
+        f"/api/v1/admin/users/{user.user_id}/account-grants",
+        headers=headers,
+        json={"account_set_id": source.account_set_id},
+    )
+    assert account_response.status_code == 201, account_response.text
+    account_grant = account_response.json()["data"]
+
+    resource_response = client.post(
+        f"/api/v1/admin/users/{user.user_id}/resource-grants",
+        headers=headers,
+        json={"resource_type": "DATASOURCE", "resource_id": "1"},
+    )
+    assert resource_response.status_code == 201, resource_response.text
+    assert resource_response.json()["data"]["account_set_id"] == (source.account_set_id)
+
+    available = client.get(
+        f"/api/v1/admin/users/{user.user_id}/resource-grants/available"
+    )
+    assert available.status_code == 200
+    assert available.json()["data"] == []
+
+    impact_response = client.get(
+        f"/api/v1/admin/users/{user.user_id}/account-grants/"
+        f"{account_grant['grant_id']}/impact"
+    )
+    impact = impact_response.json()["data"]
+    assert impact["affected_resource_grants"] == 1
+
+    unconfirmed = client.request(
+        "DELETE",
+        f"/api/v1/admin/users/{user.user_id}/account-grants/"
+        f"{account_grant['grant_id']}",
+        headers=headers,
+        json={
+            "reason": "Scope removed",
+            "confirm_impact": False,
+            "impact_token": impact["impact_token"],
+        },
+    )
+    assert unconfirmed.status_code == 409
+
+    revoked = client.request(
+        "DELETE",
+        f"/api/v1/admin/users/{user.user_id}/account-grants/"
+        f"{account_grant['grant_id']}",
+        headers=headers,
+        json={
+            "reason": "Scope removed",
+            "confirm_impact": True,
+            "impact_token": impact["impact_token"],
+        },
+    )
+    assert revoked.status_code == 200
+    assert revoked.json()["data"]["affected_resource_grants"] == 1
+
+
+def test_resource_assignment_and_scope_errors(client, service):
+    source, target, user = setup_scope(service)
+    headers = login_headers(client)
+    grant_response = client.post(
+        f"/api/v1/admin/users/{user.user_id}/account-grants",
+        headers=headers,
+        json={"account_set_id": source.account_set_id},
+    )
+    assert grant_response.status_code == 201
+
+    resources = client.get("/api/v1/admin/resources?resource_type=DATASOURCE")
+    assert resources.status_code == 200
+    assert resources.json()["data"]["items"][0]["resource_id"] == "1"
+
+    impact_response = client.get(
+        "/api/v1/admin/resources/DATASOURCE/1/impact",
+        params={"new_account_set_id": target.account_set_id},
+    )
+    assert impact_response.status_code == 200
+    impact = impact_response.json()["data"]
+
+    moved = client.patch(
+        "/api/v1/admin/resources/DATASOURCE/1/account-set",
+        headers=headers,
+        json={
+            "account_set_id": target.account_set_id,
+            "reason": "Ownership changed",
+            "confirm_impact": True,
+            "impact_token": impact["impact_token"],
+        },
+    )
+    assert moved.status_code == 200, moved.text
+    assert moved.json()["data"]["account_set_id"] == target.account_set_id
+
+    client.cookies.clear()
+    query_headers = login_headers(client, "alice", "query-password")
+    forbidden = client.get("/api/v1/admin/resources", headers=query_headers)
+    assert forbidden.status_code == 403
+
+
+def test_invalid_resource_type_is_rejected_at_http_boundary(client):
+    login_headers(client)
+    response = client.get(
+        "/api/v1/admin/resources/FILE/1/impact",
+        params={"new_account_set_id": "account-1"},
+    )
+    assert response.status_code == 422

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_endpoints.py
@@ -30,28 +30,28 @@ def setup_database():
     with db.engine.begin() as connection:
         connection.execute(
             text(
-                "CREATE TABLE connect_config ("
+                "CREATE TABLE IF NOT EXISTS connect_config ("
                 "id INTEGER PRIMARY KEY, db_name VARCHAR(255), "
                 "account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE knowledge_space ("
+                "CREATE TABLE IF NOT EXISTS knowledge_space ("
                 "id INTEGER PRIMARY KEY, name VARCHAR(255), "
                 "account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE gpts_app ("
+                "CREATE TABLE IF NOT EXISTS gpts_app ("
                 "id INTEGER PRIMARY KEY, app_code VARCHAR(255), "
                 "app_name VARCHAR(255), account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE gpts_app_detail ("
+                "CREATE TABLE IF NOT EXISTS gpts_app_detail ("
                 "id INTEGER PRIMARY KEY, app_code VARCHAR(255), resources TEXT)"
             )
         )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_service.py
@@ -1,0 +1,350 @@
+"""Transactional tests for account-set and resource authorization management."""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.schemas import (
+    AccountSetCreateRequest,
+    AssignResourceAccountRequest,
+    ConfirmRevokeRequest,
+    RevokeRequest,
+    UserCreateRequest,
+)
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import (
+    UserAccountGrantDao,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantDao,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.errors import (
+    ImpactConfirmationRequiredError,
+    ManagementValidationError,
+)
+from dbgpt_serve.auth.service.service import Service
+from dbgpt_serve.utils.auth import UserRequest
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    with db.engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE connect_config ("
+                "id INTEGER PRIMARY KEY, db_name VARCHAR(255), "
+                "account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE knowledge_space ("
+                "id INTEGER PRIMARY KEY, name VARCHAR(255), "
+                "account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE gpts_app ("
+                "id INTEGER PRIMARY KEY, app_code VARCHAR(255), "
+                "app_name VARCHAR(255), account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE gpts_app_detail ("
+                "id INTEGER PRIMARY KEY, app_code VARCHAR(255), resources TEXT)"
+            )
+        )
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    return Service(None, ServeConfig(jwt_secret=TEST_SECRET))
+
+
+@pytest.fixture
+def admin(service):
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="admin-1",
+                login_name="admin",
+                display_name="Administrator",
+                password_hash=service.hash_password("admin-password"),
+                role="system_admin",
+                is_active=True,
+            )
+        )
+    return UserRequest(user_id="admin-1", role="system_admin")
+
+
+def create_account_set(service, admin, name):
+    return service.create_account_set(AccountSetCreateRequest(name=name), admin)
+
+
+def create_user(service, admin, login_name, role="query_user"):
+    return service.create_user(
+        UserCreateRequest(
+            login_name=login_name,
+            display_name=login_name.title(),
+            role=role,
+            initial_password="correct-password",
+        ),
+        admin,
+    )
+
+
+def insert_resource(table_name, resource_id, name_column, name, account_set_id=None):
+    id_column = "app_code" if table_name == "gpts_app" else "id"
+    with db.session() as session:
+        session.execute(
+            text(
+                f"INSERT INTO {table_name} "
+                f"({id_column}, {name_column}, account_set_id) "
+                "VALUES (:resource_id, :name, :account_set_id)"
+            ),
+            {
+                "resource_id": resource_id,
+                "name": name,
+                "account_set_id": account_set_id,
+            },
+        )
+
+
+def test_account_grant_revoke_cascades_resource_grants(service, admin):
+    account_set = create_account_set(service, admin, "Account A")
+    user = create_user(service, admin, "alice")
+    insert_resource("connect_config", 1, "db_name", "sales", account_set.account_set_id)
+
+    account_grant = service.grant_user_account(
+        user.user_id, account_set.account_set_id, admin
+    )
+    resource_grant = service.grant_user_resource(user.user_id, "DATASOURCE", "1", admin)
+    impact = service.get_user_account_revoke_impact(
+        user.user_id, account_grant.grant_id, admin
+    )
+
+    assert impact.affected_resource_grants == 1
+    with pytest.raises(ImpactConfirmationRequiredError):
+        service.revoke_user_account(
+            user.user_id,
+            account_grant.grant_id,
+            ConfirmRevokeRequest(
+                reason="Scope removed",
+                confirm_impact=False,
+                impact_token=impact.impact_token,
+            ),
+            admin,
+        )
+
+    service.revoke_user_account(
+        user.user_id,
+        account_grant.grant_id,
+        ConfirmRevokeRequest(
+            reason="Scope removed",
+            confirm_impact=True,
+            impact_token=impact.impact_token,
+        ),
+        admin,
+    )
+
+    assert not UserAccountGrantDao().has_active_grant(
+        user.user_id, account_set.account_set_id
+    )
+    assert not UserResourceGrantDao().has_active_grant(user.user_id, "DATASOURCE", "1")
+    with db.session(commit=False) as session:
+        persisted_resource_grant = (
+            session.query(UserResourceGrantEntity)
+            .filter_by(grant_id=resource_grant.grant_id)
+            .one()
+        )
+        assert persisted_resource_grant.revoke_reason == ("ACCOUNT_SET_GRANT_REVOKED")
+
+    restored_account = service.grant_user_account(
+        user.user_id, account_set.account_set_id, admin
+    )
+    restored_resource = service.grant_user_resource(
+        user.user_id, "DATASOURCE", "1", admin
+    )
+    assert restored_account.grant_id == account_grant.grant_id
+    assert restored_resource.grant_id == resource_grant.grant_id
+
+
+def test_agent_grant_requires_dependencies_and_move_revokes_both(service, admin):
+    source_account = create_account_set(service, admin, "Account A")
+    target_account = create_account_set(service, admin, "Account B")
+    user = create_user(service, admin, "alice")
+    service.grant_user_account(user.user_id, source_account.account_set_id, admin)
+    insert_resource(
+        "connect_config", 1, "db_name", "sales", source_account.account_set_id
+    )
+    insert_resource(
+        "knowledge_space", 2, "name", "manual", source_account.account_set_id
+    )
+    insert_resource(
+        "gpts_app", "agent-1", "app_name", "Sales Agent", source_account.account_set_id
+    )
+    resources = [
+        {"type": "database", "value": json.dumps({"db_name": "sales"})},
+        {"type": "knowledge", "value": json.dumps({"space_name": "manual"})},
+    ]
+    with db.session() as session:
+        session.execute(
+            text(
+                "INSERT INTO gpts_app_detail (app_code, resources) "
+                "VALUES (:app_code, :resources)"
+            ),
+            {"app_code": "agent-1", "resources": json.dumps(resources)},
+        )
+
+    with pytest.raises(ManagementValidationError, match="every protected"):
+        service.grant_user_resource(user.user_id, "AGENT", "agent-1", admin)
+
+    datasource_grant = service.grant_user_resource(
+        user.user_id, "DATASOURCE", "1", admin
+    )
+    knowledge_grant = service.grant_user_resource(
+        user.user_id, "KNOWLEDGE_BASE", "2", admin
+    )
+    agent_grant = service.grant_user_resource(user.user_id, "AGENT", "agent-1", admin)
+
+    service.revoke_user_resource(
+        user.user_id,
+        knowledge_grant.grant_id,
+        RevokeRequest(reason="Knowledge access removed"),
+        admin,
+    )
+    with db.session(commit=False) as session:
+        cascaded_agent = (
+            session.query(UserResourceGrantEntity)
+            .filter_by(grant_id=agent_grant.grant_id)
+            .one()
+        )
+        assert cascaded_agent.is_active is False
+        assert cascaded_agent.revoke_reason == "DEPENDENCY_GRANT_REVOKED"
+    service.grant_user_resource(user.user_id, "KNOWLEDGE_BASE", "2", admin)
+    agent_grant = service.grant_user_resource(user.user_id, "AGENT", "agent-1", admin)
+
+    impact = service.get_resource_impact(
+        "DATASOURCE", "1", target_account.account_set_id, admin
+    )
+    assert impact.affected_resource_grants == 1
+    assert impact.affected_agent_grants == 1
+    moved = service.assign_resource_account(
+        "DATASOURCE",
+        "1",
+        AssignResourceAccountRequest(
+            account_set_id=target_account.account_set_id,
+            reason="Business ownership changed",
+            confirm_impact=True,
+            impact_token=impact.impact_token,
+        ),
+        admin,
+    )
+    assert moved.account_set_id == target_account.account_set_id
+    with db.session(commit=False) as session:
+        grants = {
+            grant.grant_id: grant
+            for grant in session.query(UserResourceGrantEntity)
+            .filter(
+                UserResourceGrantEntity.grant_id.in_(
+                    [datasource_grant.grant_id, agent_grant.grant_id]
+                )
+            )
+            .all()
+        }
+        assert grants[datasource_grant.grant_id].is_active is False
+        assert grants[agent_grant.grant_id].is_active is False
+
+
+def test_operations_admin_resource_scope_is_enforced(service, admin):
+    first = create_account_set(service, admin, "Account A")
+    second = create_account_set(service, admin, "Account B")
+    operator = create_user(service, admin, "operator", role="operations_admin")
+    service.grant_user_account(operator.user_id, first.account_set_id, admin)
+    operator_request = UserRequest(user_id=operator.user_id, role="operations_admin")
+    insert_resource("connect_config", 1, "db_name", "first", first.account_set_id)
+    insert_resource("connect_config", 2, "db_name", "second", second.account_set_id)
+    insert_resource("connect_config", 3, "db_name", "unowned")
+
+    visible = service.list_managed_resources(
+        1, 20, operator_request, resource_type="DATASOURCE"
+    )
+    assert [item.resource_id for item in visible.items] == ["1"]
+
+    with pytest.raises(ManagementValidationError, match="within their"):
+        service.get_resource_impact(
+            "DATASOURCE", "1", second.account_set_id, operator_request
+        )
+    with pytest.raises(ManagementValidationError, match="unowned"):
+        service.get_resource_impact(
+            "DATASOURCE", "3", first.account_set_id, operator_request
+        )
+
+    service.grant_user_account(operator.user_id, second.account_set_id, admin)
+    impact = service.get_resource_impact(
+        "DATASOURCE", "1", second.account_set_id, operator_request
+    )
+    moved = service.assign_resource_account(
+        "DATASOURCE",
+        "1",
+        AssignResourceAccountRequest(
+            account_set_id=second.account_set_id,
+            reason="Operations transfer",
+            confirm_impact=True,
+            impact_token=impact.impact_token,
+        ),
+        operator_request,
+    )
+    assert moved.account_set_id == second.account_set_id
+
+
+def test_resource_grant_revoke_requires_reason(service, admin):
+    account_set = create_account_set(service, admin, "Account A")
+    user = create_user(service, admin, "alice")
+    service.grant_user_account(user.user_id, account_set.account_set_id, admin)
+    insert_resource("connect_config", 1, "db_name", "sales", account_set.account_set_id)
+    grant = service.grant_user_resource(user.user_id, "DATASOURCE", "1", admin)
+
+    revoked = service.revoke_user_resource(
+        user.user_id,
+        grant.grant_id,
+        RevokeRequest(reason="No longer needed"),
+        admin,
+    )
+
+    assert revoked.is_active is False
+    with db.session(commit=False) as session:
+        account_grant = session.query(UserAccountGrantEntity).one()
+        assert account_grant.is_active is True
+
+
+def test_resource_listing_paginates_across_all_resource_types(service, admin):
+    account_set = create_account_set(service, admin, "Account A")
+    insert_resource("connect_config", 1, "db_name", "sales", account_set.account_set_id)
+    insert_resource("knowledge_space", 2, "name", "manual", account_set.account_set_id)
+    insert_resource(
+        "gpts_app", "agent-1", "app_name", "Assistant", account_set.account_set_id
+    )
+
+    first_page = service.list_managed_resources(1, 2, admin)
+    second_page = service.list_managed_resources(2, 2, admin)
+
+    assert first_page.total == 3
+    assert len(first_page.items) == 2
+    assert len(second_page.items) == 1
+    assert {item.resource_type for item in [*first_page.items, *second_page.items]} == {
+        "DATASOURCE",
+        "KNOWLEDGE_BASE",
+        "AGENT",
+    }

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_authorization_service.py
@@ -38,28 +38,28 @@ def setup_database():
     with db.engine.begin() as connection:
         connection.execute(
             text(
-                "CREATE TABLE connect_config ("
+                "CREATE TABLE IF NOT EXISTS connect_config ("
                 "id INTEGER PRIMARY KEY, db_name VARCHAR(255), "
                 "account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE knowledge_space ("
+                "CREATE TABLE IF NOT EXISTS knowledge_space ("
                 "id INTEGER PRIMARY KEY, name VARCHAR(255), "
                 "account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE gpts_app ("
+                "CREATE TABLE IF NOT EXISTS gpts_app ("
                 "id INTEGER PRIMARY KEY, app_code VARCHAR(255), "
                 "app_name VARCHAR(255), account_set_id VARCHAR(128))"
             )
         )
         connection.execute(
             text(
-                "CREATE TABLE gpts_app_detail ("
+                "CREATE TABLE IF NOT EXISTS gpts_app_detail ("
                 "id INTEGER PRIMARY KEY, app_code VARCHAR(255), resources TEXT)"
             )
         )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_management_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_management_endpoints.py
@@ -1,0 +1,297 @@
+"""HTTP contract tests for authorization administration APIs."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.endpoints import router
+from dbgpt_serve.auth.api.schemas import ImportCandidateResponse, UserCreateRequest
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import AuditEventEntity, UserEntity
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.utils.auth import UserRequest
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+class FakeImporter:
+    source_name = "erp-directory"
+
+    def preview(self, limit=100):
+        return [
+            ImportCandidateResponse(
+                employee_no="E001",
+                name="Imported Alice",
+                is_enabled=True,
+                category="sales",
+                position="manager",
+                team="A",
+                role_label="query",
+            )
+        ][:limit]
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    with db.engine.begin() as connection:
+        for table_name in ("connect_config", "knowledge_space", "gpts_app"):
+            connection.execute(
+                text(
+                    f"CREATE TABLE IF NOT EXISTS {table_name} "
+                    "(id INTEGER PRIMARY KEY, account_set_id VARCHAR(128))"
+                )
+            )
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def service():
+    auth_service = Service(
+        None,
+        ServeConfig(jwt_secret=TEST_SECRET),
+        importer=FakeImporter(),
+    )
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="admin-1",
+                login_name="admin",
+                display_name="Administrator",
+                password_hash=auth_service.hash_password("admin-password"),
+                role="system_admin",
+                is_active=True,
+            )
+        )
+    return auth_service
+
+
+@pytest.fixture
+def app(service):
+    api = FastAPI()
+    api.include_router(router, prefix="/api/v1/admin")
+    api.dependency_overrides[get_auth_service] = lambda: service
+    return api
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, base_url="https://testserver")
+
+
+def login_headers(client, login_name="admin", password="admin-password"):
+    response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": login_name, "password": password},
+    )
+    assert response.status_code == 200, response.text
+    return {"X-CSRF-Token": client.cookies["dbgpt_csrf"]}
+
+
+def create_account_set(client, headers, name="Account A"):
+    response = client.post(
+        "/api/v1/admin/account-sets",
+        headers=headers,
+        json={"name": name},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["data"]
+
+
+def create_query_user(client, headers, account_set_id=None, login_name="alice"):
+    body = {
+        "login_name": login_name,
+        "display_name": "Alice",
+        "role": "query_user",
+        "initial_password": "correct-password",
+    }
+    if account_set_id:
+        body["initial_account_set_ids"] = [account_set_id]
+    response = client.post("/api/v1/admin/users", headers=headers, json=body)
+    assert response.status_code == 201, response.text
+    return response.json()["data"]
+
+
+def test_admin_user_and_role_management_contract(client):
+    headers = login_headers(client)
+    csrf_failure = client.post(
+        "/api/v1/admin/users",
+        json={
+            "login_name": "blocked",
+            "display_name": "Blocked",
+            "role": "query_user",
+            "initial_password": "correct-password",
+        },
+    )
+    assert csrf_failure.status_code == 403
+
+    account_set = create_account_set(client, headers)
+    user = create_query_user(client, headers, account_set["account_set_id"])
+    assert "password" not in str(user).lower()
+    with db.session(commit=False) as session:
+        event = (
+            session.query(AuditEventEntity)
+            .filter_by(action="USER.CREATE", target_id=user["user_id"])
+            .one()
+        )
+        assert event.source_ip == "testclient"
+        assert event.user_agent == "testclient"
+        assert event.request_id
+
+    list_response = client.get("/api/v1/admin/users?page=1&page_size=20")
+    assert list_response.status_code == 200
+    assert list_response.headers["cache-control"] == "no-store"
+    assert list_response.json()["data"]["total"] == 2
+
+    unconfirmed = client.patch(
+        f"/api/v1/admin/users/{user['user_id']}",
+        headers=headers,
+        json={"role": "operations_admin"},
+    )
+    assert unconfirmed.status_code == 409
+    assert unconfirmed.json()["detail"]["code"] == "IMPACT_CONFIRMATION_REQUIRED"
+
+    confirmed = client.patch(
+        f"/api/v1/admin/users/{user['user_id']}",
+        headers=headers,
+        json={
+            "role": "operations_admin",
+            "change_reason": "Changed responsibilities",
+            "confirm_role_change": True,
+        },
+    )
+    assert confirmed.status_code == 200
+    assert confirmed.json()["data"]["role"] == "operations_admin"
+
+    roles = client.get("/api/v1/admin/roles")
+    assert roles.status_code == 200
+    assert {item["role"] for item in roles.json()["data"]} == {
+        "system_admin",
+        "operations_admin",
+        "query_user",
+    }
+
+    duplicate = client.post(
+        "/api/v1/admin/users",
+        headers=headers,
+        json={
+            "login_name": "alice",
+            "display_name": "Duplicate",
+            "role": "query_user",
+            "initial_password": "correct-password",
+        },
+    )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"]["code"] == "CONFLICT"
+    assert client.get("/api/v1/admin/users?page_size=101").status_code == 422
+
+
+def test_query_user_cannot_access_management_routes(client, service):
+    admin = UserRequest(user_id="admin-1", role="system_admin")
+    service.create_user(
+        UserCreateRequest(
+            login_name="query",
+            display_name="Query User",
+            role="query_user",
+            initial_password="query-password",
+        ),
+        admin,
+    )
+    client.cookies.clear()
+    headers = login_headers(client, "query", "query-password")
+
+    response = client.post(
+        "/api/v1/admin/account-sets",
+        headers=headers,
+        json={"name": "Forbidden"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Permission denied"
+
+
+def test_account_set_deactivation_requires_impact_token(client):
+    headers = login_headers(client)
+    account_set = create_account_set(client, headers)
+    create_query_user(client, headers, account_set["account_set_id"])
+
+    impact_response = client.get(
+        f"/api/v1/admin/account-sets/{account_set['account_set_id']}/impact"
+    )
+    impact = impact_response.json()["data"]
+    assert impact["user_grant_count"] == 1
+
+    unconfirmed = client.post(
+        f"/api/v1/admin/account-sets/{account_set['account_set_id']}/deactivate",
+        headers=headers,
+        json={
+            "reason": "Retired",
+            "confirm_impact": False,
+            "impact_token": impact["impact_token"],
+        },
+    )
+    assert unconfirmed.status_code == 409
+
+    confirmed = client.post(
+        f"/api/v1/admin/account-sets/{account_set['account_set_id']}/deactivate",
+        headers=headers,
+        json={
+            "reason": "Retired",
+            "confirm_impact": True,
+            "impact_token": impact["impact_token"],
+        },
+    )
+    assert confirmed.status_code == 200
+    assert confirmed.json()["data"]["is_active"] is False
+
+
+def test_import_contract_exposes_allowlist_and_password_free_history(client):
+    headers = login_headers(client)
+
+    candidates = client.get("/api/v1/admin/import/candidates")
+    assert candidates.status_code == 200
+    candidate = candidates.json()["data"][0]
+    assert set(candidate) == {
+        "employee_no",
+        "name",
+        "is_enabled",
+        "category",
+        "position",
+        "team",
+        "role_label",
+    }
+
+    batch = client.post(
+        "/api/v1/admin/import/batch",
+        headers=headers,
+        json={
+            "users": [
+                {
+                    "employee_no": "E001",
+                    "login_name": "imported-alice",
+                    "role": "query_user",
+                    "initial_password": "import-password",
+                }
+            ]
+        },
+    )
+    assert batch.status_code == 201
+    assert batch.json()["data"]["created_count"] == 1
+    assert "import-password" not in batch.text
+    assert "password" not in batch.text.lower()
+
+    history = client.get("/api/v1/admin/import/batches")
+    assert history.status_code == 200
+    assert history.json()["data"]["total"] == 1
+    assert "password" not in history.text.lower()

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_management_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_management_service.py
@@ -1,0 +1,431 @@
+"""Transactional tests for authorization administration services."""
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.schemas import (
+    AccountSetCreateRequest,
+    ConfirmImpactRequest,
+    ImportBatchRequest,
+    ImportCandidateResponse,
+    UserCreateRequest,
+    UserListRequest,
+    UserUpdateRequest,
+)
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import (
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionEntity,
+    UserAccountGrantEntity,
+    UserEntity,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.errors import (
+    ImpactConfirmationRequiredError,
+    ImportSourceError,
+    ManagementConflictError,
+)
+from dbgpt_serve.auth.service.importer import LszyzdImporter
+from dbgpt_serve.auth.service.service import AuthenticationError, Service
+from dbgpt_serve.utils.auth import UserRequest
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+def utcnow():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class FakeImporter:
+    source_name = "erp-directory"
+
+    def __init__(self):
+        self.candidates = [
+            ImportCandidateResponse(
+                employee_no="E001",
+                name="Imported Alice",
+                is_enabled=True,
+                category="sales",
+                position="manager",
+                team="A",
+                role_label="query",
+            ),
+            ImportCandidateResponse(employee_no="E002", name="Imported Bob"),
+        ]
+
+    def preview(self, limit=100):
+        return self.candidates[:limit]
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    with db.engine.begin() as connection:
+        for table_name in ("connect_config", "knowledge_space", "gpts_app"):
+            connection.execute(
+                text(
+                    f"CREATE TABLE IF NOT EXISTS {table_name} "
+                    "(id INTEGER PRIMARY KEY, account_set_id VARCHAR(128))"
+                )
+            )
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def importer():
+    return FakeImporter()
+
+
+@pytest.fixture
+def service(importer):
+    return Service(
+        None,
+        ServeConfig(jwt_secret=TEST_SECRET),
+        importer=importer,
+    )
+
+
+@pytest.fixture
+def admin(service):
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="admin-1",
+                login_name="admin",
+                display_name="Administrator",
+                password_hash=service.hash_password("admin-password"),
+                role="system_admin",
+                is_active=True,
+            )
+        )
+    return UserRequest(user_id="admin-1", role="system_admin")
+
+
+def create_account_set(service, admin, name="Account A"):
+    return service.create_account_set(AccountSetCreateRequest(name=name), admin)
+
+
+def create_query_user(service, admin, account_set_id=None, login_name="alice"):
+    return service.create_user(
+        UserCreateRequest(
+            login_name=login_name,
+            display_name="Alice",
+            role="query_user",
+            initial_password="correct-password",
+            initial_account_set_ids=[account_set_id] if account_set_id else [],
+        ),
+        admin,
+    )
+
+
+def test_create_list_and_audit_user_without_exposing_password(service, admin):
+    account_set = create_account_set(service, admin)
+    user = create_query_user(service, admin, account_set.account_set_id)
+
+    page = service.list_users(
+        filters=UserListRequest(login_name_like="ali"),
+        page=1,
+        page_size=20,
+        operator=admin,
+    )
+
+    assert page.total == 1
+    assert any(item.user_id == user.user_id for item in page.items)
+    with db.session(commit=False) as session:
+        entity = session.query(UserEntity).filter_by(user_id=user.user_id).one()
+        grant = (
+            session.query(UserAccountGrantEntity).filter_by(user_id=user.user_id).one()
+        )
+        event_entity = (
+            session.query(AuditEventEntity)
+            .filter_by(action="USER.CREATE", target_id=user.user_id)
+            .one()
+        )
+        assert entity.password_hash != "correct-password"
+        assert service.verify_password("correct-password", entity.password_hash)
+        assert grant.account_set_id == account_set.account_set_id
+        assert "password" not in (event_entity.after_snapshot or "").lower()
+
+    with pytest.raises(ManagementConflictError):
+        create_query_user(service, admin, login_name="alice")
+
+
+def test_role_change_requires_confirmation_and_revokes_scope(service, admin):
+    account_set = create_account_set(service, admin)
+    user = create_query_user(service, admin, account_set.account_set_id)
+    now = utcnow()
+    with db.session() as session:
+        session.add(
+            UserResourceGrantEntity(
+                grant_id="resource-grant-1",
+                user_id=user.user_id,
+                resource_type="DATASOURCE",
+                resource_id="datasource-1",
+                account_set_id=account_set.account_set_id,
+                is_active=True,
+                granted_by=admin.user_id,
+                gmt_created=now,
+                gmt_modified=now,
+            )
+        )
+
+    with pytest.raises(ImpactConfirmationRequiredError):
+        service.update_user(
+            user.user_id,
+            UserUpdateRequest(role="operations_admin"),
+            admin,
+        )
+
+    updated = service.update_user(
+        user.user_id,
+        UserUpdateRequest(
+            role="operations_admin",
+            change_reason="Changed job responsibilities",
+            confirm_role_change=True,
+        ),
+        admin,
+    )
+    assert updated.role == "operations_admin"
+    with db.session(commit=False) as session:
+        resource_grant = session.query(UserResourceGrantEntity).one()
+        account_grant = session.query(UserAccountGrantEntity).one()
+        assert resource_grant.is_active is False
+        assert resource_grant.revoke_reason == "ROLE_CHANGED"
+        assert account_grant.is_active is True
+
+    service.update_user(
+        user.user_id,
+        UserUpdateRequest(
+            role="system_admin",
+            change_reason="Emergency administrator assignment",
+            confirm_role_change=True,
+        ),
+        admin,
+    )
+    with db.session(commit=False) as session:
+        assert session.query(UserAccountGrantEntity).one().is_active is False
+
+
+def test_last_active_system_admin_cannot_be_disabled_or_demoted(service, admin):
+    with pytest.raises(ManagementConflictError, match="last active"):
+        service.toggle_user_active(admin.user_id, False, admin)
+
+    with pytest.raises(ManagementConflictError, match="last active"):
+        service.update_user(
+            admin.user_id,
+            UserUpdateRequest(
+                role="query_user",
+                change_reason="Invalid last-admin change",
+                confirm_role_change=True,
+            ),
+            admin,
+        )
+
+
+def test_disabling_and_password_reset_revoke_sessions(service, admin):
+    user = create_query_user(service, admin)
+    token, _ = service.login("alice", "correct-password", "", "")
+
+    service.toggle_user_active(user.user_id, False, admin)
+    with db.session(commit=False) as session:
+        auth_session = session.query(SessionEntity).one()
+        assert auth_session.revoked_at is not None
+        assert auth_session.revoke_reason == "USER_DISABLED"
+
+    service.toggle_user_active(user.user_id, True, admin)
+    service.set_password(user.user_id, "new-password", admin)
+    with pytest.raises(AuthenticationError):
+        service.authenticate_token(token)
+    service.login("alice", "new-password", "", "")
+
+
+def test_account_set_deactivation_requires_current_impact(service, admin):
+    account_set = create_account_set(service, admin)
+    create_query_user(service, admin, account_set.account_set_id)
+    with db.session() as session:
+        for table_name in ("connect_config", "knowledge_space", "gpts_app"):
+            session.execute(
+                text(
+                    f"INSERT INTO {table_name} (account_set_id) "
+                    "VALUES (:account_set_id)"
+                ),
+                {"account_set_id": account_set.account_set_id},
+            )
+    impact = service.get_account_set_impact(account_set.account_set_id, admin)
+
+    assert impact.user_grant_count == 1
+    assert impact.resource_count == 3
+    with pytest.raises(ImpactConfirmationRequiredError):
+        service.toggle_account_set_active(
+            account_set.account_set_id, False, admin, None
+        )
+
+    deactivated = service.toggle_account_set_active(
+        account_set.account_set_id,
+        False,
+        admin,
+        ConfirmImpactRequest(
+            reason="Account set retired",
+            confirm_impact=True,
+            impact_token=impact.impact_token,
+        ),
+    )
+    assert deactivated.is_active is False
+
+
+def test_import_is_one_time_password_free_and_does_not_sync(service, admin, importer):
+    request = ImportBatchRequest(
+        users=[
+            {
+                "employee_no": "E001",
+                "login_name": "imported-alice",
+                "role": "query_user",
+                "initial_password": "import-password",
+            }
+        ]
+    )
+
+    first = service.create_from_import(request, admin)
+    importer.candidates[0] = ImportCandidateResponse(
+        employee_no="E001", name="Externally Renamed"
+    )
+    second = service.create_from_import(request, admin)
+
+    assert first.created_count == 1
+    assert second.created_count == 0
+    assert second.skipped_count == 1
+    assert second.result_summary[0]["reason"] == "SOURCE_RECORD_ALREADY_IMPORTED"
+    with db.session(commit=False) as session:
+        user = session.query(UserEntity).filter_by(login_name="imported-alice").one()
+        batches = session.query(ImportBatchEntity).all()
+        serialized = "".join(
+            (batch.selected_summary or "") + (batch.result_summary or "")
+            for batch in batches
+        )
+        assert user.display_name == "Imported Alice"
+        assert "import-password" not in serialized
+        assert "password" not in serialized.lower()
+
+
+def test_skipped_source_record_can_be_imported_when_it_appears(
+    service, admin, importer
+):
+    request = ImportBatchRequest(
+        users=[
+            {
+                "employee_no": "E003",
+                "login_name": "late-user",
+                "role": "query_user",
+                "initial_password": "import-password",
+            }
+        ]
+    )
+
+    missing = service.create_from_import(request, admin)
+    importer.candidates.append(
+        ImportCandidateResponse(employee_no="E003", name="Late User")
+    )
+    created = service.create_from_import(request, admin)
+
+    assert missing.result_summary[0]["reason"] == "SOURCE_RECORD_MISSING"
+    assert created.created_count == 1
+
+
+class RecordingConnector:
+    def __init__(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        self._session_factory = sessionmaker(bind=self.engine)
+        self.statements = []
+        with self.engine.begin() as connection:
+            connection.execute(
+                text(
+                    "CREATE TABLE LSZYZD ("
+                    "LSZYZD_BH TEXT, LSZYZD_MC TEXT, LSZYZD_YXBZ INTEGER, "
+                    "LSZYZD_LBBH TEXT, LSZYZD_ZW TEXT, LSZYZD_BANZU TEXT, "
+                    "LSZYZD_ROLE TEXT, LSZYZD_PWD TEXT)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO LSZYZD VALUES "
+                    "('E001', 'Alice', 1, 'sales', 'manager', 'A', 'query', "
+                    "'forbidden-password')"
+                )
+            )
+        event.listen(self.engine, "before_cursor_execute", self._record_statement)
+
+    def _record_statement(
+        self, connection, cursor, statement, parameters, context, executemany
+    ):
+        self.statements.append(statement)
+
+    def get_table_names(self):
+        return ["LSZYZD"]
+
+    def get_columns(self, table_name):
+        return [
+            {"name": name}
+            for name in (
+                "LSZYZD_BH",
+                "LSZYZD_MC",
+                "LSZYZD_YXBZ",
+                "LSZYZD_LBBH",
+                "LSZYZD_ZW",
+                "LSZYZD_BANZU",
+                "LSZYZD_ROLE",
+                "LSZYZD_PWD",
+            )
+        ]
+
+    @contextmanager
+    def session_scope(self, commit=False):
+        session = self._session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+
+class RecordingConnectorManager:
+    def __init__(self, connector):
+        self.connector = connector
+
+    def get_connector(self, datasource_name):
+        assert datasource_name == "erp-directory"
+        return self.connector
+
+
+def test_lszyzd_importer_selects_only_allowed_fields():
+    connector = RecordingConnector()
+    importer = LszyzdImporter(
+        RecordingConnectorManager(connector), datasource_name="erp-directory"
+    )
+
+    candidates = importer.preview()
+    select_sql = next(
+        statement for statement in connector.statements if "SELECT" in statement.upper()
+    )
+
+    assert candidates[0].employee_no == "E001"
+    assert candidates[0].name == "Alice"
+    assert "LSZYZD_PWD" not in select_sql.upper()
+    assert "LSZYZD_BH" in select_sql.upper()
+
+
+def test_lszyzd_importer_requires_business_number_and_name():
+    connector = RecordingConnector()
+    connector.get_columns = lambda table_name: [{"name": "LSZYZD_MC"}]
+    importer = LszyzdImporter(
+        RecordingConnectorManager(connector), datasource_name="erp-directory"
+    )
+
+    with pytest.raises(ImportSourceError, match="missing required fields"):
+        importer.preview()

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_models.py
@@ -1,0 +1,445 @@
+"""Tests for authorization-center persistence models."""
+
+import ast
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventDao,
+    AuditEventEntity,
+    ImportBatchEntity,
+    SessionDao,
+    SessionEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantDao,
+    UserAccountGrantEntity,
+    UserDao,
+    UserEntity,
+    UserResourceGrantDao,
+    UserResourceGrantEntity,
+)
+
+AUTH_TABLE_COLUMNS = {
+    "dbgpt_auth_user": {
+        "id",
+        "user_id",
+        "login_name",
+        "display_name",
+        "password_hash",
+        "role",
+        "is_active",
+        "activation_token",
+        "activation_token_exp",
+        "reset_token",
+        "reset_token_exp",
+        "login_fail_count",
+        "locked_until",
+        "created_by",
+        "disabled_by",
+        "disabled_at",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_account_set": {
+        "id",
+        "account_set_id",
+        "name",
+        "description",
+        "is_active",
+        "created_by",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_user_account_grant": {
+        "id",
+        "grant_id",
+        "user_id",
+        "account_set_id",
+        "is_active",
+        "granted_by",
+        "revoked_by",
+        "revoked_at",
+        "revoke_reason",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_user_resource_grant": {
+        "id",
+        "grant_id",
+        "user_id",
+        "resource_type",
+        "resource_id",
+        "account_set_id",
+        "is_active",
+        "granted_by",
+        "revoked_by",
+        "revoked_at",
+        "revoke_reason",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_import_batch": {
+        "id",
+        "batch_id",
+        "operator_user_id",
+        "source_name",
+        "selected_count",
+        "created_count",
+        "skipped_count",
+        "selected_summary",
+        "result_summary",
+        "gmt_created",
+    },
+    "dbgpt_auth_token_usage": {
+        "id",
+        "call_id",
+        "request_id",
+        "session_id",
+        "user_id",
+        "role_snapshot",
+        "account_set_id",
+        "account_set_snapshot",
+        "entry_resource_type",
+        "entry_resource_id",
+        "agent_id",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "metering_source",
+        "duration_ms",
+        "status",
+        "error_type",
+        "gmt_created",
+    },
+    "dbgpt_auth_token_daily": {
+        "id",
+        "stat_date",
+        "user_id",
+        "role_snapshot",
+        "account_set_id",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "call_count",
+        "gmt_created",
+        "gmt_modified",
+    },
+    "dbgpt_auth_audit_event": {
+        "id",
+        "event_id",
+        "event_time",
+        "operator_user_id",
+        "operator_role_snapshot",
+        "target_account_set_id",
+        "target_type",
+        "target_id",
+        "action",
+        "result",
+        "source_ip",
+        "user_agent",
+        "request_id",
+        "before_snapshot",
+        "after_snapshot",
+        "deny_reason",
+    },
+    "dbgpt_auth_session": {
+        "id",
+        "session_id",
+        "user_id",
+        "issued_at",
+        "last_seen_at",
+        "idle_expires_at",
+        "absolute_expires_at",
+        "revoked_at",
+        "revoked_by",
+        "revoke_reason",
+        "source_ip",
+        "user_agent",
+        "gmt_created",
+        "gmt_modified",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+def test_auth_tables_match_design():
+    inspector = inspect(db.engine)
+    table_names = set(inspector.get_table_names())
+
+    assert AUTH_TABLE_COLUMNS.keys() <= table_names
+    for table_name, expected_columns in AUTH_TABLE_COLUMNS.items():
+        actual_columns = {
+            column["name"] for column in inspector.get_columns(table_name)
+        }
+        assert actual_columns == expected_columns
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "entity_name", "expected_index"),
+    [
+        (
+            "datasource/manages/connect_config_db.py",
+            "ConnectConfigEntity",
+            "idx_connect_account_set",
+        ),
+        ("rag/models/models.py", "KnowledgeSpaceEntity", "idx_ks_account_set"),
+        ("agent/db/gpts_app.py", "GptsAppEntity", "idx_app_account_set"),
+    ],
+)
+def test_resource_models_have_account_set_scope_without_runtime_imports(
+    relative_path, entity_name, expected_index
+):
+    source_path = Path(__file__).parents[2] / relative_path
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    entity = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == entity_name
+    )
+    account_set_assignment = next(
+        node
+        for node in entity.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id == "account_set_id"
+    )
+    column_call = account_set_assignment.value
+    assert isinstance(column_call, ast.Call)
+    assert isinstance(column_call.func, ast.Name)
+    assert column_call.func.id == "Column"
+    string_type = column_call.args[0]
+    assert isinstance(string_type, ast.Call)
+    assert isinstance(string_type.func, ast.Name)
+    assert string_type.func.id == "String"
+    assert isinstance(string_type.args[0], ast.Constant)
+    assert string_type.args[0].value == 128
+    nullable = next(
+        keyword.value for keyword in column_call.keywords if keyword.arg == "nullable"
+    )
+    assert isinstance(nullable, ast.Constant)
+    assert nullable.value is True
+
+    index_names = {
+        argument.value
+        for node in ast.walk(entity)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Index"
+        for argument in node.args[:1]
+        if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+    }
+
+    assert expected_index in index_names
+
+
+def test_migration_registry_imports_all_authorization_entities():
+    repository_root = Path(__file__).parents[6]
+    registry_path = (
+        repository_root
+        / "packages"
+        / "dbgpt-app"
+        / "src"
+        / "dbgpt_app"
+        / "initialization"
+        / "db_model_initialization.py"
+    )
+    module = ast.parse(registry_path.read_text(encoding="utf-8"))
+    registry_assignment = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_MODELS"
+            for target in node.targets
+        )
+    )
+    assert isinstance(registry_assignment.value, ast.List)
+    registered_names = {
+        item.id for item in registry_assignment.value.elts if isinstance(item, ast.Name)
+    }
+
+    assert {
+        "UserEntity",
+        "AccountSetEntity",
+        "UserAccountGrantEntity",
+        "UserResourceGrantEntity",
+        "ImportBatchEntity",
+        "TokenUsageEntity",
+        "TokenDailyEntity",
+        "AuditEventEntity",
+        "SessionEntity",
+        "GptsAppEntity",
+    } <= registered_names
+
+
+def test_user_unique_constraints_and_defaults():
+    with db.session() as session:
+        session.add(
+            UserEntity(
+                user_id="user-1",
+                login_name="alice",
+                display_name="Alice",
+                password_hash="not-a-real-hash",
+                role="query_user",
+            )
+        )
+
+    user = UserDao().get_by_login_name("alice")
+    assert user is not None
+    assert user.is_active is True
+    assert user.login_fail_count == 0
+    assert user.gmt_created is not None
+    assert UserDao().count_active_admins() == 0
+
+    with pytest.raises(IntegrityError):
+        with db.session() as session:
+            session.add(
+                UserEntity(
+                    user_id="user-2",
+                    login_name="alice",
+                    display_name="Other Alice",
+                    password_hash="not-a-real-hash",
+                    role="query_user",
+                )
+            )
+
+
+def test_grant_dao_checks_only_active_grants():
+    with db.session() as session:
+        session.add_all(
+            [
+                UserAccountGrantEntity(
+                    grant_id="account-grant-1",
+                    user_id="user-1",
+                    account_set_id="account-set-1",
+                    granted_by="admin-1",
+                ),
+                UserResourceGrantEntity(
+                    grant_id="resource-grant-1",
+                    user_id="user-1",
+                    resource_type="DATASOURCE",
+                    resource_id="datasource-1",
+                    account_set_id="account-set-1",
+                    granted_by="admin-1",
+                ),
+            ]
+        )
+
+    assert UserAccountGrantDao().has_active_grant("user-1", "account-set-1")
+    assert UserResourceGrantDao().has_active_grant(
+        "user-1", "DATASOURCE", "datasource-1"
+    )
+    assert not UserResourceGrantDao().has_active_grant(
+        "user-1", "KNOWLEDGE_BASE", "datasource-1"
+    )
+
+
+def test_daily_usage_dimensions_are_unique_for_pure_chat():
+    assert TokenUsageEntity.__table__.c.account_set_id.nullable is True
+    assert TokenDailyEntity.__table__.c.account_set_id.nullable is False
+
+    daily = {
+        "stat_date": "2026-07-17",
+        "user_id": "user-1",
+        "role_snapshot": "query_user",
+        "account_set_id": "",
+        "model": "test-model",
+    }
+    with db.session() as session:
+        session.add(TokenDailyEntity(**daily))
+
+    with pytest.raises(IntegrityError):
+        with db.session() as session:
+            session.add(TokenDailyEntity(**daily))
+
+    with db.session() as session:
+        session.add(TokenDailyEntity(**{**daily, "role_snapshot": "operations_admin"}))
+
+
+def test_session_dao_rejects_expired_and_revoked_sessions():
+    now = datetime.now()
+    with db.session() as session:
+        session.add_all(
+            [
+                SessionEntity(
+                    session_id="active-session",
+                    user_id="user-1",
+                    idle_expires_at=now + timedelta(minutes=30),
+                    absolute_expires_at=now + timedelta(hours=8),
+                ),
+                SessionEntity(
+                    session_id="expired-session",
+                    user_id="user-1",
+                    idle_expires_at=now - timedelta(minutes=1),
+                    absolute_expires_at=now + timedelta(hours=8),
+                ),
+                SessionEntity(
+                    session_id="revoked-session",
+                    user_id="user-1",
+                    idle_expires_at=now + timedelta(minutes=30),
+                    absolute_expires_at=now + timedelta(hours=8),
+                    revoked_at=now,
+                ),
+            ]
+        )
+
+    dao = SessionDao()
+    assert dao.get_active_session("active-session", "user-1", now) is not None
+    assert dao.get_active_session("expired-session", "user-1", now) is None
+    assert dao.get_active_session("revoked-session", "user-1", now) is None
+
+
+def test_audit_dao_is_append_only():
+    dao = AuditEventDao()
+    event = dao.append(
+        {
+            "event_id": "event-1",
+            "target_type": "SYSTEM",
+            "action": "MIGRATION.VERIFY",
+            "result": "success",
+        }
+    )
+
+    result = dao.query({"target_type": "SYSTEM"}, page=1, page_size=20)
+    assert event.id is not None
+    assert result.total_count == 1
+    assert result.items[0].event_id == "event-1"
+
+    with pytest.raises(TypeError, match="append-only"):
+        dao.delete({"event_id": "event-1"})
+    with pytest.raises(TypeError, match="append-only"):
+        dao.update({"event_id": "event-1"}, {"result": "error"})
+
+
+def test_all_entity_classes_are_registered():
+    expected_entities = {
+        UserEntity,
+        AccountSetEntity,
+        UserAccountGrantEntity,
+        UserResourceGrantEntity,
+        ImportBatchEntity,
+        TokenUsageEntity,
+        TokenDailyEntity,
+        AuditEventEntity,
+        SessionEntity,
+    }
+
+    assert {entity.__table__.name for entity in expected_entities} == set(
+        AUTH_TABLE_COLUMNS
+    )

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_runtime_access.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_runtime_access.py
@@ -1,0 +1,270 @@
+"""Runtime authorization checks for protected resources."""
+
+import json
+
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    AuditEventEntity,
+    UserAccountGrantEntity,
+    UserResourceGrantEntity,
+)
+from dbgpt_serve.auth.service.access import (
+    AccessService,
+    get_access_service,
+)
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.utils.auth import (
+    UserRequest,
+    get_current_user,
+    require_permission,
+)
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    with db.engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS connect_config (id INTEGER PRIMARY KEY, "
+                "db_name VARCHAR(255), account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS knowledge_space (id INTEGER PRIMARY KEY, "
+                "name VARCHAR(255), account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS gpts_app (id INTEGER PRIMARY KEY, "
+                "app_code VARCHAR(255), app_name VARCHAR(255), "
+                "account_set_id VARCHAR(128))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS gpts_app_detail (id INTEGER PRIMARY KEY, "
+                "app_code VARCHAR(255), resources TEXT)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS knowledge_document "
+                "(id INTEGER PRIMARY KEY, space VARCHAR(255))"
+            )
+        )
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def access_data():
+    with db.session() as session:
+        session.add(
+            AccountSetEntity(
+                account_set_id="account-1",
+                name="Account A",
+                is_active=True,
+                created_by="admin-1",
+            )
+        )
+        for user_id in ("operator-1", "query-1"):
+            session.add(
+                UserAccountGrantEntity(
+                    grant_id=f"account-grant-{user_id}",
+                    user_id=user_id,
+                    account_set_id="account-1",
+                    is_active=True,
+                    granted_by="admin-1",
+                )
+            )
+        session.execute(
+            text(
+                "INSERT INTO connect_config (id, db_name, account_set_id) "
+                "VALUES (1, 'sales', 'account-1'), (2, 'unowned', NULL)"
+            )
+        )
+        session.execute(
+            text(
+                "INSERT INTO knowledge_space (id, name, account_set_id) "
+                "VALUES (3, 'manual', 'account-1')"
+            )
+        )
+        session.execute(
+            text(
+                "INSERT INTO gpts_app (app_code, app_name, account_set_id) "
+                "VALUES ('agent-1', 'Sales Agent', 'account-1')"
+            )
+        )
+        session.execute(
+            text(
+                "INSERT INTO gpts_app_detail (app_code, resources) "
+                "VALUES ('agent-1', :resources)"
+            ),
+            {
+                "resources": json.dumps(
+                    [
+                        {
+                            "type": "database",
+                            "value": json.dumps({"db_name": "sales"}),
+                        }
+                    ]
+                )
+            },
+        )
+        session.execute(
+            text("INSERT INTO knowledge_document (id, space) VALUES (10, 'manual')")
+        )
+
+
+def test_operations_scope_and_system_admin_unassigned_access(access_data):
+    service = AccessService()
+    operator = UserRequest(user_id="operator-1", role="operations_admin")
+    admin = UserRequest(user_id="admin-1", role="system_admin")
+
+    assert (
+        service.require_resource_access(
+            operator, "DATASOURCE", "sales", manage=True
+        ).resource_id
+        == "1"
+    )
+    assert service.allowed_resource_ids(operator, "DATASOURCE") == {"1"}
+    assert (
+        service.require_resource_access(admin, "DATASOURCE", "2").account_set_id is None
+    )
+    with pytest.raises(HTTPException) as denied:
+        service.require_resource_access(operator, "DATASOURCE", "2")
+    assert denied.value.status_code == 403
+
+
+def test_query_user_requires_concrete_and_agent_dependency_grants(access_data):
+    service = AccessService()
+    user = UserRequest(user_id="query-1", role="query_user", request_id="request-1")
+
+    with pytest.raises(HTTPException):
+        service.require_resource_access(user, "DATASOURCE", "1")
+    with db.session() as session:
+        session.add(
+            UserResourceGrantEntity(
+                grant_id="resource-grant-ds",
+                user_id="query-1",
+                resource_type="DATASOURCE",
+                resource_id="1",
+                account_set_id="account-1",
+                is_active=True,
+                granted_by="admin-1",
+            )
+        )
+    assert service.require_resource_access(user, "DATASOURCE", "1").name == "sales"
+
+    with db.session() as session:
+        session.add(
+            UserResourceGrantEntity(
+                grant_id="resource-grant-agent",
+                user_id="query-1",
+                resource_type="AGENT",
+                resource_id="agent-1",
+                account_set_id="account-1",
+                is_active=True,
+                granted_by="admin-1",
+            )
+        )
+    assert (
+        service.require_resource_access(user, "AGENT", "agent-1").resource_id
+        == "agent-1"
+    )
+    with db.session() as session:
+        datasource_grant = (
+            session.query(UserResourceGrantEntity)
+            .filter_by(grant_id="resource-grant-ds")
+            .one()
+        )
+        datasource_grant.is_active = False
+    with pytest.raises(HTTPException) as denied:
+        service.require_resource_access(user, "AGENT", "agent-1")
+    assert denied.value.detail["code"] == "AGENT_DEPENDENCY_GRANT_MISSING"
+    with db.session(commit=False) as session:
+        assert (
+            session.query(AuditEventEntity)
+            .filter_by(action="AUTHZ.CHECK", request_id="request-1")
+            .count()
+            >= 2
+        )
+
+
+def test_document_access_resolves_owning_knowledge_space(access_data):
+    service = AccessService()
+    user = UserRequest(user_id="query-1", role="query_user")
+    with db.session() as session:
+        session.add(
+            UserResourceGrantEntity(
+                grant_id="resource-grant-kb",
+                user_id="query-1",
+                resource_type="KNOWLEDGE_BASE",
+                resource_id="3",
+                account_set_id="account-1",
+                is_active=True,
+                granted_by="admin-1",
+            )
+        )
+
+    assert service.require_document_access(user, "10").resource_id == "3"
+
+
+def test_fastapi_guard_returns_401_403_and_success(access_data):
+    app = FastAPI()
+
+    @app.get("/datasources/{resource_id}")
+    async def protected_datasource(
+        resource_id: str,
+        user: UserRequest = Depends(require_permission("DATASOURCE_USE")),
+        access: AccessService = Depends(get_access_service),
+    ):
+        return access.require_resource_access(
+            user, "DATASOURCE", resource_id
+        ).resource_id
+
+    app.dependency_overrides[get_auth_service] = lambda: Service(
+        None, ServeConfig(jwt_secret=TEST_SECRET)
+    )
+    client = TestClient(app)
+    assert client.get("/datasources/1").status_code == 401
+
+    app.dependency_overrides[get_current_user] = lambda: UserRequest(
+        user_id="query-1", role="query_user"
+    )
+    assert client.get("/datasources/1").status_code == 403
+    with db.session() as session:
+        session.add(
+            UserResourceGrantEntity(
+                grant_id="resource-grant-http",
+                user_id="query-1",
+                resource_type="DATASOURCE",
+                resource_id="1",
+                account_set_id="account-1",
+                is_active=True,
+                granted_by="admin-1",
+            )
+        )
+    response = client.get("/datasources/1")
+    assert response.status_code == 200
+    assert response.json() == "1"

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_usage_audit_endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_usage_audit_endpoints.py
@@ -1,0 +1,142 @@
+"""HTTP contracts for usage and audit administration APIs."""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.endpoints import router
+from dbgpt_serve.auth.api.schemas import AuditEventCreate, TokenUsageCreate
+from dbgpt_serve.auth.config import ServeConfig
+from dbgpt_serve.auth.models.models import UserEntity
+from dbgpt_serve.auth.service.audit_service import AuditService, get_audit_service
+from dbgpt_serve.auth.service.service import Service, get_auth_service
+from dbgpt_serve.auth.service.token_service import TokenService, get_token_service
+
+TEST_SECRET = "test-only-jwt-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db(
+        "sqlite://",
+        engine_args={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+    )
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+@pytest.fixture
+def services():
+    auth_service = Service(None, ServeConfig(jwt_secret=TEST_SECRET))
+    with db.session() as session:
+        session.add_all(
+            [
+                UserEntity(
+                    user_id="admin-1",
+                    login_name="admin",
+                    display_name="Administrator",
+                    password_hash=auth_service.hash_password("admin-password"),
+                    role="system_admin",
+                    is_active=True,
+                ),
+                UserEntity(
+                    user_id="query-1",
+                    login_name="query",
+                    display_name="Query User",
+                    password_hash=auth_service.hash_password("query-password"),
+                    role="query_user",
+                    is_active=True,
+                ),
+            ]
+        )
+    token_service = TokenService()
+    audit_service = AuditService()
+    token_service.record_usage(
+        TokenUsageCreate(
+            call_id="call-1",
+            request_id="request-1",
+            user_id="query-1",
+            role_snapshot="query_user",
+            model="gpt-test",
+            input_tokens=10,
+            output_tokens=2,
+            total_tokens=12,
+            metering_source="provider",
+            status="success",
+            gmt_created=datetime(2026, 7, 17, 1, 0, tzinfo=timezone.utc),
+        )
+    )
+    audit_service.record(
+        AuditEventCreate(
+            event_time=datetime(2026, 7, 17, 1, 0),
+            operator_user_id="admin-1",
+            operator_role_snapshot="system_admin",
+            target_type="USER",
+            target_id="query-1",
+            action="USER.TEST",
+            result="success",
+        )
+    )
+    return auth_service, token_service, audit_service
+
+
+@pytest.fixture
+def client(services):
+    auth_service, token_service, audit_service = services
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/admin")
+    app.dependency_overrides[get_auth_service] = lambda: auth_service
+    app.dependency_overrides[get_token_service] = lambda: token_service
+    app.dependency_overrides[get_audit_service] = lambda: audit_service
+    return TestClient(app, base_url="https://testserver")
+
+
+def login(client, login_name, password):
+    response = client.post(
+        "/api/v1/admin/auth/login",
+        json={"login_name": login_name, "password": password},
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_admin_usage_and_audit_contract(client):
+    login(client, "admin", "admin-password")
+
+    detail = client.get("/api/v1/admin/token-usage/detail")
+    assert detail.status_code == 200
+    assert detail.json()["data"]["total"] == 1
+    daily = client.get(
+        "/api/v1/admin/token-usage/daily",
+        params={"date_from": "2026-07-17", "date_to": "2026-07-17"},
+    )
+    assert daily.status_code == 200
+    assert daily.json()["data"][0]["total_tokens"] == 12
+    summary = client.get(
+        "/api/v1/admin/token-usage/summary",
+        params={"stat_date": "2026-07-17"},
+    )
+    assert summary.json()["data"]["call_count"] == 1
+
+    audit = client.get("/api/v1/admin/audit", params={"action": "USER.TEST"})
+    assert audit.status_code == 200
+    event = audit.json()["data"]["items"][0]
+    assert event["target_id"] == "query-1"
+    assert client.get(f"/api/v1/admin/audit/{event['event_id']}").status_code == 200
+    assert client.delete(f"/api/v1/admin/audit/{event['event_id']}").status_code == 405
+
+
+def test_query_user_sees_only_self_usage_and_not_audit(client):
+    login(client, "query", "query-password")
+
+    own = client.get("/api/v1/admin/token-usage/detail")
+    assert own.status_code == 200
+    assert own.json()["data"]["items"][0]["user_id"] == "query-1"
+    assert client.get("/api/v1/admin/audit").status_code == 403

--- a/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_usage_audit_service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/auth/tests/test_usage_audit_service.py
@@ -1,0 +1,165 @@
+"""Tests for idempotent usage metering and append-only audit queries."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dbgpt.storage.metadata import db
+from dbgpt_serve.auth.api.schemas import (
+    AuditEventCreate,
+    AuditQueryRequest,
+    TokenUsageCreate,
+    TokenUsageQueryRequest,
+)
+from dbgpt_serve.auth.models.models import (
+    AccountSetEntity,
+    TokenDailyEntity,
+    TokenUsageEntity,
+    UserAccountGrantEntity,
+)
+from dbgpt_serve.auth.service.audit_service import AuditService
+from dbgpt_serve.auth.service.errors import ManagementValidationError
+from dbgpt_serve.auth.service.token_service import TokenService
+from dbgpt_serve.utils.auth import UserRequest
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+    yield
+    db.Model.metadata.drop_all(bind=db.engine)
+
+
+def usage(call_id, user_id="query-1", account_set_id="account-1", tokens=12):
+    return TokenUsageCreate(
+        call_id=call_id,
+        request_id="request-1",
+        session_id="session-1",
+        user_id=user_id,
+        role_snapshot="query_user",
+        account_set_id=account_set_id,
+        account_set_snapshot="Account A",
+        entry_resource_type="DATASOURCE",
+        entry_resource_id="1",
+        model="gpt-test",
+        input_tokens=tokens - 2,
+        output_tokens=2,
+        total_tokens=tokens,
+        metering_source="provider",
+        duration_ms=100,
+        status="success",
+        gmt_created=datetime(2026, 7, 16, 16, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_record_usage_is_idempotent_and_uses_shanghai_day():
+    service = TokenService()
+
+    assert service.record_usage(usage("call-1")) is True
+    assert service.record_usage(usage("call-1")) is False
+    assert service.record_usage(usage("call-2", tokens=8)) is True
+
+    with db.session(commit=False) as session:
+        assert session.query(TokenUsageEntity).count() == 2
+        daily = session.query(TokenDailyEntity).one()
+        assert daily.stat_date == "2026-07-17"
+        assert daily.input_tokens == 16
+        assert daily.output_tokens == 4
+        assert daily.total_tokens == 20
+        assert daily.call_count == 2
+
+
+def test_usage_queries_enforce_role_data_scope():
+    service = TokenService()
+    service.record_usage(usage("call-query", user_id="query-1"))
+    service.record_usage(
+        usage("call-other", user_id="query-2", account_set_id="account-2")
+    )
+    with db.session() as session:
+        session.add_all(
+            [
+                AccountSetEntity(
+                    account_set_id="account-1",
+                    name="Account A",
+                    is_active=True,
+                    created_by="admin-1",
+                ),
+                AccountSetEntity(
+                    account_set_id="account-2",
+                    name="Account B",
+                    is_active=True,
+                    created_by="admin-1",
+                ),
+                UserAccountGrantEntity(
+                    grant_id="grant-1",
+                    user_id="operator-1",
+                    account_set_id="account-1",
+                    is_active=True,
+                    granted_by="admin-1",
+                ),
+            ]
+        )
+
+    query_page = service.query_usage(
+        TokenUsageQueryRequest(),
+        UserRequest(user_id="query-1", role="query_user"),
+        1,
+        20,
+    )
+    operations_page = service.query_usage(
+        TokenUsageQueryRequest(),
+        UserRequest(user_id="operator-1", role="operations_admin"),
+        1,
+        20,
+    )
+    admin_page = service.query_usage(
+        TokenUsageQueryRequest(),
+        UserRequest(user_id="admin-1", role="system_admin"),
+        1,
+        20,
+    )
+
+    assert [item.call_id for item in query_page.items] == ["call-query"]
+    assert [item.call_id for item in operations_page.items] == ["call-query"]
+    assert admin_page.total == 2
+
+
+def test_audit_is_append_only_scoped_and_rejects_sensitive_snapshots():
+    service = AuditService()
+    admin = UserRequest(user_id="admin-1", role="system_admin")
+    event = service.record(
+        AuditEventCreate(
+            event_time=datetime(2026, 7, 17, 8, 0),
+            operator_user_id="admin-1",
+            operator_role_snapshot="system_admin",
+            target_type="USER",
+            target_id="query-1",
+            action="USER.DISABLE",
+            result="success",
+            request_id="request-1",
+            before_snapshot='{"is_active":true}',
+            after_snapshot='{"is_active":false}',
+        )
+    )
+
+    page = service.query(AuditQueryRequest(action="USER.DISABLE"), 1, 20, admin)
+    assert page.total == 1
+    assert service.get(event.event_id, admin).target_id == "query-1"
+    with pytest.raises(ManagementValidationError, match="system administrator"):
+        service.query(
+            AuditQueryRequest(),
+            1,
+            20,
+            UserRequest(user_id="query-1", role="query_user"),
+        )
+    with pytest.raises(ManagementValidationError, match="Sensitive"):
+        service.record(
+            AuditEventCreate(
+                event_time=datetime(2026, 7, 17, 8, 0),
+                target_type="USER",
+                action="USER.UPDATE",
+                result="success",
+                after_snapshot='{"password":"forbidden"}',
+            )
+        )

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/endpoints.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 
 from dbgpt.component import SystemApp
+from dbgpt_serve.auth.service.access import AccessService, get_access_service
 from dbgpt_serve.core import ResourceTypes, Result, blocking_func_to_async
 from dbgpt_serve.datasource.api.schemas import (
     DatasourceCreateRequest,
@@ -13,12 +14,33 @@ from dbgpt_serve.datasource.api.schemas import (
 )
 from dbgpt_serve.datasource.config import SERVE_SERVICE_COMPONENT_NAME, ServeConfig
 from dbgpt_serve.datasource.service.service import Service
+from dbgpt_serve.utils.auth import UserRequest, require_permission
 
 router = APIRouter()
 
 # Add your API endpoints here
 
 global_system_app: Optional[SystemApp] = None
+
+_SENSITIVE_PARAMETER_MARKERS = ("password", "pwd", "secret", "token", "api_key")
+
+
+def _sanitize_parameters(value):
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_parameters(item)
+            for key, item in value.items()
+            if not any(
+                marker in str(key).lower() for marker in _SENSITIVE_PARAMETER_MARKERS
+            )
+        }
+    if isinstance(value, list):
+        return [_sanitize_parameters(item) for item in value]
+    return value
+
+
+def _sanitize_response(response: DatasourceQueryResponse) -> DatasourceQueryResponse:
+    return response.model_copy(update={"params": _sanitize_parameters(response.params)})
 
 
 def get_service() -> Service:
@@ -99,11 +121,12 @@ async def test_auth():
 @router.post(
     "/datasources",
     response_model=Result[DatasourceQueryResponse],
-    dependencies=[Depends(check_api_key)],
 )
 async def create(
     request: Union[DatasourceCreateRequest, DatasourceServeRequest],
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[DatasourceQueryResponse]:
     """Create a new Space entity
 
@@ -114,18 +137,22 @@ async def create(
     Returns:
         ServerResponse: The response
     """
+    if not request.account_set_id:
+        raise HTTPException(status_code=422, detail="account_set_id is required")
+    access.require_account_access(operator, request.account_set_id, "DATASOURCE_MANAGE")
     res = await blocking_func_to_async(global_system_app, service.create, request)
-    return Result.succ(res)
+    return Result.succ(_sanitize_response(res))
 
 
 @router.put(
     "/datasources",
     response_model=Result[DatasourceQueryResponse],
-    dependencies=[Depends(check_api_key)],
 )
 async def update(
     request: Union[DatasourceCreateRequest, DatasourceServeRequest],
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[DatasourceQueryResponse]:
     """Update a Space entity
 
@@ -135,17 +162,30 @@ async def update(
     Returns:
         ServerResponse: The response
     """
+    if request.id is None:
+        raise HTTPException(status_code=422, detail="id is required")
+    resource = access.require_resource_access(
+        operator, "DATASOURCE", str(request.id), manage=True
+    )
+    if request.account_set_id not in (None, resource.account_set_id):
+        raise HTTPException(
+            status_code=409,
+            detail="Use the resource account-set impact and assignment APIs",
+        )
+    request.account_set_id = resource.account_set_id
     res = await blocking_func_to_async(global_system_app, service.update, request)
-    return Result.succ(res)
+    return Result.succ(_sanitize_response(res))
 
 
 @router.delete(
     "/datasources/{datasource_id}",
     response_model=Result[None],
-    dependencies=[Depends(check_api_key)],
 )
 async def delete(
-    datasource_id: str, service: Service = Depends(get_service)
+    datasource_id: str,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[None]:
     """Delete a Space entity
 
@@ -155,17 +195,20 @@ async def delete(
     Returns:
         ServerResponse: The response
     """
+    access.require_resource_access(operator, "DATASOURCE", datasource_id, manage=True)
     await blocking_func_to_async(global_system_app, service.delete, datasource_id)
     return Result.succ(None)
 
 
 @router.get(
     "/datasources/{datasource_id}",
-    dependencies=[Depends(check_api_key)],
     response_model=Result[DatasourceQueryResponse],
 )
 async def query(
-    datasource_id: str, service: Service = Depends(get_service)
+    datasource_id: str,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[DatasourceQueryResponse]:
     """Query Space entities
 
@@ -175,13 +218,13 @@ async def query(
     Returns:
         List[ServeResponse]: The response
     """
+    access.require_resource_access(operator, "DATASOURCE", datasource_id)
     res = await blocking_func_to_async(global_system_app, service.get, datasource_id)
-    return Result.succ(res)
+    return Result.succ(_sanitize_response(res))
 
 
 @router.get(
     "/datasources",
-    dependencies=[Depends(check_api_key)],
     response_model=Result[List[DatasourceQueryResponse]],
 )
 async def query_page(
@@ -189,6 +232,8 @@ async def query_page(
         None, description="Database type, e.g. sqlite, mysql, etc."
     ),
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[List[DatasourceQueryResponse]]:
     """Query Space entities
 
@@ -200,12 +245,15 @@ async def query_page(
     res = await blocking_func_to_async(
         global_system_app, service.get_list, db_type=db_type
     )
-    return Result.succ(res)
+    allowed_ids = access.allowed_resource_ids(operator, "DATASOURCE")
+    if allowed_ids is not None:
+        res = [item for item in res if str(item.id) in allowed_ids]
+    return Result.succ([_sanitize_response(item) for item in res])
 
 
 @router.get(
     "/datasource-types",
-    dependencies=[Depends(check_api_key)],
+    dependencies=[Depends(require_permission("DATASOURCE_USE"))],
     response_model=Result[ResourceTypes],
 )
 async def get_datasource_types(
@@ -218,7 +266,7 @@ async def get_datasource_types(
 
 @router.post(
     "/datasources/test-connection",
-    dependencies=[Depends(check_api_key)],
+    dependencies=[Depends(require_permission("DATASOURCE_MANAGE"))],
     response_model=Result[bool],
 )
 async def test_connection(
@@ -244,11 +292,13 @@ async def test_connection(
 
 @router.post(
     "/datasources/{datasource_id}/refresh",
-    dependencies=[Depends(check_api_key)],
     response_model=Result[bool],
 )
 async def refresh_datasource(
-    datasource_id: str, service: Service = Depends(get_service)
+    datasource_id: str,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("DATASOURCE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[bool]:
     """Refresh a datasource by its ID
 
@@ -262,6 +312,7 @@ async def refresh_datasource(
     Raises:
         HTTPException: When the refresh operation fails
     """
+    access.require_resource_access(operator, "DATASOURCE", datasource_id, manage=True)
     res = await blocking_func_to_async(
         global_system_app, service.refresh, datasource_id
     )

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/schemas.py
@@ -10,6 +10,7 @@ class DatasourceServeRequest(BaseModel):
 
     """vector_type: vector type"""
     id: Optional[int] = Field(None, description="The datasource id")
+    account_set_id: Optional[str] = Field(None, description="Owning account set ID")
     db_type: str = Field(..., description="Database type, e.g. sqlite, mysql, etc.")
     db_name: str = Field(..., description="Database name.")
     db_path: Optional[str] = Field("", description="File path for file-based database.")
@@ -32,6 +33,7 @@ class DatasourceServeResponse(BaseModel):
 
     """vector_type: vector type"""
     id: int = Field(None, description="The datasource id")
+    account_set_id: Optional[str] = Field(None, description="Owning account set ID")
     db_type: str = Field(..., description="Database type, e.g. sqlite, mysql, etc.")
     db_name: str = Field(..., description="Database name.")
     db_path: Optional[str] = Field("", description="File path for file-based database.")
@@ -76,6 +78,7 @@ class DatasourceCreateRequest(BaseModel):
         None, description="Optional description of the datasource."
     )
     id: Optional[int] = Field(None, description="The datasource id")
+    account_set_id: Optional[str] = Field(None, description="Owning account set ID")
 
     class Config:
         json_schema_extra = {

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
@@ -44,6 +44,7 @@ class ConnectConfigEntity(Model):
     sys_code = Column(String(128), index=True, nullable=True, comment="System code")
     user_id = Column(String(128), index=True, nullable=True, comment="User id")
     user_name = Column(String(128), index=True, nullable=True, comment="User name")
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     gmt_created = Column(DateTime, default=datetime.now, comment="Record creation time")
     gmt_modified = Column(DateTime, default=datetime.now, comment="Record update time")
     ext_config = Column(
@@ -52,6 +53,7 @@ class ConnectConfigEntity(Model):
     __table_args__ = (
         UniqueConstraint("db_name", name="uk_db"),
         Index("idx_q_db_type", "db_type"),
+        Index("idx_connect_account_set", "account_set_id"),
     )
 
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/service.py
@@ -126,6 +126,7 @@ class Service(
         else:
             persisted_state = model_to_dict(request)
             desc = request.comment
+        persisted_state["account_set_id"] = request.account_set_id
         if "ext_config" in persisted_state and isinstance(
             persisted_state["ext_config"], dict
         ):
@@ -175,11 +176,6 @@ class Service(
         Returns:
             DatasourceQueryResponse: The response
         """
-        str_db_type = (
-            request.type
-            if isinstance(request, DatasourceCreateRequest)
-            else request.db_type
-        )
         desc = ""
         if isinstance(request, DatasourceCreateRequest):
             connector_params: BaseDatasourceParameters = (
@@ -190,6 +186,7 @@ class Service(
         else:
             persisted_state = model_to_dict(request)
             desc = request.comment
+        persisted_state["account_set_id"] = request.account_set_id
         if "ext_config" in persisted_state and isinstance(
             persisted_state["ext_config"], dict
         ):
@@ -272,6 +269,7 @@ class Service(
             params=param_dict,
             description=res.comment,
             id=res.id,
+            account_set_id=res.account_set_id,
             db_name=res.db_name,
             gmt_created=res.gmt_created,
             gmt_modified=res.gmt_modified,

--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/api/endpoints.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/api/endpoints.py
@@ -14,6 +14,7 @@ from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 from dbgpt.component import SystemApp
 from dbgpt.util import PaginationResult
 from dbgpt_ext.rag.chunk_manager import ChunkParameters
+from dbgpt_serve.auth.service.access import AccessService, get_access_service
 from dbgpt_serve.core import Result, blocking_func_to_async
 from dbgpt_serve.rag.api.schemas import (
     DocumentServeRequest,
@@ -25,6 +26,7 @@ from dbgpt_serve.rag.api.schemas import (
 )
 from dbgpt_serve.rag.config import SERVE_SERVICE_COMPONENT_NAME, ServeConfig
 from dbgpt_serve.rag.service.service import Service
+from dbgpt_serve.utils.auth import UserRequest, require_permission
 
 router = APIRouter()
 
@@ -112,6 +114,8 @@ async def test_auth():
 async def create(
     request: SpaceServeRequest,
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Space entity
 
@@ -121,12 +125,20 @@ async def create(
     Returns:
         ServerResponse: The response
     """
+    if not request.account_set_id:
+        raise HTTPException(status_code=422, detail="account_set_id is required")
+    access.require_account_access(
+        operator, request.account_set_id, "KNOWLEDGE_BASE_MANAGE"
+    )
     return Result.succ(service.create_space(request))
 
 
-@router.put("/spaces", dependencies=[Depends(check_api_key)])
+@router.put("/spaces")
 async def update(
-    request: SpaceServeRequest, service: Service = Depends(get_service)
+    request: SpaceServeRequest,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Update a Space entity
 
@@ -136,16 +148,29 @@ async def update(
     Returns:
         ServerResponse: The response
     """
+    if request.id is None:
+        raise HTTPException(status_code=422, detail="id is required")
+    resource = access.require_resource_access(
+        operator, "KNOWLEDGE_BASE", str(request.id), manage=True
+    )
+    if request.account_set_id not in (None, resource.account_set_id):
+        raise HTTPException(
+            status_code=409,
+            detail="Use the resource account-set impact and assignment APIs",
+        )
+    request.account_set_id = resource.account_set_id
     return Result.succ(service.update_space(request))
 
 
 @router.delete(
     "/spaces/{space_id}",
     response_model=Result[None],
-    dependencies=[Depends(check_api_key)],
 )
 async def delete(
-    space_id: str, service: Service = Depends(get_service)
+    space_id: str,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[None]:
     """Delete a Space entity
 
@@ -155,6 +180,7 @@ async def delete(
     Returns:
         ServerResponse: The response
     """
+    access.require_resource_access(operator, "KNOWLEDGE_BASE", space_id, manage=True)
     # TODO: Delete the files in the space
     res = await blocking_func_to_async(global_system_app, service.delete, space_id)
     return Result.succ(res)
@@ -164,9 +190,11 @@ async def delete(
     "/spaces/{space_id}",
     response_model=Result[List],
 )
-async def query(
+async def query_space(
     space_id: str,
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[List[SpaceServeResponse]]:
     """Query Space entities
 
@@ -176,6 +204,7 @@ async def query(
     Returns:
         List[ServeResponse]: The response
     """
+    access.require_resource_access(operator, "KNOWLEDGE_BASE", space_id)
     request = {"id": space_id}
     return Result.succ(service.get(request))
 
@@ -184,10 +213,12 @@ async def query(
     "/spaces",
     response_model=Result[PaginationResult[SpaceServeResponse]],
 )
-async def query_page(
+async def query_space_page(
     page: int = Query(default=1, description="current page"),
     page_size: int = Query(default=20, description="page size"),
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[PaginationResult[SpaceServeResponse]]:
     """Query Space entities
 
@@ -198,7 +229,13 @@ async def query_page(
     Returns:
         ServerResponse: The response
     """
-    return Result.succ(service.get_list_by_page({}, page, page_size))
+    result = service.get_list_by_page({}, page, page_size)
+    allowed_ids = access.allowed_resource_ids(operator, "KNOWLEDGE_BASE")
+    if allowed_ids is not None:
+        result.items = [item for item in result.items if str(item.id) in allowed_ids]
+        result.total_count = len(result.items)
+        result.total_pages = 1 if result.items else 0
+    return Result.succ(result)
 
 
 @router.post("/spaces/{space_id}/retrieve")
@@ -206,6 +243,8 @@ async def space_retrieve(
     space_id: int,
     request: KnowledgeRetrieveRequest,
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Document entity
 
@@ -216,6 +255,7 @@ async def space_retrieve(
     Returns:
         ServerResponse: The response
     """
+    access.require_resource_access(operator, "KNOWLEDGE_BASE", str(space_id))
     request.space_id = space_id
     space_request = {
         "id": space_id,
@@ -234,6 +274,8 @@ async def create_document(
     content: Optional[str] = Form(None),
     doc_file: Union[UploadFile, str] = Form(None),
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Document entity
 
@@ -243,6 +285,7 @@ async def create_document(
     Returns:
         ServerResponse: The response
     """
+    access.require_resource_access(operator, "KNOWLEDGE_BASE", space_id, manage=True)
     request = DocumentServeRequest(
         doc_name=doc_name,
         doc_type=doc_type,
@@ -260,9 +303,11 @@ async def create_document(
     "/documents/{document_id}",
     response_model=Result[List],
 )
-async def query(
+async def query_document(
     document_id: int,
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[List[SpaceServeResponse]]:
     """Query Space entities
 
@@ -272,6 +317,7 @@ async def query(
     Returns:
         List[ServeResponse]: The response
     """
+    access.require_document_access(operator, str(document_id))
     request = {"id": document_id}
     return Result.succ(service.get_document(request))
 
@@ -280,10 +326,12 @@ async def query(
     "/documents",
     response_model=Result[PaginationResult[SpaceServeResponse]],
 )
-async def query_page(
+async def query_document_page(
     page: int = Query(default=1, description="current page"),
     page_size: int = Query(default=20, description="page size"),
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_USE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[PaginationResult[DocumentServeResponse]]:
     """Query Space entities
 
@@ -294,7 +342,13 @@ async def query_page(
     Returns:
         ServerResponse: The response
     """
-    return Result.succ(service.get_document_list_page({}, page, page_size))
+    result = service.get_document_list_page({}, page, page_size)
+    allowed_names = access.allowed_resource_names(operator, "KNOWLEDGE_BASE")
+    if allowed_names is not None:
+        result.items = [item for item in result.items if item.space in allowed_names]
+        result.total_count = len(result.items)
+        result.total_pages = 1 if result.items else 0
+    return Result.succ(result)
 
 
 @router.post("/documents/chunks/add")
@@ -303,13 +357,21 @@ async def add_documents_chunks(
     space_id: int = Form(...),
     content: List[str] = Form(None),
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """ """
+    access.require_resource_access(
+        operator, "KNOWLEDGE_BASE", str(space_id), manage=True
+    )
 
 
-@router.post("/documents/sync", dependencies=[Depends(check_api_key)])
+@router.post("/documents/sync")
 async def sync_documents(
-    requests: List[KnowledgeSyncRequest], service: Service = Depends(get_service)
+    requests: List[KnowledgeSyncRequest],
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Document entity
 
@@ -319,13 +381,26 @@ async def sync_documents(
     Returns:
         ServerResponse: The response
     """
+    for request in requests:
+        if request.doc_id is not None:
+            access.require_document_access(operator, str(request.doc_id), manage=True)
+        elif request.space_id:
+            access.require_resource_access(
+                operator, "KNOWLEDGE_BASE", str(request.space_id), manage=True
+            )
+        else:
+            raise HTTPException(
+                status_code=422, detail="doc_id or space_id is required"
+            )
     return Result.succ(service.sync_document(requests))
 
 
 @router.post("/documents/batch_sync")
-async def sync_documents(
+async def batch_sync_documents(
     requests: List[KnowledgeSyncRequest],
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Document entity
 
@@ -335,6 +410,17 @@ async def sync_documents(
     Returns:
         ServerResponse: The response
     """
+    for request in requests:
+        if request.doc_id is not None:
+            access.require_document_access(operator, str(request.doc_id), manage=True)
+        elif request.space_id:
+            access.require_resource_access(
+                operator, "KNOWLEDGE_BASE", str(request.space_id), manage=True
+            )
+        else:
+            raise HTTPException(
+                status_code=422, detail="doc_id or space_id is required"
+            )
     return Result.succ(service.sync_document(requests))
 
 
@@ -343,6 +429,8 @@ async def sync_document(
     document_id: int,
     request: KnowledgeSyncRequest,
     service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result:
     """Create a new Document entity
 
@@ -352,6 +440,7 @@ async def sync_document(
     Returns:
         ServerResponse: The response
     """
+    access.require_document_access(operator, str(document_id), manage=True)
     request.doc_id = document_id
     if request.chunk_parameters is None:
         request.chunk_parameters = ChunkParameters(chunk_strategy="Automatic")
@@ -360,11 +449,13 @@ async def sync_document(
 
 @router.delete(
     "/documents/{document_id}",
-    dependencies=[Depends(check_api_key)],
     response_model=Result[None],
 )
 async def delete_document(
-    document_id: str, service: Service = Depends(get_service)
+    document_id: str,
+    service: Service = Depends(get_service),
+    operator: UserRequest = Depends(require_permission("KNOWLEDGE_BASE_MANAGE")),
+    access: AccessService = Depends(get_access_service),
 ) -> Result[None]:
     """Delete a Space entity
 
@@ -374,6 +465,7 @@ async def delete_document(
     Returns:
         ServerResponse: The response
     """
+    access.require_document_access(operator, document_id, manage=True)
     # TODO: Delete the files of the document
     res = await blocking_func_to_async(
         global_system_app, service.delete_document, document_id

--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/api/schemas.py
@@ -13,6 +13,7 @@ class SpaceServeRequest(BaseModel):
 
     """vector_type: vector type"""
     id: Optional[int] = Field(None, description="The space id")
+    account_set_id: Optional[str] = Field(None, description="Owning account set ID")
     name: str = Field(None, description="The space name")
     """vector_type: vector type"""
     vector_type: str = Field(None, description="The vector type")
@@ -148,6 +149,7 @@ class SpaceServeResponse(BaseModel):
 
     """vector_type: vector type"""
     id: Optional[int] = Field(None, description="The space id")
+    account_set_id: Optional[str] = Field(None, description="Owning account set ID")
     name: Optional[str] = Field(None, description="The space name")
     """vector_type: vector type"""
     vector_type: Optional[str] = Field(None, description="The vector type")

--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
@@ -39,6 +39,7 @@ class KnowledgeSpaceDao(BaseDao):
         session = self.get_raw_session()
         knowledge_space = KnowledgeSpaceEntity(
             name=space.name,
+            account_set_id=space.account_set_id,
             vector_type=space.vector_type,
             domain_type=space.domain_type,
             desc=space.desc,
@@ -165,6 +166,7 @@ class KnowledgeSpaceDao(BaseDao):
         """
         return SpaceServeRequest(
             id=entity.id,
+            account_set_id=entity.account_set_id,
             name=entity.name,
             vector_type=entity.vector_type,
             desc=entity.desc,
@@ -183,6 +185,7 @@ class KnowledgeSpaceDao(BaseDao):
         """
         return SpaceServeResponse(
             id=entity.id,
+            account_set_id=entity.account_set_id,
             name=entity.name,
             vector_type=entity.vector_type,
             desc=entity.desc,

--- a/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/rag/models/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, Union
 
-from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text
 
 from dbgpt._private.pydantic import model_to_dict
 from dbgpt.storage.metadata import BaseDao, Model
@@ -18,8 +18,11 @@ class KnowledgeSpaceEntity(Model):
     desc = Column(String(100))
     owner = Column(String(100))
     context = Column(Text)
+    account_set_id = Column(String(128), nullable=True, comment="Owning account set ID")
     gmt_created = Column(DateTime)
     gmt_modified = Column(DateTime)
+
+    __table_args__ = (Index("idx_ks_account_set", "account_set_id"),)
 
     def __repr__(self):
         return (

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,5 +1,6 @@
 """Authentication dependencies shared by DB-GPT HTTP endpoints."""
 
+import uuid
 from datetime import datetime
 from typing import Optional
 
@@ -28,6 +29,9 @@ class UserRequest(BaseModel):
     role: Optional[str] = "normal"
     is_active: bool = True
     session_id: Optional[str] = Field(default=None, exclude=True)
+    source_ip: Optional[str] = Field(default=None, exclude=True)
+    user_agent: Optional[str] = Field(default=None, exclude=True)
+    request_id: Optional[str] = Field(default=None, exclude=True)
     gmt_created: Optional[datetime] = None
     disabled_at: Optional[datetime] = None
 
@@ -86,6 +90,9 @@ async def get_current_user(
                 detail="CSRF validation failed",
             )
 
+    raw_request_id = getattr(request.state, "request_id", None)
+    request_id = str(raw_request_id).strip()[:128] if raw_request_id else ""
+
     return UserRequest(
         user_id=user.user_id,
         login_name=user.login_name,
@@ -93,6 +100,9 @@ async def get_current_user(
         role=user.role,
         is_active=user.is_active,
         session_id=session_id,
+        source_ip=(request.client.host if request.client else "")[:64] or None,
+        user_agent=request.headers.get("user-agent", "")[:512] or None,
+        request_id=request_id or str(uuid.uuid4()),
         gmt_created=user.gmt_created,
         disabled_at=user.disabled_at,
         user_no=user.user_id,

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -1,38 +1,117 @@
-import logging
+"""Authentication dependencies shared by DB-GPT HTTP endpoints."""
+
+from datetime import datetime
 from typing import Optional
 
-from fastapi import Header
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from dbgpt._private.pydantic import BaseModel
+from dbgpt._private.pydantic import BaseModel, Field
+from dbgpt_serve.auth.constants import ROLE_PERMISSIONS
+from dbgpt_serve.auth.service.service import (
+    AuthConfigurationError,
+    AuthenticationError,
+    Service,
+    get_auth_service,
+)
 
-logger = logging.getLogger(__name__)
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 class UserRequest(BaseModel):
+    """Current user plus legacy aliases used by existing endpoints."""
+
     user_id: Optional[str] = None
+    login_name: Optional[str] = None
+    display_name: Optional[str] = None
+    role: Optional[str] = "normal"
+    is_active: bool = True
+    session_id: Optional[str] = Field(default=None, exclude=True)
+    gmt_created: Optional[datetime] = None
+    disabled_at: Optional[datetime] = None
+
+    # Compatibility fields for existing endpoint and unit-test call sites.
     user_no: Optional[str] = None
     real_name: Optional[str] = None
-    # same with user_id
     user_name: Optional[str] = None
     user_channel: Optional[str] = None
-    role: Optional[str] = "normal"
     nick_name: Optional[str] = None
     email: Optional[str] = None
     avatar_url: Optional[str] = None
     nick_name_like: Optional[str] = None
 
 
-def get_user_from_headers(user_id: Optional[str] = Header(None)):
+def _not_authenticated() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def get_current_user(
+    request: Request,
+    auth: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    service: Service = Depends(get_auth_service),
+) -> UserRequest:
+    """Authenticate from a bearer token or the secure session cookie."""
+    token = auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    if not token:
+        token = request.cookies.get("dbgpt_session")
+    if not token:
+        raise _not_authenticated()
+
     try:
-        # Mock User Info
-        if user_id:
-            return UserRequest(
-                user_id=user_id, role="admin", nick_name=user_id, real_name=user_id
+        user, session_id = service.authenticate_token(token)
+    except AuthenticationError as exc:
+        raise _not_authenticated() from exc
+    except AuthConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from exc
+
+    return UserRequest(
+        user_id=user.user_id,
+        login_name=user.login_name,
+        display_name=user.display_name,
+        role=user.role,
+        is_active=user.is_active,
+        session_id=session_id,
+        gmt_created=user.gmt_created,
+        disabled_at=user.disabled_at,
+        user_no=user.user_id,
+        real_name=user.display_name,
+        user_name=user.login_name,
+        nick_name=user.display_name,
+    )
+
+
+async def get_user_from_headers(
+    request: Request,
+    auth: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    service: Service = Depends(get_auth_service),
+) -> UserRequest:
+    """Compatibility name for endpoints that previously used mock header auth."""
+    return await get_current_user(request, auth, service)
+
+
+def require_permission(permission: str):
+    """Build a FastAPI dependency that enforces a fixed role permission."""
+
+    async def dependency(
+        user: UserRequest = Depends(get_current_user),
+    ) -> UserRequest:
+        if permission not in ROLE_PERMISSIONS.get(user.role or "", set()):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
             )
-        else:
-            return UserRequest(
-                user_id="001", role="admin", nick_name="dbgpt", real_name="dbgpt"
-            )
-    except Exception as e:
-        logging.exception("Authentication failed!")
-        raise Exception(f"Authentication failed. {str(e)}")
+        return user
+
+    return dependency
+
+
+def require_admin():
+    """Require the system-administrator user-management capability."""
+    return require_permission("USER_MANAGE")

--- a/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/utils/auth.py
@@ -16,6 +16,7 @@ from dbgpt_serve.auth.service.service import (
 )
 
 _bearer_scheme = HTTPBearer(auto_error=False)
+_SAFE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 class UserRequest(BaseModel):
@@ -55,7 +56,10 @@ async def get_current_user(
     service: Service = Depends(get_auth_service),
 ) -> UserRequest:
     """Authenticate from a bearer token or the secure session cookie."""
-    token = auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    bearer_token = (
+        auth.credentials if auth and auth.scheme.lower() == "bearer" else None
+    )
+    token = bearer_token
     if not token:
         token = request.cookies.get("dbgpt_session")
     if not token:
@@ -70,6 +74,17 @@ async def get_current_user(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Authentication service unavailable",
         ) from exc
+
+    if request.method.upper() not in _SAFE_HTTP_METHODS and not bearer_token:
+        csrf_cookie = request.cookies.get("dbgpt_csrf", "")
+        csrf_header = request.headers.get("x-csrf-token", "")
+        if csrf_cookie != csrf_header or not service.validate_csrf_token(
+            token, csrf_header
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CSRF validation failed",
+            )
 
     return UserRequest(
         user_id=user.user_id,

--- a/uv.lock
+++ b/uv.lock
@@ -6186,7 +6186,6 @@ dependencies = [
     { name = "apscheduler" },
     { name = "bcrypt" },
     { name = "dbgpt-ext" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "python-jose", extra = ["cryptography"] },
 ]
 
@@ -6204,7 +6203,6 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4,<5" },
     { name = "dbgpt-ext", editable = "packages/dbgpt-ext" },
     { name = "libro", marker = "extra == 'libro'", specifier = ">=0.1.25" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "poetry", marker = "extra == 'dbgpts'" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
 ]
@@ -14596,20 +14594,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/9c/9c366aed65acb40a97842ce1375a87b27ea37d735fc9717f7729bae3cc00/partial_json_parser-0.2.1.1.post5.tar.gz", hash = "sha256:992710ac67e90b367921d52727698928040f7713ba7ecb33b96371ea7aec82ca", size = 10313, upload-time = "2025-01-08T15:44:02.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ee/a9476f01f27c74420601be208c6c2c0dd3486681d515e9d765931b89851c/partial_json_parser-0.2.1.1.post5-py3-none-any.whl", hash = "sha256:627715aaa3cb3fb60a65b0d62223243acaa6c70846520a90326fef3a2f0b61ca", size = 10885, upload-time = "2025-01-08T15:44:00.987Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -6184,7 +6184,10 @@ version = "0.8.1"
 source = { editable = "packages/dbgpt-serve" }
 dependencies = [
     { name = "apscheduler" },
+    { name = "bcrypt" },
     { name = "dbgpt-ext" },
+    { name = "passlib", extra = ["bcrypt"] },
+    { name = "python-jose", extra = ["cryptography"] },
 ]
 
 [package.optional-dependencies]
@@ -6198,9 +6201,12 @@ libro = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.10,<4" },
+    { name = "bcrypt", specifier = ">=4,<5" },
     { name = "dbgpt-ext", editable = "packages/dbgpt-ext" },
     { name = "libro", marker = "extra == 'libro'", specifier = ">=0.1.25" },
+    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "poetry", marker = "extra == 'dbgpts'" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
 ]
 provides-extras = ["libro", "dbgpts"]
 
@@ -6455,6 +6461,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186, upload-time = "2024-10-02T17:59:00.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461, upload-time = "2024-10-02T17:58:59.349Z" },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -14581,6 +14599,20 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
+]
+
+[package.optional-dependencies]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
 name = "pathlib-abc"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -15831,6 +15863,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/06/1ef763af20d0572c032fa22882cfbfb005fba6e7300715a37840858c919e/python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba", size = 37399, upload-time = "2023-02-24T06:46:37.282Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/2f/62ea1c8b593f4e093cc1a7768f0d46112107e790c3e478532329e434f00b/python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a", size = 19482, upload-time = "2023-02-24T06:46:36.009Z" },
+]
+
+[[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
 ]
 
 [[package]]

--- a/web/client/api/admin/account-sets.ts
+++ b/web/client/api/admin/account-sets.ts
@@ -1,0 +1,33 @@
+import {
+  AccountSet,
+  AccountSetImpact,
+  AccountSetInput,
+  AccountSetListParams,
+  AdminResult,
+  ImpactConfirmation,
+  Page,
+} from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const ACCOUNT_SETS_BASE = '/api/v1/admin/account-sets';
+
+export const listAccountSets = (params: AccountSetListParams = {}) =>
+  api.get<unknown, AdminResult<Page<AccountSet>>>(ACCOUNT_SETS_BASE, { params });
+
+export const getAccountSet = (accountSetId: string) =>
+  api.get<unknown, AdminResult<AccountSet>>(`${ACCOUNT_SETS_BASE}/${encodeURIComponent(accountSetId)}`);
+
+export const createAccountSet = (body: AccountSetInput) =>
+  api.post<unknown, AdminResult<AccountSet>>(ACCOUNT_SETS_BASE, body);
+
+export const updateAccountSet = (accountSetId: string, body: Partial<AccountSetInput>) =>
+  api.patch<unknown, AdminResult<AccountSet>>(`${ACCOUNT_SETS_BASE}/${encodeURIComponent(accountSetId)}`, body);
+
+export const getAccountSetImpact = (accountSetId: string) =>
+  api.get<unknown, AdminResult<AccountSetImpact>>(`${ACCOUNT_SETS_BASE}/${encodeURIComponent(accountSetId)}/impact`);
+
+export const toggleAccountSetActive = (accountSetId: string, activate: boolean, confirmation?: ImpactConfirmation) =>
+  api.post<unknown, AdminResult<AccountSet>>(
+    `${ACCOUNT_SETS_BASE}/${encodeURIComponent(accountSetId)}/${activate ? 'activate' : 'deactivate'}`,
+    activate ? {} : confirmation,
+  );

--- a/web/client/api/admin/audit.ts
+++ b/web/client/api/admin/audit.ts
@@ -1,0 +1,10 @@
+import { AdminResult, AuditEvent, AuditEventListParams, Page } from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const AUDIT_BASE = '/api/v1/admin/audit';
+
+export const getAuditEvents = (params: AuditEventListParams = {}) =>
+  api.get<unknown, AdminResult<Page<AuditEvent>>>(AUDIT_BASE, { params });
+
+export const getAuditEventDetail = (eventId: string) =>
+  api.get<unknown, AdminResult<AuditEvent>>(`${AUDIT_BASE}/${encodeURIComponent(eventId)}`);

--- a/web/client/api/admin/auth.ts
+++ b/web/client/api/admin/auth.ts
@@ -1,0 +1,15 @@
+import api from '@/utils/ctx-axios';
+
+import { AdminLoginResponse, AdminResult, AdminUser } from '@/types/admin';
+
+const ADMIN_AUTH_BASE = '/api/v1/admin/auth';
+
+export const adminLogin = (loginName: string, password: string) =>
+  api.post<unknown, AdminResult<AdminLoginResponse>>(`${ADMIN_AUTH_BASE}/login`, {
+    login_name: loginName,
+    password,
+  });
+
+export const adminLogout = () => api.post<unknown, AdminResult<null>>(`${ADMIN_AUTH_BASE}/logout`, {});
+
+export const getAdminCurrentUser = () => api.get<unknown, AdminResult<AdminUser>>(`${ADMIN_AUTH_BASE}/me`);

--- a/web/client/api/admin/grants.ts
+++ b/web/client/api/admin/grants.ts
@@ -1,0 +1,50 @@
+import {
+  AdminResource,
+  AdminResourceType,
+  AdminResult,
+  GrantListParams,
+  Page,
+  ResourceGrantListParams,
+  RevokeImpact,
+  UserAccountGrant,
+  UserResourceGrant,
+} from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const userPath = (userId: string) => `/api/v1/admin/users/${encodeURIComponent(userId)}`;
+
+export const getUserAccountGrants = (userId: string, params: GrantListParams = {}) =>
+  api.get<unknown, AdminResult<Page<UserAccountGrant>>>(`${userPath(userId)}/account-grants`, { params });
+
+export const grantUserAccount = (userId: string, accountSetId: string) =>
+  api.post<unknown, AdminResult<UserAccountGrant>>(`${userPath(userId)}/account-grants`, {
+    account_set_id: accountSetId,
+  });
+
+export const getUserAccountGrantImpact = (userId: string, grantId: string) =>
+  api.get<unknown, AdminResult<RevokeImpact>>(
+    `${userPath(userId)}/account-grants/${encodeURIComponent(grantId)}/impact`,
+  );
+
+export const revokeUserAccountGrant = (userId: string, grantId: string, reason: string, impactToken: string) =>
+  api.delete<unknown, AdminResult<RevokeImpact>>(`${userPath(userId)}/account-grants/${encodeURIComponent(grantId)}`, {
+    data: { reason, impact_token: impactToken, confirm_impact: true },
+  });
+
+export const getUserResourceGrants = (userId: string, params: ResourceGrantListParams = {}) =>
+  api.get<unknown, AdminResult<Page<UserResourceGrant>>>(`${userPath(userId)}/resource-grants`, { params });
+
+export const getAvailableResources = (userId: string) =>
+  api.get<unknown, AdminResult<AdminResource[]>>(`${userPath(userId)}/resource-grants/available`);
+
+export const grantUserResource = (userId: string, resourceType: AdminResourceType, resourceId: string) =>
+  api.post<unknown, AdminResult<UserResourceGrant>>(`${userPath(userId)}/resource-grants`, {
+    resource_type: resourceType,
+    resource_id: resourceId,
+  });
+
+export const revokeUserResourceGrant = (userId: string, grantId: string, reason: string) =>
+  api.delete<unknown, AdminResult<UserResourceGrant>>(
+    `${userPath(userId)}/resource-grants/${encodeURIComponent(grantId)}`,
+    { data: { reason } },
+  );

--- a/web/client/api/admin/index.ts
+++ b/web/client/api/admin/index.ts
@@ -1,0 +1,7 @@
+export * from './account-sets';
+export * from './audit';
+export * from './auth';
+export * from './grants';
+export * from './resources';
+export * from './token-usage';
+export * from './users';

--- a/web/client/api/admin/resources.ts
+++ b/web/client/api/admin/resources.ts
@@ -1,0 +1,34 @@
+import {
+  AdminResource,
+  AdminResourceListParams,
+  AdminResourceType,
+  AdminResult,
+  Page,
+  ResourceImpact,
+} from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const resourcePath = (type: AdminResourceType, id: string) =>
+  `/api/v1/admin/resources/${type}/${encodeURIComponent(id)}`;
+
+export const listAdminResources = (params: AdminResourceListParams = {}) =>
+  api.get<unknown, AdminResult<Page<AdminResource>>>('/api/v1/admin/resources', { params });
+
+export const getResourceImpact = (type: AdminResourceType, id: string, newAccountSetId: string) =>
+  api.get<unknown, AdminResult<ResourceImpact>>(`${resourcePath(type, id)}/impact`, {
+    params: { new_account_set_id: newAccountSetId },
+  });
+
+export const assignResourceAccountSet = (
+  type: AdminResourceType,
+  id: string,
+  accountSetId: string,
+  reason: string,
+  impactToken: string,
+) =>
+  api.patch<unknown, AdminResult<AdminResource>>(`${resourcePath(type, id)}/account-set`, {
+    account_set_id: accountSetId,
+    reason,
+    impact_token: impactToken,
+    confirm_impact: true,
+  });

--- a/web/client/api/admin/token-usage.ts
+++ b/web/client/api/admin/token-usage.ts
@@ -1,0 +1,23 @@
+import {
+  AdminResult,
+  Page,
+  TokenDailyStat,
+  TokenUsageDetail,
+  TokenUsageFilters,
+  TokenUsageListParams,
+  TokenUsageSummary,
+} from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const TOKEN_USAGE_BASE = '/api/v1/admin/token-usage';
+
+export const getTokenUsageSummary = (statDate?: string) =>
+  api.get<unknown, AdminResult<TokenUsageSummary>>(`${TOKEN_USAGE_BASE}/summary`, {
+    params: statDate ? { stat_date: statDate } : undefined,
+  });
+
+export const getTokenUsageDetail = (params: TokenUsageListParams = {}) =>
+  api.get<unknown, AdminResult<Page<TokenUsageDetail>>>(`${TOKEN_USAGE_BASE}/detail`, { params });
+
+export const getTokenUsageDaily = (params: TokenUsageFilters = {}) =>
+  api.get<unknown, AdminResult<TokenDailyStat[]>>(`${TOKEN_USAGE_BASE}/daily`, { params });

--- a/web/client/api/admin/users.ts
+++ b/web/client/api/admin/users.ts
@@ -1,0 +1,36 @@
+import {
+  AdminResult,
+  AdminRoleInfo,
+  AdminUser,
+  AdminUserCreate,
+  AdminUserListParams,
+  AdminUserUpdate,
+  Page,
+} from '@/types/admin';
+import api from '@/utils/ctx-axios';
+
+const USERS_BASE = '/api/v1/admin/users';
+
+export const listAdminUsers = (params: AdminUserListParams = {}) =>
+  api.get<unknown, AdminResult<Page<AdminUser>>>(USERS_BASE, { params });
+
+export const getAdminUser = (userId: string) =>
+  api.get<unknown, AdminResult<AdminUser>>(`${USERS_BASE}/${encodeURIComponent(userId)}`);
+
+export const createAdminUser = (body: AdminUserCreate) => api.post<unknown, AdminResult<AdminUser>>(USERS_BASE, body);
+
+export const updateAdminUser = (userId: string, body: AdminUserUpdate) =>
+  api.patch<unknown, AdminResult<AdminUser>>(`${USERS_BASE}/${encodeURIComponent(userId)}`, body);
+
+export const toggleUserActive = (userId: string, activate: boolean) =>
+  api.post<unknown, AdminResult<AdminUser>>(
+    `${USERS_BASE}/${encodeURIComponent(userId)}/${activate ? 'activate' : 'deactivate'}`,
+    {},
+  );
+
+export const setUserPassword = (userId: string, password: string) =>
+  api.post<unknown, AdminResult<null>>(`${USERS_BASE}/${encodeURIComponent(userId)}/set-password`, {
+    new_password: password,
+  });
+
+export const listAdminRoles = () => api.get<unknown, AdminResult<AdminRoleInfo[]>>('/api/v1/admin/roles');

--- a/web/hooks/use-admin-auth.ts
+++ b/web/hooks/use-admin-auth.ts
@@ -1,0 +1,46 @@
+import { getAdminCurrentUser } from '@/client/api/admin';
+import { AdminUser } from '@/types/admin';
+import { useRouter } from 'next/router';
+import { createContext, createElement, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+interface AdminAuthState {
+  user: AdminUser | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+const AdminAuthContext = createContext<AdminAuthState | null>(null);
+
+export function AdminAuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await getAdminCurrentUser();
+      if (!result.success || !result.data) throw new Error('Invalid authentication response');
+      setUser(result.data);
+    } catch {
+      setUser(null);
+      if (router.pathname !== '/admin/login') await router.replace('/admin/login');
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo(() => ({ user, loading, refresh }), [loading, refresh, user]);
+
+  return createElement(AdminAuthContext.Provider, { value }, children);
+}
+
+export function useAdminAuthGuard() {
+  const context = useContext(AdminAuthContext);
+  if (!context) throw new Error('useAdminAuthGuard must be used inside AdminAuthProvider');
+  return context;
+}

--- a/web/new-components/admin/AdminLayout.tsx
+++ b/web/new-components/admin/AdminLayout.tsx
@@ -1,0 +1,88 @@
+import { LogoutOutlined } from '@ant-design/icons';
+import { App, Button, Layout, Spin, Tag, Typography } from 'antd';
+import { useRouter } from 'next/router';
+import { ReactNode, useEffect, useState } from 'react';
+
+import { adminLogout } from '@/client/api/admin';
+import { AdminAuthProvider, useAdminAuthGuard } from '@/hooks/use-admin-auth';
+import { AdminRole } from '@/types/admin';
+
+import { AdminSider, canAccessAdminPath, getDefaultAdminPath } from './AdminSider';
+
+const ROLE_LABELS: Record<AdminRole, string> = {
+  system_admin: '系统管理员',
+  operations_admin: '运营管理员',
+  query_user: '查询用户',
+};
+
+function AdminLayoutContent({ children }: { children: ReactNode }) {
+  const { message } = App.useApp();
+  const router = useRouter();
+  const { user, loading } = useAdminAuthGuard();
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  useEffect(() => {
+    if (user && !canAccessAdminPath(user.role, router.pathname)) {
+      void router.replace(getDefaultAdminPath(user.role));
+    }
+  }, [router, user]);
+
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    try {
+      const result = await adminLogout();
+      if (!result.success) throw new Error('Logout failed');
+    } catch {
+      message.error('退出登录失败，请重试');
+      setLoggingOut(false);
+      return;
+    }
+    await router.replace('/admin/login');
+  };
+
+  if (loading || !user) {
+    return (
+      <div className='flex h-screen w-screen items-center justify-center bg-gray-50' aria-label='正在验证登录状态'>
+        <Spin size='large' />
+      </div>
+    );
+  }
+
+  return (
+    <Layout className='h-screen min-h-[520px] bg-gray-50'>
+      <AdminSider role={user.role} />
+      <Layout className='min-w-0 overflow-hidden bg-gray-50'>
+        <Layout.Header className='flex h-16 items-center justify-end gap-3 border-0 border-b border-solid border-gray-200 bg-white px-4 md:px-6'>
+          <div className='min-w-0 text-right leading-5'>
+            <Typography.Text className='block max-w-40 truncate text-sm' title={user.display_name}>
+              {user.display_name}
+            </Typography.Text>
+            <Tag bordered={false} className='m-0 text-xs'>
+              {ROLE_LABELS[user.role]}
+            </Tag>
+          </div>
+          <Button
+            aria-label='退出登录'
+            icon={<LogoutOutlined />}
+            loading={loggingOut}
+            onClick={() => void handleLogout()}
+            type='text'
+          >
+            <span className='hidden sm:inline'>退出</span>
+          </Button>
+        </Layout.Header>
+        <Layout.Content className='min-h-0 overflow-auto p-4 md:p-6'>{children}</Layout.Content>
+      </Layout>
+    </Layout>
+  );
+}
+
+export function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <AdminAuthProvider>
+      <AdminLayoutContent>{children}</AdminLayoutContent>
+    </AdminAuthProvider>
+  );
+}
+
+export default AdminLayout;

--- a/web/new-components/admin/AdminSider.tsx
+++ b/web/new-components/admin/AdminSider.tsx
@@ -1,0 +1,98 @@
+import {
+  ApartmentOutlined,
+  AuditOutlined,
+  BarChartOutlined,
+  DatabaseOutlined,
+  SafetyCertificateOutlined,
+  TeamOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { Layout, Menu, Typography } from 'antd';
+import { useRouter } from 'next/router';
+
+import { AdminRole } from '@/types/admin';
+
+interface AdminMenuItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  roles: AdminRole[];
+}
+
+const ALL_ROLES: AdminRole[] = ['system_admin', 'operations_admin', 'query_user'];
+
+const ADMIN_MENU: AdminMenuItem[] = [
+  { key: '/admin/users', label: '用户管理', icon: <UserOutlined />, roles: ['system_admin'] },
+  { key: '/admin/roles', label: '角色权限', icon: <SafetyCertificateOutlined />, roles: ['system_admin'] },
+  { key: '/admin/account-sets', label: '账套管理', icon: <ApartmentOutlined />, roles: ['system_admin'] },
+  {
+    key: '/admin/user-account-grants',
+    label: '用户账套授权',
+    icon: <TeamOutlined />,
+    roles: ['system_admin'],
+  },
+  {
+    key: '/admin/user-resource-grants',
+    label: '用户资源授权',
+    icon: <SafetyCertificateOutlined />,
+    roles: ['system_admin'],
+  },
+  {
+    key: '/admin/resources',
+    label: '资源管理',
+    icon: <DatabaseOutlined />,
+    roles: ['system_admin', 'operations_admin'],
+  },
+  { key: '/admin/token-usage', label: 'Token 用量', icon: <BarChartOutlined />, roles: ALL_ROLES },
+  { key: '/admin/audit', label: '审计日志', icon: <AuditOutlined />, roles: ['system_admin'] },
+];
+
+export const getDefaultAdminPath = (role: AdminRole) => {
+  if (role === 'system_admin') return '/admin/users';
+  if (role === 'operations_admin') return '/admin/resources';
+  return '/admin/token-usage';
+};
+
+export const canAccessAdminPath = (role: AdminRole, path: string) => {
+  const item = ADMIN_MENU.find(menuItem => path === menuItem.key || path.startsWith(`${menuItem.key}/`));
+  return item ? item.roles.includes(role) : path === '/admin';
+};
+
+export function AdminSider({ role }: { role: AdminRole }) {
+  const router = useRouter();
+  const items: MenuProps['items'] = ADMIN_MENU.filter(item => item.roles.includes(role)).map(
+    ({ roles: _roles, ...item }) => item,
+  );
+  const selected = ADMIN_MENU.find(item => router.pathname === item.key || router.pathname.startsWith(`${item.key}/`));
+
+  return (
+    <Layout.Sider
+      breakpoint='lg'
+      collapsedWidth={0}
+      width={232}
+      className='border-r border-solid border-gray-200 bg-white max-lg:absolute max-lg:inset-y-0 max-lg:left-0 max-lg:z-20 max-lg:shadow-lg'
+      theme='light'
+      zeroWidthTriggerStyle={{ top: 14 }}
+    >
+      <div className='flex h-16 items-center gap-3 border-0 border-b border-solid border-gray-200 px-5'>
+        <img src='/LOGO_SMALL.png' width={30} height={30} alt='DB-GPT' />
+        <div className='min-w-0'>
+          <Typography.Text strong className='block text-[15px] leading-5'>
+            DB-GPT
+          </Typography.Text>
+          <Typography.Text type='secondary' className='block text-xs leading-4'>
+            管理后台
+          </Typography.Text>
+        </div>
+      </div>
+      <Menu
+        className='border-0 px-2 py-3'
+        items={items}
+        mode='inline'
+        selectedKeys={selected ? [selected.key] : []}
+        onClick={({ key }) => void router.push(key)}
+      />
+    </Layout.Sider>
+  );
+}

--- a/web/new-components/admin/ConfirmModal.tsx
+++ b/web/new-components/admin/ConfirmModal.tsx
@@ -1,0 +1,112 @@
+import { Alert, Button, Input, Modal, Space, Typography } from 'antd';
+import { useEffect, useState } from 'react';
+
+export interface ConfirmModalProps {
+  open: boolean;
+  title: string;
+  description: string;
+  impact?: string;
+  impactItems?: { label: string; value: string }[];
+  requireReason?: boolean;
+  confirmText?: string;
+  onConfirm: (reason?: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  open,
+  title,
+  description,
+  impact,
+  impactItems = [],
+  requireReason = false,
+  confirmText = '确认执行',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setReason('');
+      setSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [open]);
+
+  const handleConfirm = async () => {
+    const normalizedReason = reason.trim();
+    if (requireReason && !normalizedReason) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onConfirm(normalizedReason || undefined);
+    } catch {
+      setSubmitError('操作失败，请重试');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={title}
+      onCancel={submitting ? undefined : onCancel}
+      footer={
+        <Space>
+          <Button disabled={submitting} onClick={onCancel}>
+            取消
+          </Button>
+          <Button
+            danger
+            disabled={requireReason && !reason.trim()}
+            loading={submitting}
+            onClick={() => void handleConfirm()}
+            type='primary'
+          >
+            {confirmText}
+          </Button>
+        </Space>
+      }
+      destroyOnClose
+      maskClosable={!submitting}
+    >
+      <Space className='w-full' direction='vertical' size={16}>
+        <Typography.Paragraph className='mb-0 text-sm'>{description}</Typography.Paragraph>
+        {submitError && <Alert message={submitError} type='error' showIcon />}
+        {impact && <Alert message={impact} type='warning' showIcon />}
+        {impactItems.length > 0 && (
+          <div className='max-h-40 overflow-auto border-0 border-l-2 border-solid border-amber-400 pl-3'>
+            {impactItems.map(item => (
+              <div className='flex gap-3 py-1 text-sm' key={`${item.label}-${item.value}`}>
+                <Typography.Text type='secondary' className='w-28 shrink-0'>
+                  {item.label}
+                </Typography.Text>
+                <Typography.Text className='break-all'>{item.value}</Typography.Text>
+              </div>
+            ))}
+          </div>
+        )}
+        {requireReason && (
+          <div>
+            <Typography.Text className='mb-2 block text-sm'>操作原因</Typography.Text>
+            <Input.TextArea
+              autoFocus
+              maxLength={512}
+              placeholder='请输入操作原因'
+              rows={3}
+              showCount
+              value={reason}
+              onChange={event => setReason(event.target.value)}
+            />
+          </div>
+        )}
+      </Space>
+    </Modal>
+  );
+}
+
+export default ConfirmModal;

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -130,6 +130,17 @@ function LayoutWrapper({ children }: { children: React.ReactNode }) {
 }
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  if (router.pathname.startsWith('/admin')) {
+    return (
+      <ConfigProvider locale={zhCN} theme={{ token: { colorPrimary: '#0C75FC', borderRadius: 4 } }}>
+        <App>
+          <Component {...pageProps} />
+        </App>
+      </ConfigProvider>
+    );
+  }
+
   return (
     <ChatContextProvider>
       <CssWrapper>

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -1,0 +1,25 @@
+import { Spin } from 'antd';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { getAdminCurrentUser } from '@/client/api/admin';
+import { getDefaultAdminPath } from '@/new-components/admin/AdminSider';
+
+export default function AdminIndexPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    void getAdminCurrentUser()
+      .then(result => {
+        if (!result.success || !result.data) throw new Error('Not authenticated');
+        return router.replace(getDefaultAdminPath(result.data.role));
+      })
+      .catch(() => router.replace('/admin/login'));
+  }, [router]);
+
+  return (
+    <div className='flex h-screen w-screen items-center justify-center bg-gray-50' aria-label='正在进入管理后台'>
+      <Spin size='large' />
+    </div>
+  );
+}

--- a/web/pages/admin/login.tsx
+++ b/web/pages/admin/login.tsx
@@ -1,0 +1,101 @@
+import { LockOutlined, UserOutlined } from '@ant-design/icons';
+import { Alert, Button, Form, Input, Typography } from 'antd';
+import type { AxiosError } from 'axios';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+import { adminLogin, getAdminCurrentUser } from '@/client/api/admin';
+import { getDefaultAdminPath } from '@/new-components/admin/AdminSider';
+
+interface LoginFormValues {
+  loginName: string;
+  password: string;
+}
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void getAdminCurrentUser()
+      .then(result => {
+        if (active && result.success && result.data) {
+          void router.replace(getDefaultAdminPath(result.data.role));
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  const handleSubmit = async ({ loginName, password }: LoginFormValues) => {
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      const result = await adminLogin(loginName.trim(), password);
+      if (!result.success || !result.data) throw new Error('Invalid authentication response');
+      await router.replace(getDefaultAdminPath(result.data.user.role));
+    } catch (error) {
+      const status = (error as AxiosError).response?.status;
+      setErrorMessage(status === 503 ? '认证服务暂不可用，请稍后重试' : '登录名或密码错误');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>登录 | DB-GPT 管理后台</title>
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+      </Head>
+      <main className='flex min-h-screen items-center justify-center bg-gray-100 px-4 py-8'>
+        <section className='w-full max-w-[400px] rounded-md border border-solid border-gray-200 bg-white px-6 py-8 shadow-sm sm:px-8'>
+          <div className='mb-7 flex items-center gap-3'>
+            <img src='/LOGO_SMALL.png' width={42} height={42} alt='DB-GPT' />
+            <div>
+              <Typography.Title className='m-0 text-xl leading-7' level={1}>
+                DB-GPT 管理后台
+              </Typography.Title>
+              <Typography.Text type='secondary' className='text-sm'>
+                使用管理员账号登录
+              </Typography.Text>
+            </div>
+          </div>
+
+          {errorMessage && <Alert className='mb-5' message={errorMessage} type='error' showIcon />}
+
+          <Form<LoginFormValues> layout='vertical' requiredMark={false} onFinish={values => void handleSubmit(values)}>
+            <Form.Item
+              label='登录名'
+              name='loginName'
+              rules={[{ required: true, whitespace: true, message: '请输入登录名' }]}
+            >
+              <Input
+                autoComplete='username'
+                prefix={<UserOutlined className='text-gray-400' />}
+                placeholder='请输入登录名'
+                size='large'
+              />
+            </Form.Item>
+            <Form.Item label='密码' name='password' rules={[{ required: true, message: '请输入密码' }]}>
+              <Input.Password
+                autoComplete='current-password'
+                prefix={<LockOutlined className='text-gray-400' />}
+                placeholder='请输入密码'
+                size='large'
+              />
+            </Form.Item>
+            <Button className='mt-1 w-full' htmlType='submit' loading={submitting} size='large' type='primary'>
+              登录
+            </Button>
+          </Form>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/web/types/admin.ts
+++ b/web/types/admin.ts
@@ -1,0 +1,254 @@
+export type AdminRole = 'system_admin' | 'operations_admin' | 'query_user';
+
+export type AdminResourceType = 'DATASOURCE' | 'KNOWLEDGE_BASE' | 'AGENT';
+
+export type AuditResult = 'success' | 'failed' | 'denied';
+
+export interface AdminResult<T> {
+  success: boolean;
+  err_code: string | null;
+  err_msg: string | null;
+  data: T | null;
+}
+
+export interface Page<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface AdminUser {
+  user_id: string;
+  login_name: string;
+  display_name: string;
+  role: AdminRole;
+  is_active: boolean;
+  gmt_created: string;
+  disabled_at?: string | null;
+}
+
+export interface AdminLoginResponse {
+  access_token: string;
+  token_type: 'bearer';
+  user: AdminUser;
+}
+
+export interface AdminUserListParams {
+  page?: number;
+  page_size?: number;
+  login_name_like?: string;
+  display_name_like?: string;
+  role?: AdminRole;
+  is_active?: boolean;
+}
+
+export interface AdminUserCreate {
+  login_name: string;
+  display_name: string;
+  role: Exclude<AdminRole, 'system_admin'>;
+  initial_password?: string;
+  send_activation?: boolean;
+  initial_account_set_ids?: string[];
+}
+
+export interface AdminUserUpdate {
+  display_name?: string;
+  role?: AdminRole;
+  change_reason?: string;
+  confirm_role_change?: boolean;
+}
+
+export interface AdminRoleInfo {
+  role: AdminRole;
+  permissions: string[];
+  user_count: number;
+}
+
+export interface AccountSet {
+  account_set_id: string;
+  name: string;
+  description?: string | null;
+  is_active: boolean;
+  gmt_created: string;
+}
+
+export interface AccountSetListParams {
+  page?: number;
+  page_size?: number;
+  name_like?: string;
+  is_active?: boolean;
+}
+
+export interface AccountSetInput {
+  name: string;
+  description?: string | null;
+}
+
+export interface AccountSetImpact {
+  account_set_id: string;
+  user_grant_count: number;
+  resource_grant_count: number;
+  resource_count: number;
+  impact_token: string;
+}
+
+export interface ImpactConfirmation {
+  reason: string;
+  confirm_impact: true;
+  impact_token: string;
+}
+
+export interface UserAccountGrant {
+  grant_id: string;
+  user_id: string;
+  account_set_id: string;
+  is_active: boolean;
+  granted_by: string;
+  revoked_by?: string | null;
+  revoked_at?: string | null;
+  revoke_reason?: string | null;
+  gmt_created: string;
+}
+
+export interface UserResourceGrant {
+  grant_id: string;
+  user_id: string;
+  resource_type: AdminResourceType;
+  resource_id: string;
+  account_set_id: string;
+  is_active: boolean;
+  granted_by: string;
+  revoked_by?: string | null;
+  revoked_at?: string | null;
+  revoke_reason?: string | null;
+  gmt_created: string;
+}
+
+export interface GrantListParams {
+  page?: number;
+  page_size?: number;
+  is_active?: boolean;
+}
+
+export interface ResourceGrantListParams extends GrantListParams {
+  resource_type?: AdminResourceType;
+}
+
+export interface RevokeImpact {
+  grant_id: string;
+  affected_resource_grants: number;
+  affected_grants_detail: Array<Record<string, unknown>>;
+  impact_token: string;
+}
+
+export interface AdminResource {
+  resource_type: AdminResourceType;
+  resource_id: string;
+  name: string;
+  account_set_id?: string | null;
+}
+
+export interface AdminResourceListParams {
+  page?: number;
+  page_size?: number;
+  resource_type?: AdminResourceType;
+  account_set_id?: string;
+  unassigned?: boolean;
+}
+
+export interface ResourceImpact {
+  resource_type: AdminResourceType;
+  resource_id: string;
+  current_account_set_id?: string | null;
+  new_account_set_id: string;
+  affected_resource_grants: number;
+  affected_agent_grants: number;
+  affected_grants_detail: Array<Record<string, unknown>>;
+  impact_token: string;
+}
+
+export interface TokenUsageFilters {
+  user_id?: string;
+  account_set_id?: string;
+  model?: string;
+  date_from?: string;
+  date_to?: string;
+  role?: AdminRole;
+}
+
+export interface TokenUsageListParams extends TokenUsageFilters {
+  page?: number;
+  page_size?: number;
+}
+
+export interface TokenUsageSummary {
+  stat_date: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  call_count: number;
+}
+
+export interface TokenUsageDetail {
+  call_id: string;
+  request_id: string;
+  session_id?: string | null;
+  user_id: string;
+  role_snapshot: AdminRole;
+  account_set_id?: string | null;
+  account_set_snapshot?: string | null;
+  entry_resource_type?: AdminResourceType | null;
+  entry_resource_id?: string | null;
+  agent_id?: string | null;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  metering_source: 'provider' | 'estimated' | 'unknown';
+  duration_ms?: number | null;
+  status: 'success' | 'failed';
+  error_type?: string | null;
+  gmt_created: string;
+}
+
+export interface TokenDailyStat {
+  stat_date: string;
+  user_id: string;
+  role_snapshot: AdminRole;
+  account_set_id: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  call_count: number;
+}
+
+export interface AuditEvent {
+  event_id: string;
+  event_time: string;
+  operator_user_id?: string | null;
+  operator_role_snapshot?: AdminRole | null;
+  target_account_set_id?: string | null;
+  target_type: string;
+  target_id?: string | null;
+  action: string;
+  result: AuditResult;
+  source_ip?: string | null;
+  user_agent?: string | null;
+  request_id?: string | null;
+  before_snapshot?: string | null;
+  after_snapshot?: string | null;
+  deny_reason?: string | null;
+}
+
+export interface AuditEventListParams {
+  page?: number;
+  page_size?: number;
+  target_type?: string;
+  action?: string;
+  operator_user_id?: string;
+  result?: AuditResult;
+  date_from?: string;
+  date_to?: string;
+}

--- a/web/utils/ctx-axios.ts
+++ b/web/utils/ctx-axios.ts
@@ -6,6 +6,36 @@ const api = axios.create({
 
 api.defaults.timeout = 10000;
 
+const ADMIN_API_PREFIX = '/api/v1/admin/';
+const UNSAFE_METHODS = new Set(['post', 'put', 'patch', 'delete']);
+
+const readBrowserCookie = (name: string) => {
+  if (typeof document === 'undefined') return null;
+  const prefix = `${encodeURIComponent(name)}=`;
+  const cookie = document.cookie
+    .split(';')
+    .map(item => item.trim())
+    .find(item => item.startsWith(prefix));
+  if (!cookie) return null;
+  try {
+    return decodeURIComponent(cookie.slice(prefix.length));
+  } catch {
+    return null;
+  }
+};
+
+api.interceptors.request.use(request => {
+  const method = request.method?.toLowerCase();
+  if (!request.url?.startsWith(ADMIN_API_PREFIX)) return request;
+
+  request.withCredentials = true;
+  if (method && UNSAFE_METHODS.has(method)) {
+    const csrfToken = readBrowserCookie('dbgpt_csrf');
+    if (csrfToken) request.headers.set('X-CSRF-Token', csrfToken);
+  }
+  return request;
+});
+
 api.interceptors.response.use(
   response => response.data,
   err => Promise.reject(err),


### PR DESCRIPTION
## Summary
- add typed admin API clients for authentication, users, account sets, grants, protected resources, token usage, and audit events
- add an HttpOnly-cookie authentication guard with CSRF header propagation for admin write requests; no JWT is stored in browser storage
- add the role-aware responsive admin shell, high-risk confirmation modal, admin index redirect, and login flow
- isolate `/admin/*` from the legacy mock-auth/main-site application wrapper

## Dependency
This stacked Phase 7 PR depends on #3147 (Phase 6). Merge the phases in order.

## Verification
- targeted ESLint for all changed frontend files
- targeted TypeScript compilation for the Phase 7 files
- `pytest packages/dbgpt-serve/src/dbgpt_serve/auth/tests -q`: 60 passed
- Playwright desktop flow: generic invalid-login error, successful system-admin redirect to `/admin/users`, full role menu, CSRF-protected logout
- Playwright 390x844 flow: operations-admin menu only exposes Resources and Token Usage; collapsed and expanded navigation checked by screenshot
- `git diff --check` and staged credential-pattern scan

## Repository Baseline Notes
- Next production JavaScript compilation succeeds. Full `next build` remains blocked during existing whole-site page-data collection timeouts; the default build also reports pre-existing CRLF/Prettier failures outside this change.
- `npm audit --omit=dev` reports the repository's existing dependency baseline (65 findings, including framework/chart dependency upgrade paths). This PR adds no dependency and does not mix a broad lockfile migration into the phase.