### PR TITLE
docs: add SECURITY.md with private vulnerability reporting process (#3126)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+The DB-GPT community takes the security of the project seriously. We
+appreciate your efforts to responsibly disclose your findings, and will make
+every effort to acknowledge your contributions.
+
+## Supported Versions
+
+Security fixes are applied to the latest release and the `main` branch. We
+recommend always running the most recent version.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| latest release | :white_check_mark: |
+| `main`         | :white_check_mark: |
+| older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.** Public disclosure before a fix is available
+puts all users at risk.
+
+Instead, please use one of the private channels below:
+
+1. **GitHub Private Vulnerability Reporting (preferred).**
+   Go to the [Security tab](https://github.com/eosphoros-ai/DB-GPT/security)
+   of this repository and click **"Report a vulnerability"**. This opens a
+   private advisory visible only to you and the maintainers.
+
+   <!--
+   Maintainers: this requires "Private vulnerability reporting" to be enabled
+   under Settings -> Security -> Advanced Security. See:
+   https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository
+   -->
+
+2. **Email.** If you are unable to use GitHub's private reporting, contact the
+   maintainers privately.
+
+   <!-- Maintainers: add a security contact email here, e.g. security@dbgpt.example -->
+   <!-- TODO: replace with the project's official security contact address. -->
+
+To help us triage and resolve the issue quickly, please include as much of the
+following as you can:
+
+- A description of the vulnerability and its potential impact.
+- The affected version(s), commit, or component (e.g. a specific module,
+  endpoint, or file).
+- Step-by-step instructions to reproduce the issue.
+- Proof-of-concept code, logs, or screenshots, if available.
+- Any suggested remediation or mitigation you may have.
+
+## Response Process
+
+When you report a vulnerability, you can expect the following:
+
+- **Acknowledgement.** We aim to acknowledge your report within a few business
+  days.
+- **Assessment.** We will investigate, determine the severity and affected
+  versions, and keep you informed of our progress.
+- **Fix and disclosure.** We will work on a fix and coordinate a disclosure
+  timeline with you. We ask that you keep the report confidential until a fix
+  has been released.
+- **Credit.** With your permission, we are happy to credit you for the
+  discovery once the issue is resolved.
+
+Thank you for helping keep DB-GPT and its users safe.


### PR DESCRIPTION
# Description

Fixes #3126.

The repository currently has no `SECURITY.md`, no documented security contact, and no advertised private disclosure channel. As raised in #3126, this leaves security researchers with no responsible way to report vulnerabilities privately — the only options are public issues/discussions, which expose the vulnerability before a fix exists.

This PR adds a `SECURITY.md` at the repository root (GitHub automatically surfaces it under the **Security** tab and the "Report a vulnerability" flow). It documents:

- **Supported versions** — latest release and `main`.
- **How to report** — GitHub Private Vulnerability Reporting as the preferred private channel, with a placeholder for a security email as a fallback.
- **What to include** in a report (impact, affected version/component, reproduction steps, PoC, suggested fix).
- **Response process** — acknowledgement, assessment, coordinated fix/disclosure, and optional credit.

## Notes for maintainers

Two things need your input, marked with HTML comments in the file so they don't render:

1. To make the preferred channel work, please enable **Private vulnerability reporting** under *Settings → Security → Advanced Security*.
2. If you'd like to offer an email fallback, drop the official security contact address into the marked spot (currently a placeholder `TODO`).

Happy to adjust the wording, supported-version table, or response-time expectations to match the team's actual process.

# How Has This Been Tested?

Documentation-only change. Verified the file renders as valid Markdown and that no `SECURITY.md` previously existed in the repo root or `.github/`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules