### PR TITLE
fix(security): validate user_id to prevent path traversal in python file upload (#3104)

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, UploadFile
@@ -11,6 +12,45 @@ from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 router = APIRouter()
 CFG = Config()
 logger = logging.getLogger(__name__)
+
+# Only allow alphanumeric characters, underscores and hyphens in user_id.
+# This prevents path traversal via "../" or path separators in the header.
+_SAFE_USER_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def _resolve_user_id(user_id: str) -> str:
+    """Validate the user_id so it cannot be used for path traversal.
+
+    The user_id is sourced from an HTTP header and used as a path component
+    of the upload directory, so it must only contain safe characters.
+    """
+    if not user_id or not isinstance(user_id, str):
+        return "default"
+    user_id = user_id.strip()
+    if not user_id:
+        return "default"
+    if not _SAFE_USER_ID_RE.match(user_id):
+        raise ValueError(
+            "Invalid user_id: only alphanumeric characters, underscores and "
+            "hyphens are allowed"
+        )
+    return user_id
+
+
+def _resolve_upload_dir(base_dir: str, user_id: str) -> str:
+    """Build the per-user upload directory and verify it stays within
+    ``<base_dir>/python_uploads`` to prevent path traversal via user_id.
+    """
+    base_path = Path(base_dir).resolve()
+    uploads_root = (base_path / "python_uploads").resolve()
+    upload_dir = (uploads_root / user_id).resolve()
+    try:
+        upload_dir.relative_to(uploads_root)
+    except ValueError as exc:
+        raise ValueError(
+            "user_id resolves to a path outside the upload directory"
+        ) from exc
+    return str(upload_dir)
 
 
 def _resolve_upload_path(upload_dir: str, filename: str) -> str:
@@ -36,7 +76,7 @@ async def python_file_upload(
         if not file or not file.filename:
             return Result.failed(msg="No file provided or filename is empty")
 
-        user_id = user_token.user_id or "default"
+        user_id = _resolve_user_id(user_token.user_id)
         logger.info(
             f"Uploading file: {file.filename}, content_type: {file.content_type}, "
             f"user: {user_id}"
@@ -51,7 +91,7 @@ async def python_file_upload(
         ):
             base_dir = CFG.SYSTEM_APP.work_dir
 
-        upload_dir = os.path.join(base_dir, "python_uploads", user_id)
+        upload_dir = _resolve_upload_dir(base_dir, user_id)
         os.makedirs(upload_dir, exist_ok=True)
 
         file_path = _resolve_upload_path(upload_dir, file.filename)

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
@@ -109,6 +109,15 @@ async def python_file_upload(
 
         file_path = _resolve_upload_path(upload_dir, file.filename)
 
+        # Re-verify the resolved file path is still inside upload_dir after
+        # directory creation.  This mitigates TOCTOU races where a symlink is
+        # planted between the containment check and the actual write.
+        if not Path(file_path).resolve().is_relative_to(Path(upload_dir).resolve()):
+            raise HTTPException(
+                status_code=400,
+                detail="Resolved file path escapes the upload directory",
+            )
+
         # Read file content and write to disk
         content = await file.read()
         if not content:

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
@@ -3,7 +3,7 @@ import os
 import re
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from dbgpt._private.config import Config
 from dbgpt_app.openapi.api_view_model import Result
@@ -26,10 +26,9 @@ def _resolve_user_id(user_id: str) -> str:
     """
     if not user_id or not isinstance(user_id, str):
         return "default"
-    user_id = user_id.strip()
-    if not user_id:
+    if not user_id.strip():
         return "default"
-    if not _SAFE_USER_ID_RE.match(user_id):
+    if not _SAFE_USER_ID_RE.fullmatch(user_id):
         raise ValueError(
             "Invalid user_id: only alphanumeric characters, underscores and "
             "hyphens are allowed"
@@ -43,6 +42,12 @@ def _resolve_upload_dir(base_dir: str, user_id: str) -> str:
     """
     base_path = Path(base_dir).resolve()
     uploads_root = (base_path / "python_uploads").resolve()
+    try:
+        uploads_root.relative_to(base_path)
+    except ValueError as exc:
+        raise ValueError(
+            "python_uploads resolves to a path outside the base directory"
+        ) from exc
     upload_dir = (uploads_root / user_id).resolve()
     try:
         upload_dir.relative_to(uploads_root)
@@ -76,7 +81,11 @@ async def python_file_upload(
         if not file or not file.filename:
             return Result.failed(msg="No file provided or filename is empty")
 
-        user_id = _resolve_user_id(user_token.user_id)
+        try:
+            user_id = _resolve_user_id(user_token.user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
         logger.info(
             f"Uploading file: {file.filename}, content_type: {file.content_type}, "
             f"user: {user_id}"
@@ -91,7 +100,11 @@ async def python_file_upload(
         ):
             base_dir = CFG.SYSTEM_APP.work_dir
 
-        upload_dir = _resolve_upload_dir(base_dir, user_id)
+        try:
+            upload_dir = _resolve_upload_dir(base_dir, user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
         os.makedirs(upload_dir, exist_ok=True)
 
         file_path = _resolve_upload_path(upload_dir, file.filename)
@@ -108,6 +121,8 @@ async def python_file_upload(
         logger.info(f"File uploaded successfully to {abs_path} ({len(content)} bytes)")
 
         return Result.succ(abs_path)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"File upload failed: {e}")
         return Result.failed(msg=f"Upload error: {str(e)}")

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/python_upload_api.py
@@ -84,7 +84,7 @@ async def python_file_upload(
         try:
             user_id = _resolve_user_id(user_token.user_id)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         logger.info(
             f"Uploading file: {file.filename}, content_type: {file.content_type}, "
@@ -103,7 +103,7 @@ async def python_file_upload(
         try:
             upload_dir = _resolve_upload_dir(base_dir, user_id)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         os.makedirs(upload_dir, exist_ok=True)
 

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
@@ -101,6 +101,9 @@ async def test_python_file_upload_rejects_symlink_escape(tmp_path, monkeypatch):
 async def test_python_file_upload_rejects_traversal_user_id(tmp_path, monkeypatch):
     from dbgpt_app.openapi.api_v1 import python_upload_api
 
+    outside_dir = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside_dir.mkdir()
+
     monkeypatch.setattr(
         python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
     )
@@ -108,11 +111,11 @@ async def test_python_file_upload_rejects_traversal_user_id(tmp_path, monkeypatc
     with pytest.raises(HTTPException) as exc_info:
         await python_upload_api.python_file_upload(
             FakeUploadFile("inside.py", b"print('inside')"),
-            UserRequest(user_id="../../../../tmp/evil"),
+            UserRequest(user_id=f"../../{outside_dir.name}"),
         )
 
     assert exc_info.value.status_code == 400
-    assert not (tmp_path / "tmp" / "evil").exists()
+    assert not (outside_dir / "inside.py").exists()
 
 
 @pytest.mark.asyncio
@@ -130,11 +133,14 @@ async def test_python_file_upload_rejects_whitespace_user_id(tmp_path, monkeypat
         )
 
     assert exc_info.value.status_code == 400
-    assert not (tmp_path / "python_uploads" / "alice").exists()
+    assert not (tmp_path / "python_uploads" / " alice ").exists()
 
 
+@pytest.mark.parametrize("user_id", [None, "", "   "])
 @pytest.mark.asyncio
-async def test_python_file_upload_defaults_empty_user_id(tmp_path, monkeypatch):
+async def test_python_file_upload_defaults_empty_user_id(
+    tmp_path, monkeypatch, user_id
+):
     from dbgpt_app.openapi.api_v1 import python_upload_api
 
     monkeypatch.setattr(
@@ -143,7 +149,7 @@ async def test_python_file_upload_defaults_empty_user_id(tmp_path, monkeypatch):
 
     result = await python_upload_api.python_file_upload(
         FakeUploadFile("inside.py", b"print('inside')"),
-        UserRequest(user_id=None),
+        UserRequest(user_id=user_id),
     )
 
     expected_path = tmp_path / "python_uploads" / "default" / "inside.py"

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_python_upload_api.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from dbgpt_serve.utils.auth import UserRequest
 
@@ -94,3 +95,86 @@ async def test_python_file_upload_rejects_symlink_escape(tmp_path, monkeypatch):
 
     assert result.success is False
     assert not (outside_dir / "escaped.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_traversal_user_id(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await python_upload_api.python_file_upload(
+            FakeUploadFile("inside.py", b"print('inside')"),
+            UserRequest(user_id="../../../../tmp/evil"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert not (tmp_path / "tmp" / "evil").exists()
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_whitespace_user_id(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await python_upload_api.python_file_upload(
+            FakeUploadFile("inside.py", b"print('inside')"),
+            UserRequest(user_id=" alice "),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert not (tmp_path / "python_uploads" / "alice").exists()
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_defaults_empty_user_id(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(tmp_path))
+    )
+
+    result = await python_upload_api.python_file_upload(
+        FakeUploadFile("inside.py", b"print('inside')"),
+        UserRequest(user_id=None),
+    )
+
+    expected_path = tmp_path / "python_uploads" / "default" / "inside.py"
+    assert result.success is True
+    assert result.data == str(expected_path)
+    assert expected_path.read_bytes() == b"print('inside')"
+
+
+@pytest.mark.asyncio
+async def test_python_file_upload_rejects_symlinked_upload_root(tmp_path, monkeypatch):
+    from dbgpt_app.openapi.api_v1 import python_upload_api
+
+    base_dir = tmp_path / "work"
+    base_dir.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    uploads_root = base_dir / "python_uploads"
+    try:
+        uploads_root.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are not available in this environment: {exc}")
+
+    monkeypatch.setattr(
+        python_upload_api.CFG, "SYSTEM_APP", SimpleNamespace(work_dir=str(base_dir))
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await python_upload_api.python_file_upload(
+            FakeUploadFile("inside.py", b"print('inside')"),
+            UserRequest(user_id="alice"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert not (outside_dir / "alice" / "inside.py").exists()


### PR DESCRIPTION
## Related Issue

Closes #3104

## Problem

The `POST /api/v1/python/file/upload` endpoint built the destination directory from an unvalidated `user_id` HTTP header:

```python
user_id = user_token.user_id or "default"
upload_dir = os.path.join(base_dir, "python_uploads", user_id)
```

A `user_id` header containing `../` segments escaped the intended upload directory, allowing an unauthenticated client to write attacker-controlled content to an arbitrary location on the server (escalating to RCE via Python startup hooks, cron dirs, agent/skill scripts, etc.).

PR #3064 previously constrained the **filename**, but the `_resolve_upload_path` check it introduced only validates the filename relative to `upload_dir` — which has already been poisoned by `user_id`. The `user_id` path component itself was never validated.

Reproduction from the issue:

```
curl -X POST http://TARGET:5670/api/v1/python/file/upload \
 -H 'user_id: ../../../../../../../../tmp/DBGPT_PWN' \
 -F 'file=@payload.py;filename=x.py'
```

## Fix

Add two layers of validation:

1. **`_resolve_user_id`** — a whitelist validator that only allows alphanumeric characters, underscores and hyphens (`^[A-Za-z0-9_\-]+$`). Empty/None/whitespace values fall back to `"default"`. Any `../`, path separators or other characters raise `ValueError`.
2. **`_resolve_upload_dir`** — defense-in-depth: resolves `<base_dir>/python_uploads/<user_id>` and verifies via `relative_to()` that the result stays within the upload root.

The handler now calls `_resolve_user_id` to sanitize the header value and `_resolve_upload_dir` to build the directory, replacing the raw `os.path.join(base_dir, "python_uploads", user_id)`.

## Verification

Verified the validators against the issue PoC and edge cases:

- traversal payloads (`../../../../../../tmp/DBGPT_PWN`, `..`, `a/b`, `a\b`, `a..b`, `a b`, `a:b`, `a;b`, `a\tb`) are rejected
- normal ids (`admin`, `user_1`, `user-2`, `ABC123`, `default`) are accepted
- `None` / `""` / `"   "` fall back to `"default"`
- normal user_id resolves inside `<base>/python_uploads/<user_id>`
- the exact PoC payload is blocked (`ValueError`) and cannot escape `base_dir`

## Checklist

- [x] Code follows the project style
- [x] Self-test passed
- [x] Linked the issue (#3104)
