### PR TITLE
build(dbgpt-ext): relax spacy pin to >=3.8 for Python 3.13 support (#3006)

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py
+++ b/packages/dbgpt-core/src/dbgpt/rag/text_splitter/tests/test_splitters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbgpt.core import Chunk
 from dbgpt.rag.text_splitter.text_splitter import (
     CharacterTextSplitter,
@@ -63,3 +65,26 @@ def test_character_text_splitter_empty_doc() -> None:
     output = splitter.split_text(text)
     expected_output = ["db", "gpt"]
     assert output == expected_output
+
+
+def test_spacy_text_splitter() -> None:
+    """Smoke test SpacyTextSplitter against the installed spacy version.
+
+    Guards the spacy>=3.8 upgrade (Python 3.13 support): verifies the public
+    spacy API used by SpacyTextSplitter (spacy.load / nlp(text).sents) still
+    works. Skips when spacy or the en pipeline is unavailable so the suite
+    stays green without the optional ``rag`` extra installed.
+    """
+    pytest.importorskip("spacy", reason="spacy (rag extra) not installed")
+
+    from dbgpt.rag.text_splitter.text_splitter import SpacyTextSplitter
+
+    try:
+        splitter = SpacyTextSplitter(pipeline="en_core_web_sm", chunk_size=1000)
+    except Exception as e:  # pragma: no cover - depends on model download
+        pytest.skip(f"spacy pipeline unavailable: {e}")
+
+    text = "This is the first sentence. Here is the second one. And a third."
+    output = splitter.split_text(text)
+    assert output, "SpacyTextSplitter returned no chunks"
+    assert "first sentence" in " ".join(output)

--- a/packages/dbgpt-ext/pyproject.toml
+++ b/packages/dbgpt-ext/pyproject.toml
@@ -26,7 +26,9 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 rag = [
-    "spacy==3.7",
+    # spacy 3.8+ is compiled with Cython 3 and ships wheels for Python 3.13.
+    # Pin below 4.0 to avoid picking up a future major release with API changes.
+    "spacy>=3.8,<4.0",
     "markdown",
     "bs4",
     "python-pptx",


### PR DESCRIPTION
## Description

\`packages/dbgpt-ext/pyproject.toml\` pins \`spacy==3.7\` in the \`rag\` extra. spaCy 3.7 predates Python 3.13 and ships no compatible prebuilt wheels, so \`pip install \"dbgpt-ext[rag]\"\` fails on Python 3.13 (falls back to a source build that typically fails without a C toolchain).

spaCy 3.8+ is compiled with Cython 3 and provides wheels for Python 3.13 (installed 3.8.15 in verification), so relaxing the pin fixes the install without any code change.

Fixes #3006

## Changes

- **\`packages/dbgpt-ext/pyproject.toml\`**: relax the \`rag\` extra pin from \`spacy==3.7\` to \`spacy>=3.8,<4.0\`. The \`<4.0\` upper bound guards against a future major release with API changes.
- **\`.../text_splitter/tests/test_splitters.py\`**: add a \`SpacyTextSplitter\` smoke test guarding the public spaCy API the splitter relies on (\`spacy.load\` / \`nlp(text).sents\`). It uses \`pytest.importorskip\` and skips gracefully when the optional \`rag\` extra (spaCy) or the pipeline model is unavailable, so the suite stays green without the extra installed.

The only in-repo spaCy usage is \`SpacyTextSplitter\`, whose public API is stable across 3.7 → 3.8 (the bump is compilation-level), so no functional code change is required.

## How Has This Been Tested?

Verified on **Python 3.13.14**, Windows 11:

- [x] \`pip install \"spacy>=3.8,<4.0\"\` installs spacy **3.8.15** entirely from prebuilt wheels — no source compilation triggered (blis, thinc, cymem etc. all resolved as cp313 wheels).
- [x] \`spacy.load("en_core_web_sm")\` and \`nlp(text).sents\` work correctly.
- [x] \`SpacyTextSplitter(pipeline="en_core_web_sm").split_text(text)\` returns correct sentence chunks.
- [x] \`pytest test_spacy_text_splitter\` — **1 passed** in 1.30s on Python 3.13.14 + spacy 3.8.15.

Note: Python 3.14 wheel support for spaCy's dependencies (blis etc.) is still in progress upstream ([explosion/spaCy#13885](https://github.com/explosion/spaCy/issues/13885)); this PR targets Python 3.13 as requested in the issue.

## Snapshots

N/A (dependency + test change).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective