### PR TITLE
fix(skill): only load files named SKILL.md as Markdown skills

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/agent/skill/loader.py
+++ b/packages/dbgpt-core/src/dbgpt/agent/skill/loader.py
@@ -63,7 +63,7 @@ class SkillLoader:
 
         if path.suffix == ".json":
             return self._load_from_json(path)
-        elif path.name == "SKILL.md" or path.suffix == ".md":
+        elif path.name == "SKILL.md":
             return self._load_from_markdown(path)
         elif path.suffix in [".yaml", ".yml"]:
             return self._load_from_yaml(path)
@@ -113,12 +113,16 @@ class SkillLoader:
         # Look for JSON/YAML files and Claude-style SKILL.md files
         pattern = "**/*" if recursive else "*"
         for file_path in path.glob(pattern):
-            if file_path.is_file() and file_path.suffix in [
-                ".json",
-                ".yaml",
-                ".yml",
-                ".md",
-            ]:
+            if (
+                file_path.is_file()
+                and file_path.suffix
+                in [
+                    ".json",
+                    ".yaml",
+                    ".yml",
+                ]
+                or file_path.name == "SKILL.md"
+            ):
                 # load_skill_from_file will dispatch appropriately
                 skill = self.load_skill_from_file(str(file_path))
                 if skill:


### PR DESCRIPTION
# Description

This PR fixes a bug where the skill loader was attempting to load all `.md` files as skill files, causing 7 ERROR logs on every startup.

## Summary of Changes
- Modified `packages/dbgpt-core/src/dbgpt/agent/skill/loader.py` to only load files named `SKILL.md` as Markdown skills
- Removed the overly broad `or path.suffix == ".md"` condition that was matching all Markdown files

## Problem
When starting the DB-GPT web interface, the skill loader was trying to load documentation files as skills:
- `README.md`, `INTEGRATION_GUIDE.md`
- `references/*.md` (reference documentation)
- `templates/*.md` (template files)

This resulted in 7 ERROR logs on every startup:
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/INTEGRATION_GUIDE.md: SKILL file must start with '---': /path/to/DB-GPT/skills/INTEGRATION_GUIDE.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/README.md: SKILL file must start with '---': /path/to/DB-GPT/skills/README.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/csv-data-analysis/references/reference.md: SKILL file must start with '---': /path/to/DB-GPT/skills/csv-data-analysis/references/reference.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/references/analysis_framework.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/references/analysis_framework.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/references/financial_metrics.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/references/financial_metrics.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/templates/report_template.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/templates/report_template.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/skill-creator/references/workflows.md: SKILL file must start with '---': /path/to/DB-GPT/skills/skill-creator/references/workflows.md



## Root Cause & Motivation
After investigating the codebase, I found that DB-GPT follows the Claude-style SKILL format:

1. **The `claude_skill` module explicitly defines the convention**: In `packages/dbgpt-core/src/dbgpt/agent/claude_skill/__init__.py` (lines 84-97), the `FileBasedSkill` class documentation states: *"Skill loaded from a SKILL.md file"*

2. **The skill registry uses the correct pattern**: Line 438 in `claude_skill/__init__.py` shows: `pattern = "**/SKILL.md"`

3. **The official skill-creator tool generates `SKILL.md` files**: The built-in skill creation workflow follows this naming convention

4. **The loader had inconsistent logic**: In `loader.py`, the condition `elif path.name == "SKILL.md" or path.suffix == ".md":` was too broad and contradicted the intended design

Since DB-GPT is built on Claude-style skills, uses the official skill creator to generate `SKILL.md` files, and parses them with the `claude_skill` package, I decided to enforce the `SKILL.md` naming convention consistently.

## Changes Made

**File: `packages/dbgpt-core/src/dbgpt/agent/skill/loader.py`**

1. **Line 66** - Restricted Markdown skill loading to `SKILL.md` only:
   ```python
   # Before
   elif path.name == "SKILL.md" or path.suffix == ".md":
       return self._load_from_markdown(path)
   
   # After
   elif path.name == "SKILL.md":
       return self._load_from_markdown(path)
Lines 116-120 - Updated file filtering in directory scanning:

# Before
if file_path.is_file() and file_path.suffix in [
    ".json", ".yaml", ".yml", ".md"
]:

# After
if file_path.is_file() and (
    file_path.suffix in [".json", ".yaml", ".yml"]
    or file_path.name == "SKILL.md"
):
## Benefits
- Eliminates 7 spurious ERROR logs on every startup
- Improves performance by not attempting to parse normal markdown files
- Aligns with Claude SKILL convention and the claude_skill module design
- Maintains JSON/YAML support - no changes to other skill formats
- No functional impact - all 5 existing skills continue to load correctly
- Better error isolation - real skill loading errors are now easier to spot in logs

## How Has This Been Tested?
Test Environment
OS: Windows 11 Home China 10.0.26200
Python: 3.11.15 (via Anaconda base environment)
Package Manager: uv
Repository: Local fork synced with upstream main branch

## Test Procedure
1. Before the fix

cd C:/Users/xupinghu/Desktop/Agent_project/DB-GPT_debug/DB-GPT
git checkout main
uv run dbgpt start
【Observed】: 7 ERROR logs appeared in the console on every startup

2. After the fix

git checkout fix/skill-loader-md-files
uv run dbgpt start
【Observed】: Clean startup with no ERROR logs related to skill loading

3. Frontend verification
Opened browser and navigated to http://127.0.0.1:5670/
Clicked on the Skills page in the web interface
Verified all 5 built-in skills are displayed correctly:
agent-browser
csv-data-analysis
financial-report-analyzer
skill-creator
walmart-sales-analyzer
4. API verification
Checked API endpoint: GET /api/v1/skills/list
Confirmed it returns HTTP 200 OK with 5 skills in the response
5. Code quality checks

uv run ruff format packages/dbgpt-core/src/dbgpt/agent/skill/loader.py
uv run ruff check packages/dbgpt-core/src/dbgpt/agent/skill/loader.py
Result: No linting errors

## Reproduction Instructions
To reproduce the fix verification:

Clone the repository and checkout this branch
Run uv sync to install dependencies
Start the server: uv run dbgpt start
Check console logs - should see no ERROR logs about failed skill loading
Open http://127.0.0.1:5670/ and navigate to Skills page
Verify all 5 skills are listed

## Snapshots:
### Before Fix - Startup Logs (7 ERROR logs)
"""
INFO:     127.0.0.1:57346 - "POST /knowledge/space/list HTTP/1.1" 405 Method Not Allowed
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/INTEGRATION_GUIDE.md: SKILL file must start with '---': /path/to/DB-GPT/skills/INTEGRATION_GUIDE.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/README.md: SKILL file must start with '---': /path/to/DB-GPT/skills/README.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/csv-data-analysis/references/reference.md: SKILL file must start with '---': /path/to/DB-GPT/skills/csv-data-analysis/references/reference.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/references/analysis_framework.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/references/analysis_framework.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/references/financial_metrics.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/references/financial_metrics.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/financial-report-analyzer/templates/report_template.md: SKILL file must start with '---': /path/to/DB-GPT/skills/financial-report-analyzer/templates/report_template.md
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.agent.skill.loader[10528] ERROR Failed to load SKILL.md skill from /path/to/DB-GPT/skills/skill-creator/references/workflows.md: SKILL file must start with '---': /path/to/DB-GPT/skills/skill-creator/references/workflows.md
INFO:     127.0.0.1:63169 - "GET /api/v2/serve/connectors/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:53025 - "GET /api/v1/skills/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:58299 - "GET /api/v2/serve/datasources HTTP/1.1" 200 OK
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt_app.openapi.api_v1.api_v1[10528] INFO /controller/model/types
2026-08-02 20:19:40 LAPTOP-4CQVV3HA dbgpt.model.cluster.controller.controller[10528] INFO Get all instances with None, healthy_only: True
INFO:     127.0.0.1:61151 - "GET /api/v1/model/types HTTP/1.1" 200 OK
INFO:     127.0.0.1:56000 - "GET /api/v1/chat/dialogue/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:57346 - "GET /api/v2/serve/connectors/ HTTP/1.1" 200 OK
"""

### After Fix - Startup Logs (Clean, no ERROR logs)
"""
INFO:     127.0.0.1:64332 - "POST /knowledge/space/list HTTP/1.1" 405 Method Not Allowed
INFO:     127.0.0.1:60186 - "GET /api/v2/serve/connectors/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:63485 - "GET /api/v1/skills/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:49803 - "GET /api/v2/serve/datasources HTTP/1.1" 200 OK
2026-08-02 19:27:30 LAPTOP-4CQVV3HA dbgpt_app.openapi.api_v1.api_v1[42368] INFO /controller/model/types
2026-08-02 19:27:30 LAPTOP-4CQVV3HA dbgpt.model.cluster.controller.controller[42368] INFO Get all instances with None, healthy_only: True
INFO:     127.0.0.1:51204 - "GET /api/v1/model/types HTTP/1.1" 200 OK
INFO:     127.0.0.1:52834 - "GET /api/v1/chat/dialogue/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:64332 - "GET /api/v2/serve/connectors/ HTTP/1.1" 200 OK
"""


## Checklist:
- [√] My code follows the style guidelines of this project
- [√] I have already rebased the commits and make the commit message conform to the project standard.
- [√] I have performed a self-review of my own code
- [  ] I have commented my code, particularly in hard-to-understand areas (N/A - changes are self-explanatory)
- [  ] I have made corresponding changes to the documentation (N/A - no user-facing API changes)
- [√] Any dependent changes have been merged and published in downstream modules

## Note for Reviewers
This is my first contribution to DB-GPT. I've tested thoroughly in my local environment and verified that:

- All existing skills continue to work correctly
- The change aligns with the Claude SKILL format used throughout the codebase
- No functionality is broken


I'm open to any feedback or suggestions. If there are concerns about this approach or if you'd prefer a different solution, I'm happy to make adjustments.
This is my first contribution to DB-GPT. I used AI tools to help me understand the codebase architecture and the skill loading workflow. However, I identified this issue myself during testing, analyzed the code to find the root cause, and made the fix independently. 
Thank you for maintaining this excellent project! 🚀