### PR TITLE
fix(core): prevent command injection in MacOSTTS (#3129)

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/speech/macos_tts.py
+++ b/packages/dbgpt-core/src/dbgpt/util/speech/macos_tts.py
@@ -1,6 +1,6 @@
 """MacOS TTS Voice."""
 
-import os
+import subprocess
 
 from dbgpt.util.speech.base import VoiceBase
 
@@ -14,9 +14,12 @@ class MacOSTTS(VoiceBase):
     def _speech(self, text: str, voice_index: int = 0) -> bool:
         """Play the given text."""
         if voice_index == 0:
-            os.system(f'say "{text}"')
+            args = ["say"]
         elif voice_index == 1:
-            os.system(f'say -v "Ava (Premium)" "{text}"')
+            args = ["say", "-v", "Ava (Premium)"]
         else:
-            os.system(f'say -v Samantha "{text}"')
+            args = ["say", "-v", "Samantha"]
+        # Pass the text as a separate argument (no shell) so it cannot be
+        # interpreted as a shell command, regardless of its content.
+        subprocess.run([*args, text], check=False)
         return True


### PR DESCRIPTION
# Description

Fixes #3129.

`MacOSTTS._speech` interpolated the spoken text directly into an `os.system` shell command:

```python
os.system(f'say "{text}"')
```

Since `text` is model/user-influenced (it is whatever gets spoken in an agent flow), a value such as `"; rm -rf ~; echo "` closes the quoted argument and executes arbitrary shell commands. This is a command injection regardless of the current call sites — the pattern is unsafe on its own.

This PR replaces `os.system` with `subprocess.run` using an argument vector, so the text is always passed as a single literal argument and is never interpreted by a shell:

```python
if voice_index == 0:
    args = ["say"]
elif voice_index == 1:
    args = ["say", "-v", "Ava (Premium)"]
else:
    args = ["say", "-v", "Samantha"]
subprocess.run([*args, text], check=False)
```

Voice-selection behaviour is unchanged (index `0` → default, `1` → Ava (Premium), otherwise → Samantha), and `check=False` preserves the previous non-raising behaviour on non-zero exit codes.

# How Has This Been Tested?

Verified the three `voice_index` branches produce the expected argument vectors and that an injection payload is preserved as a single literal argument (no shell interpretation):

- `voice_index=0` → `["say", text]`
- `voice_index=1` → `["say", "-v", "Ava (Premium)", text]`
- `voice_index=2`/other → `["say", "-v", "Samantha", text]`
- payload `"; rm -rf ~; echo "` is passed unchanged as the final argument

`say` is a macOS-only command, so runtime playback was not exercised, but the invocation is a straightforward shell-free replacement of the original commands.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules