### PR TITLE
feat(model): add OrcaRouter proxy provider

### DIFF
--- a/configs/dbgpt-proxy-orcarouter.toml
+++ b/configs/dbgpt-proxy-orcarouter.toml
@@ -1,0 +1,23 @@
+[system]
+language = "${env:DBGPT_LANG:-en}"
+api_keys = []
+encrypt_key = "your_secret_key"
+
+[service.web]
+host = "0.0.0.0"
+port = 5670
+
+[service.web.database]
+type = "sqlite"
+path = "pilot/meta_data/dbgpt.db"
+
+[rag.storage]
+[rag.storage.vector]
+type = "chroma"
+persist_path = "pilot/data"
+
+[models]
+[[models.llms]]
+name = "${env:LLM_MODEL_NAME:-openai/gpt-4o}"
+provider = "proxy/orcarouter"
+api_key = "${env:ORCAROUTER_API_KEY}"

--- a/docs/docs/installation/integrations/orcarouter_llm_install.md
+++ b/docs/docs/installation/integrations/orcarouter_llm_install.md
@@ -1,0 +1,24 @@
+# OrcaRouter
+
+### [OrcaRouter](https://www.orcarouter.ai) provides 150+ AI models including OpenAI, Anthropic, Gemini, DeepSeek and Qwen behind a single OpenAI-compatible endpoint and API key.
+
+### This section describes how to use the OrcaRouter provider with DB-GPT.
+
+1. Sign up at [OrcaRouter](https://www.orcarouter.ai) and generate an API key.
+2. Set the environment variable `ORCAROUTER_API_KEY` with your key.
+3. Use the `configs/dbgpt-proxy-orcarouter.toml` configuration when starting DB-GPT.
+
+### You can look up models at [https://www.orcarouter.ai/models](https://www.orcarouter.ai/models)
+
+### Or you can use docker/base/Dockerfile to run DB-GPT with OrcaRouter:
+
+```dockerfile
+# Expose the port for the web server, if you want to run it directly from the Dockerfile
+EXPOSE 5670
+
+# Set the environment variable for the OrcaRouter API key
+ENV ORCAROUTER_API_KEY="***"
+
+# Just uncomment the following line in the `Dockerfile` to use OrcaRouter:
+CMD ["dbgpt", "start", "webserver", "--config", "configs/dbgpt-proxy-orcarouter.toml"]
+```

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from dbgpt.model.proxy.llms.moonshot import MoonshotLLMClient
     from dbgpt.model.proxy.llms.nvidia import NvidiaLLMClient
     from dbgpt.model.proxy.llms.ollama import OllamaLLMClient
+    from dbgpt.model.proxy.llms.orcarouter import OrcaRouterLLMClient
     from dbgpt.model.proxy.llms.siliconflow import SiliconFlowLLMClient
     from dbgpt.model.proxy.llms.spark import SparkLLMClient
     from dbgpt.model.proxy.llms.tongyi import TongyiLLMClient
@@ -40,6 +41,7 @@ def __lazy_import(name):
         "MoonshotLLMClient": "dbgpt.model.proxy.llms.moonshot",
         "NvidiaLLMClient": "dbgpt.model.proxy.llms.nvidia",
         "OllamaLLMClient": "dbgpt.model.proxy.llms.ollama",
+        "OrcaRouterLLMClient": "dbgpt.model.proxy.llms.orcarouter",
         "DeepseekLLMClient": "dbgpt.model.proxy.llms.deepseek",
         "GiteeLLMClient": "dbgpt.model.proxy.llms.gitee",
         "InfiniAILLMClient": "dbgpt.model.proxy.llms.infiniai",
@@ -73,6 +75,7 @@ __all__ = [
     "MoonshotLLMClient",
     "NvidiaLLMClient",
     "OllamaLLMClient",
+    "OrcaRouterLLMClient",
     "DeepseekLLMClient",
     "GiteeLLMClient",
     "InfiniAILLMClient",

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/orcarouter.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/orcarouter.py
@@ -1,0 +1,238 @@
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+
+from dbgpt.core import ModelMetadata
+from dbgpt.core.awel.flow import (
+    TAGS_ORDER_HIGH,
+    ResourceCategory,
+    auto_register_resource,
+)
+from dbgpt.model.proxy.llms.proxy_model import ProxyModel, parse_model_request
+from dbgpt.util.i18n_utils import _
+
+from ..base import (
+    AsyncGenerateStreamFunction,
+    GenerateStreamFunction,
+    register_proxy_model_adapter,
+)
+from .chatgpt import OpenAICompatibleDeployModelParameters, OpenAILLMClient
+
+ORCAROUTER_HEADERS = {
+    "HTTP-Referer": "https://github.com/eosphoros-ai/DB-GPT",
+    "X-Title": "DB GPT",
+}
+
+if TYPE_CHECKING:
+    from httpx._types import ProxiesTypes
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+    ClientType = Union[AsyncAzureOpenAI, AsyncOpenAI]
+
+
+_ORCAROUTER_DEFAULT_MODEL = "openai/gpt-4o"
+
+
+@auto_register_resource(
+    label=_("OrcaRouter Proxy LLM"),
+    category=ResourceCategory.LLM_CLIENT,
+    tags={"order": TAGS_ORDER_HIGH},
+    description=_("OrcaRouter proxy LLM configuration."),
+    documentation_url="https://docs.orcarouter.ai",
+    show_in_ui=False,
+)
+@dataclass
+class OrcaRouterDeployModelParameters(OpenAICompatibleDeployModelParameters):
+    """Deploy model parameters for OrcaRouter."""
+
+    provider: str = "proxy/orcarouter"
+
+    api_base: Optional[str] = field(
+        default="${env:ORCAROUTER_API_BASE:-https://api.orcarouter.ai/v1}",
+        metadata={"help": _("The base url of the OrcaRouter API.")},
+    )
+
+    api_key: Optional[str] = field(
+        default="${env:ORCAROUTER_API_KEY}",
+        metadata={"help": _("The API key of the OrcaRouter API."), "tags": "privacy"},
+    )
+
+
+async def orcarouter_generate_stream(
+    model: ProxyModel, tokenizer, params, device, context_len=2048
+):
+    client: OrcaRouterLLMClient = model.proxy_llm_client
+    request = parse_model_request(params, client.default_model, stream=True)
+    async for r in client.generate_stream(request):
+        yield r
+
+
+class OrcaRouterLLMClient(OpenAILLMClient):
+    """OrcaRouter LLM Client using OpenAI-compatible endpoints.
+
+    OrcaRouter is a model routing gateway that exposes 150+ models from OpenAI,
+    Anthropic, Google, DeepSeek, Qwen, GLM and others behind a single OpenAI
+    compatible endpoint and API key. Model ids keep their provider prefix, for
+    example ``openai/gpt-4o``, ``anthropic/claude-opus-4.8`` or
+    ``deepseek/deepseek-chat``.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_type: Optional[str] = None,
+        api_version: Optional[str] = None,
+        model: Optional[str] = _ORCAROUTER_DEFAULT_MODEL,
+        proxies: Optional["ProxiesTypes"] = None,
+        timeout: Optional[int] = 240,
+        model_alias: Optional[str] = _ORCAROUTER_DEFAULT_MODEL,
+        context_length: Optional[int] = None,
+        openai_client: Optional["ClientType"] = None,
+        openai_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        api_base = (
+            api_base
+            or os.getenv("ORCAROUTER_API_BASE")
+            or "https://api.orcarouter.ai/v1"
+        )
+        api_key = api_key or os.getenv("ORCAROUTER_API_KEY")
+        model = model or _ORCAROUTER_DEFAULT_MODEL
+        if not context_length:
+            if "gpt-3.5" in model:
+                context_length = 16 * 1024
+            else:
+                context_length = 128 * 1024
+
+        if not api_key:
+            raise ValueError(
+                "OrcaRouter API key is required, please set 'ORCAROUTER_API_KEY' "
+                "in environment or pass it as an argument."
+            )
+
+        super().__init__(
+            api_key=api_key,
+            api_base=api_base,
+            api_type=api_type,
+            api_version=api_version,
+            model=model,
+            proxies=proxies,
+            timeout=timeout,
+            model_alias=model_alias,
+            context_length=context_length,
+            openai_client=openai_client,
+            openai_kwargs=openai_kwargs,
+            **kwargs,
+        )
+        try:
+            self.client.default_headers.update(ORCAROUTER_HEADERS)
+        except Exception:
+            pass
+
+    @property
+    def default_model(self) -> str:
+        model = self._model
+        if not model:
+            model = _ORCAROUTER_DEFAULT_MODEL
+        return model
+
+    @classmethod
+    def param_class(cls) -> Type[OrcaRouterDeployModelParameters]:
+        return OrcaRouterDeployModelParameters
+
+    @classmethod
+    def generate_stream_function(
+        cls,
+    ) -> Optional[Union[GenerateStreamFunction, AsyncGenerateStreamFunction]]:
+        return orcarouter_generate_stream
+
+
+register_proxy_model_adapter(
+    OrcaRouterLLMClient,
+    supported_models=[
+        ModelMetadata(
+            model=[
+                "orcarouter/fusion",
+                "orcarouter/fusion-mini",
+                "orcarouter/fusion-flash",
+            ],
+            context_length=1_000_000,
+            max_output_length=32_768,
+            description=(
+                "OrcaRouter routing models that pick the best upstream model "
+                "for each request"
+            ),
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["openai/gpt-4o", "openai/gpt-4o-mini"],
+            context_length=128_000,
+            max_output_length=16_384,
+            description="OpenAI GPT-4 family models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["openai/gpt-5.2", "openai/gpt-5.2-pro", "openai/gpt-5.4-mini"],
+            context_length=400_000,
+            max_output_length=32_768,
+            description="OpenAI GPT-5 family models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "anthropic/claude-opus-4.8",
+                "anthropic/claude-sonnet-4.6",
+                "anthropic/claude-haiku-4.5",
+            ],
+            context_length=1_000_000,
+            max_output_length=32_768,
+            description="Anthropic Claude family models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "deepseek/deepseek-chat",
+                "deepseek/deepseek-reasoner",
+                "deepseek/deepseek-v4-pro",
+            ],
+            context_length=1_048_576,
+            max_output_length=16_384,
+            description="DeepSeek models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "google/gemini-2.5-flash",
+                "google/gemini-2.5-pro",
+                "google/gemini-3.5-flash",
+            ],
+            context_length=1_048_576,
+            max_output_length=32_768,
+            description="Google Gemini family models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["qwen/qwen3.8-max", "qwen/qwen3.6-flash"],
+            context_length=1_000_000,
+            max_output_length=16_384,
+            description="Qwen models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["z-ai/glm-5.2", "z-ai/glm-4.7"],
+            context_length=1_000_000,
+            max_output_length=16_384,
+            description="GLM models via OrcaRouter",
+            link="https://www.orcarouter.ai/models",
+            function_calling=True,
+        ),
+    ],
+)


### PR DESCRIPTION
# Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

This registers OrcaRouter the same way the existing aggregator providers (AI/ML API, LiteLLM) are wired in this repo, so the model config, provider registry and docs stay consistent. Users configure `provider = "proxy/orcarouter"` with an `ORCAROUTER_API_KEY` and pick a model id such as `openai/gpt-4o`, `anthropic/claude-opus-4.8` or `deepseek/deepseek-chat`.

## What this changes

- `packages/dbgpt-core/src/dbgpt/model/proxy/llms/orcarouter.py`: new OrcaRouter provider client (`OrcaRouterLLMClient`) and deploy parameters (`OrcaRouterDeployModelParameters`, provider `proxy/orcarouter`, base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`), registered through `register_proxy_model_adapter`.
- `packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py`: expose `OrcaRouterLLMClient` in the proxy package lazy import map.
- `configs/dbgpt-proxy-orcarouter.toml`: ready-to-use config example.
- `docs/docs/installation/integrations/orcarouter_llm_install.md`: install doc alongside the other providers.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the existing aggregator gateways (AI/ML API, LiteLLM) are wired in this repo, so the model picker, config reference and docs stay consistent for users.

## How to use it

1. Get an API key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Pick a model id such as `openai/gpt-4o` or `anthropic/claude-opus-4.8`. The full catalog is at https://www.orcarouter.ai/models.

# How Has This Been Tested?

- `python -m py_compile` on the new module; `ruff format --check` and `ruff check` pass on the touched files.
- Provider discovery: `scan_model_providers()` registers the adapter and `get_model_adapter('proxy/orcarouter', ...)` matches the generated adapter.
- Live API against `https://api.orcarouter.ai/v1` with `openai/gpt-4o`: non-stream completion returns 200, stream returns 12 SSE chunks, tool calling returns 200, a bad key returns 401, an unknown model id returns an error.
- Instantiated `OrcaRouterLLMClient(api_key=...)` and streamed a real completion through the provider class end to end.

# Snapshots:

N/A (no UI change).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
