### PR TITLE
fix: correct flow operator detection in _module.py (closes #2280)

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/cli/_module.py
+++ b/packages/dbgpt-core/src/dbgpt/util/cli/_module.py
@@ -12,11 +12,16 @@ from dbgpt.util.module_utils import ModelScanner, ScannerConfig
 
 
 def _is_flow_operator(cls):
-    return (
-        issubclass(cls, BaseOperator)
-        and hasattr(cls, "metadata")
-        and isinstance(cls.metadata, ViewMetadata)
-    )
+    try:
+        metadata = getattr(cls, "metadata", None)
+        if metadata is None:
+            return False
+        # For class-level properties or descriptors, get the actual metadata object
+        if callable(metadata):
+            metadata = metadata()
+        return issubclass(cls, BaseOperator) and isinstance(metadata, ViewMetadata)
+    except Exception:
+        return False
 
 
 def _is_flow_resource(cls):


### PR DESCRIPTION
## What
The `_is_flow_operator` function in `dbgpt/util/cli/_module.py` incorrectly identified flow operators when `cls.metadata` was a property or descriptor rather than a direct `ViewMetadata` instance. This caused AWEL flow scanning to fail, leading to database schema errors (`no such table: gpts_app_collection`) during server startup.

## Fix
Updated `_is_flow_operator` to safely retrieve metadata via `getattr`, handle callable properties, and wrap the check in a try-except for robustness. This ensures correct classification of flow operators and resources.

Closes #2280