### PR TITLE
ci: attach provenance and SBOM attestations to the published image

### DIFF
--- a/.github/workflows/docker-image-publish-openai.yml
+++ b/.github/workflows/docker-image-publish-openai.yml
@@ -46,4 +46,6 @@ jobs:
             PIP_INDEX_URL=https://pypi.org/simple
           platforms: linux/arm64,linux/amd64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: eosphorosai/dbgpt-openai:${{ github.ref_name }},eosphorosai/dbgpt-openai:latest


### PR DESCRIPTION
Hi, and thanks for DB-GPT.

`.github/workflows/docker-image-publish-openai.yml` publishes the image, but the pushed manifest carries no provenance or SBOM attestation. Someone pulling it cannot check that it was built by this workflow, from this repository, at that tag.

DB-GPT is pointed at a database and given credentials for it, so the image sits directly in front of data people generally do not want leaving their environment.

The change is two lines on the build step:

```yaml
          push: ...
          provenance: mode=max
          sbom: true
```

BuildKit attaches both to the image manifest, so they travel with the image. **No permissions change is needed** — nothing has to gain `id-token`, and your tag and cache configuration are untouched.

```
docker buildx imagetools inspect <image>:<tag> --format '{{ json .Provenance }}'
```

Two caveats worth stating: `mode=max` records the full build including build arguments, so `provenance: true` is the smaller option if any have ever been sensitive; and attestations add an extra manifest to the index, which the registry supports.

No SLSA level claimed — the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
