### PR TITLE
fix(agent): respect configured max_new_tokens for agent model calls

### DIFF
--- a/configs/dbgpt-app-config.example.toml
+++ b/configs/dbgpt-app-config.example.toml
@@ -13,6 +13,8 @@ port = 5670
 cors_allowed_origins = "${env:DBGPT_CORS_ALLOWED_ORIGINS:-*}"
 
 [service.web.agent_context]
+# Default output-token limit for Agent calls. A positive API request value wins.
+max_new_tokens = 4096
 # Agent context-window budget. Set max_context_tokens to 0 to auto-detect from
 # the selected model's metadata. The effective budget shown in the UI is
 # max_context_tokens - reserved_tokens.

--- a/configs/dbgpt-proxy-openai.toml
+++ b/configs/dbgpt-proxy-openai.toml
@@ -12,6 +12,8 @@ port = 5670
 cors_allowed_origins = "${env:DBGPT_CORS_ALLOWED_ORIGINS:-*}"
 
 [service.web.agent_context]
+# Default output-token limit for Agent calls. A positive API request value wins.
+max_new_tokens = 4096
 # Agent context-window budget. Set max_context_tokens to 0 to auto-detect from
 # the selected model's metadata. The effective budget shown in the UI is
 # max_context_tokens - reserved_tokens.

--- a/configs/dbgpt-proxy-siliconflow.toml
+++ b/configs/dbgpt-proxy-siliconflow.toml
@@ -12,6 +12,8 @@ port = 5670
 cors_allowed_origins = "${env:DBGPT_CORS_ALLOWED_ORIGINS:-*}"
 
 [service.web.agent_context]
+# Default output-token limit for Agent calls. A positive API request value wins.
+max_new_tokens = 4096
 # Agent context-window budget. Non-positive values fall back to the default
 # budget. The effective budget shown in the UI is
 # max_context_tokens - reserved_tokens.

--- a/configs/dbgpt-proxy-tongyi.toml
+++ b/configs/dbgpt-proxy-tongyi.toml
@@ -12,6 +12,8 @@ port = 5670
 cors_allowed_origins = "${env:DBGPT_CORS_ALLOWED_ORIGINS:-*}"
 
 [service.web.agent_context]
+# Default output-token limit for Agent calls. A positive API request value wins.
+max_new_tokens = 4096
 # Agent context-window budget. Set max_context_tokens to 0 to auto-detect from
 # the selected model's metadata. The effective budget shown in the UI is
 # max_context_tokens - reserved_tokens.

--- a/packages/dbgpt-app/src/dbgpt_app/config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/config.py
@@ -286,6 +286,7 @@ class AgentContextParameters(BaseParameters):
     )
 
     def __post_init__(self):
+        """Validate and normalize agent context parameters."""
         if self.max_new_tokens <= 0:
             logger.warning(
                 "Invalid max_new_tokens=%s; using default 4096",

--- a/packages/dbgpt-app/src/dbgpt_app/config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/config.py
@@ -26,6 +26,7 @@ from dbgpt_serve.core.config import GPTsAppConfig
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_PARALLEL_SUBAGENTS = 3
+DEFAULT_MAX_NEW_TOKENS = 4096
 _MAX_PARALLEL_SUBAGENTS_ENV_VAR = "DBGPT_MAX_PARALLEL_SUBAGENTS"
 
 

--- a/packages/dbgpt-app/src/dbgpt_app/config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/config.py
@@ -218,6 +218,16 @@ class AgentContextParameters(BaseParameters):
 
     __cfg_type__ = "service"
 
+    max_new_tokens: int = field(
+        default=4096,
+        metadata={
+            "help": _(
+                "Default maximum number of output tokens for agent model calls. "
+                "A positive per-request value takes precedence."
+            )
+        },
+    )
+
     max_context_tokens: Optional[int] = field(
         default=DEFAULT_MAX_CONTEXT_TOKENS,
         metadata={
@@ -276,6 +286,13 @@ class AgentContextParameters(BaseParameters):
     )
 
     def __post_init__(self):
+        if self.max_new_tokens <= 0:
+            logger.warning(
+                "Invalid max_new_tokens=%s; using default 4096",
+                self.max_new_tokens,
+            )
+            self.max_new_tokens = 4096
+
         if self.max_context_tokens is None or self.max_context_tokens <= 0:
             self.max_context_tokens = DEFAULT_MAX_CONTEXT_TOKENS
 

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -78,6 +78,7 @@ async def _resolve_model_context_tokens(
 async def _load_context_budget_config(
     llm_client: Any = None,
     model_name: Optional[str] = None,
+    max_new_tokens: Optional[int] = None,
 ) -> ContextBudgetConfig:
     """Build context budget config from app TOML and model metadata."""
     defaults = ContextBudgetConfig()
@@ -95,6 +96,11 @@ async def _load_context_budget_config(
         max_context_tokens = _value(
             agent_context, "max_context_tokens", defaults.max_context_tokens
         )
+        reserved_tokens = _value(
+            agent_context, "reserved_tokens", defaults.reserved_tokens
+        )
+        if max_new_tokens is not None:
+            reserved_tokens = max(reserved_tokens, max_new_tokens)
         return ContextBudgetConfig(
             max_context_tokens=max_context_tokens,
             warning_threshold=_value(
@@ -106,9 +112,7 @@ async def _load_context_budget_config(
             critical_threshold=_value(
                 agent_context, "critical_threshold", defaults.critical_threshold
             ),
-            reserved_tokens=_value(
-                agent_context, "reserved_tokens", defaults.reserved_tokens
-            ),
+            reserved_tokens=reserved_tokens,
             min_keep_recent_rounds=_value(
                 agent_context,
                 "min_keep_recent_rounds",
@@ -142,6 +146,25 @@ async def _load_context_budget_config(
             "Failed to load agent context config; using defaults", exc_info=True
         )
         return defaults
+
+
+def _resolve_agent_max_new_tokens(requested: Optional[int]) -> int:
+    """Resolve agent output tokens with request-over-config precedence."""
+    if requested is not None:
+        if requested <= 0:
+            raise ValueError("max_new_tokens must be greater than zero")
+        return requested
+
+    try:
+        app_config = CFG.SYSTEM_APP.config.configs.get("app_config")
+        web_config = getattr(getattr(app_config, "service", None), "web", None)
+        agent_context = getattr(web_config, "agent_context", None)
+        configured = getattr(agent_context, "max_new_tokens", None)
+        if isinstance(configured, int) and configured > 0:
+            return configured
+    except Exception:
+        logger.debug("Failed to read agent max_new_tokens; using default 4096")
+    return 4096
 
 
 def _extract_auto_data_markers(text: str) -> tuple[str, Dict[str, str]]:
@@ -2176,6 +2199,7 @@ print(json.dumps(summary, ensure_ascii=False))
         gpts_app_name="ReAct",
         language="zh",
         temperature=dialogue.temperature or 0.2,
+        max_new_tokens=_resolve_agent_max_new_tokens(dialogue.max_new_tokens),
         enable_context_management=True,
     )
 
@@ -2272,6 +2296,7 @@ print(json.dumps(summary, ensure_ascii=False))
     dispatch_parallel_tasks = make_dispatch_tool(
         parent_conv_id=conv_id,
         llm_client=llm_client,
+        max_new_tokens=context.max_new_tokens,
         sub_model_name=dialogue.model_name,
         database_connector=database_connector,
         knowledge_resources=knowledge_resources,
@@ -2780,6 +2805,7 @@ Action Input: The JSON format of tool parameters
         config=await _load_context_budget_config(
             llm_client=llm_client,
             model_name=dialogue.model_name,
+            max_new_tokens=context.max_new_tokens,
         ),
         model_name=dialogue.model_name,
         on_status_event=_context_status_callback,

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -24,6 +24,7 @@ from dbgpt.component import ComponentType
 from dbgpt.configs.model_config import SKILLS_DIR, resolve_root_path
 from dbgpt.core import PromptTemplate
 from dbgpt.model.cluster import WorkerManagerFactory
+from dbgpt_app.config import DEFAULT_MAX_NEW_TOKENS
 from dbgpt_app.openapi.api_view_model import (
     ConversationVo,
     Result,
@@ -169,7 +170,7 @@ def _resolve_agent_max_new_tokens(requested: Optional[int]) -> int:
             return configured
     except Exception:
         logger.debug("Failed to read agent max_new_tokens; using default 4096")
-    return 4096
+    return DEFAULT_MAX_NEW_TOKENS
 
 
 def _extract_auto_data_markers(text: str) -> tuple[str, Dict[str, str]]:

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -149,7 +149,12 @@ async def _load_context_budget_config(
 
 
 def _resolve_agent_max_new_tokens(requested: Optional[int]) -> int:
-    """Resolve agent output tokens with request-over-config precedence."""
+    """Resolve agent output tokens with request-over-config precedence.
+
+    A positive per-request value wins. Otherwise the value configured under
+    ``[service.web.agent_context].max_new_tokens`` is used, falling back to
+    the default of 4096 when no valid configuration is available.
+    """
     if requested is not None:
         if requested <= 0:
             raise ValueError("max_new_tokens must be greater than zero")

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/dispatcher.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/dispatcher.py
@@ -301,6 +301,7 @@ async def build_sub_react_agent(
     *,
     parent_conv_id: str,
     llm_client: Any,
+    max_new_tokens: int = 4096,
     sub_model_name: Optional[str] = None,
     database_connector: Any = None,
     knowledge_resources: Any = None,
@@ -315,6 +316,7 @@ async def build_sub_react_agent(
         sub_index: Index within the dispatch batch (drives conv_id / lane).
         parent_conv_id: The lead agent's conv_id.
         llm_client: The lead agent's ``LLMClient`` (reused, not the config).
+        max_new_tokens: Maximum output tokens inherited from the lead agent.
         sub_model_name: Model for the sub-agent; None => same as main model.
         database_connector: Shared read-only DB connector (or None).
         knowledge_resources: Shared read-only knowledge resources (or None).
@@ -384,6 +386,7 @@ async def build_sub_react_agent(
         gpts_app_code="react_agent_sub",
         gpts_app_name="ReAct-Sub",
         language="zh",
+        max_new_tokens=max_new_tokens,
         enable_context_management=True,
     )
 
@@ -488,6 +491,7 @@ def make_dispatch_tool(
     *,
     parent_conv_id: str,
     llm_client: Any,
+    max_new_tokens: int = 4096,
     sub_model_name: Optional[str] = None,
     database_connector: Any = None,
     knowledge_resources: Any = None,
@@ -501,6 +505,7 @@ def make_dispatch_tool(
     Args:
         parent_conv_id: The lead agent's conv_id (sub conv_ids derive from it).
         llm_client: The lead agent's ``LLMClient`` (reused for sub-agents).
+        max_new_tokens: Maximum output tokens inherited by sub-agents.
         sub_model_name: Sub-agent model; None => same as main model.
         database_connector: Shared read-only DB connector (or None).
         knowledge_resources: Shared read-only knowledge resources (or None).
@@ -586,6 +591,7 @@ def make_dispatch_tool(
                     idx,
                     parent_conv_id=parent_conv_id,
                     llm_client=llm_client,
+                    max_new_tokens=max_new_tokens,
                     sub_model_name=sub_model_name,
                     database_connector=database_connector,
                     knowledge_resources=knowledge_resources,

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/tests/test_dispatch_tool.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/tests/test_dispatch_tool.py
@@ -151,6 +151,29 @@ async def test_dispatch_runs_all_tasks_and_relays_text(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_passes_parent_max_new_tokens_to_subagents(monkeypatch):
+    captured_limits = []
+
+    async def _fake_build(goal, idx, **kwargs):
+        captured_limits.append(kwargs["max_new_tokens"])
+        return _FakeAgent(f"result-{idx}"), f"parent__sub_{idx}", {
+            "generated_images": []
+        }
+
+    monkeypatch.setattr(disp, "build_sub_react_agent", _fake_build)
+    tool = make_dispatch_tool(
+        parent_conv_id="p",
+        llm_client=_make_fake_llm_client(),
+        max_new_tokens=16384,
+        emit_event=_collector()[1],
+    )
+
+    await tool(tasks=[{"goal": "g0"}, {"goal": "g1"}])
+
+    assert captured_limits == [16384, 16384]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_summary_never_relays_react_envelope(monkeypatch):
     raw = """``````vis-thinking
 internal draft

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/tests/test_dispatch_tool.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/tests/test_dispatch_tool.py
@@ -156,9 +156,11 @@ async def test_dispatch_passes_parent_max_new_tokens_to_subagents(monkeypatch):
 
     async def _fake_build(goal, idx, **kwargs):
         captured_limits.append(kwargs["max_new_tokens"])
-        return _FakeAgent(f"result-{idx}"), f"parent__sub_{idx}", {
-            "generated_images": []
-        }
+        return (
+            _FakeAgent(f"result-{idx}"),
+            f"parent__sub_{idx}",
+            {"generated_images": []},
+        )
 
     monkeypatch.setattr(disp, "build_sub_react_agent", _fake_build)
     tool = make_dispatch_tool(

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_agentic_data_api_lifecycle.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_agentic_data_api_lifecycle.py
@@ -8,11 +8,63 @@ import pytest
 
 from dbgpt_app.openapi.api_v1 import agentic_data_api
 from dbgpt_app.openapi.api_v1.react_final import AgentFinalAnswer
+from dbgpt_app.openapi.api_view_model import ConversationVo
 
 
 def _decode_sse_event(event: str):
     assert event.startswith("data: ")
     return json.loads(event.removeprefix("data: ").strip())
+
+
+def test_agent_max_new_tokens_defaults_to_config(monkeypatch) -> None:
+    agent_context = SimpleNamespace(max_new_tokens=16384)
+    app_config = SimpleNamespace(
+        service=SimpleNamespace(web=SimpleNamespace(agent_context=agent_context))
+    )
+    system_app = SimpleNamespace(
+        config=SimpleNamespace(configs={"app_config": app_config})
+    )
+    monkeypatch.setattr(agentic_data_api.CFG, "SYSTEM_APP", system_app)
+
+    assert ConversationVo().max_new_tokens is None
+    assert agentic_data_api._resolve_agent_max_new_tokens(None) == 16384
+
+
+def test_agent_max_new_tokens_request_overrides_config(monkeypatch) -> None:
+    agent_context = SimpleNamespace(max_new_tokens=16384)
+    app_config = SimpleNamespace(
+        service=SimpleNamespace(web=SimpleNamespace(agent_context=agent_context))
+    )
+    system_app = SimpleNamespace(
+        config=SimpleNamespace(configs={"app_config": app_config})
+    )
+    monkeypatch.setattr(agentic_data_api.CFG, "SYSTEM_APP", system_app)
+
+    assert agentic_data_api._resolve_agent_max_new_tokens(32768) == 32768
+
+
+def test_agent_max_new_tokens_rejects_non_positive_request() -> None:
+    with pytest.raises(ValueError, match="greater than zero"):
+        agentic_data_api._resolve_agent_max_new_tokens(0)
+
+
+@pytest.mark.asyncio
+async def test_context_budget_reserves_configured_output_tokens(monkeypatch) -> None:
+    agent_context = SimpleNamespace(
+        max_context_tokens=120000,
+        reserved_tokens=4096,
+    )
+    app_config = SimpleNamespace(
+        service=SimpleNamespace(web=SimpleNamespace(agent_context=agent_context))
+    )
+    system_app = SimpleNamespace(
+        config=SimpleNamespace(configs={"app_config": app_config})
+    )
+    monkeypatch.setattr(agentic_data_api.CFG, "SYSTEM_APP", system_app)
+
+    config = await agentic_data_api._load_context_budget_config(max_new_tokens=16384)
+
+    assert config.reserved_tokens == 16384
 
 
 def test_history_failure_does_not_drop_final_or_done(caplog) -> None:

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_view_model.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_view_model.py
@@ -69,7 +69,7 @@ class ConversationVo(BaseModel):
     app_code: Optional[str] = ""
 
     temperature: Optional[float] = 0.5
-    max_new_tokens: Optional[int] = 4000
+    max_new_tokens: Optional[int] = Field(default=None, gt=0)
     """
     chat scene select param 
     """

--- a/packages/dbgpt-app/src/dbgpt_app/scene/base_chat.py
+++ b/packages/dbgpt-app/src/dbgpt_app/scene/base_chat.py
@@ -34,6 +34,7 @@ from dbgpt.util.annotations import Deprecated
 from dbgpt.util.executor_utils import ExecutorFactory, blocking_func_to_async
 from dbgpt.util.retry import async_retry
 from dbgpt.util.tracer import root_tracer, trace
+from dbgpt_app.config import DEFAULT_MAX_NEW_TOKENS
 from dbgpt_app.scene.base import AppScenePromptTemplateAdapter, ChatScene
 from dbgpt_app.scene.operators.app_operator import (
     AppChatComposerOperator,
@@ -108,6 +109,23 @@ def _build_conversation(
         conv_storage=conv_serve.conv_storage,
         message_storage=conv_serve.message_storage,
     )
+
+
+def resolve_max_new_tokens(
+    requested: Optional[int], app_config_max: Optional[int]
+) -> int:
+    """Resolve scene max_new_tokens with request > config > default precedence.
+
+    Mirrors the agent-side resolution (``_resolve_agent_max_new_tokens``) so
+    that omitting ``max_new_tokens`` on the standard chat path does not regress
+    the default from ``DEFAULT_MAX_NEW_TOKENS`` (4096) to a lower scene
+    fallback. Non-positive values are treated as unset.
+    """
+    if requested is not None and int(requested) > 0:
+        return int(requested)
+    if app_config_max is not None and int(app_config_max) > 0:
+        return int(app_config_max)
+    return DEFAULT_MAX_NEW_TOKENS
 
 
 class BaseChat(ABC):
@@ -304,15 +322,14 @@ class BaseChat(ABC):
         """Get the max new tokens for LLM generation.
 
         The order of priority is:
-        1. chat_param.max_new_tokens(From API)
-        2. app_config.max_new_tokens(From config file)
-        3. prompt_template.max_new_tokens(From prompt template)
+        1. chat_param.max_new_tokens (From API)
+        2. app_config.max_new_tokens (From config file)
+        3. DEFAULT_MAX_NEW_TOKENS (fallback, 4096)
         """
-        if self._chat_param.max_new_tokens:
-            return int(self._chat_param.max_new_tokens)
-        elif self._chat_param.app_config and self._chat_param.app_config.max_new_tokens:
-            return int(self.app_config.max_new_tokens)
-        return self.prompt_template.max_new_tokens
+        return resolve_max_new_tokens(
+            self._chat_param.max_new_tokens,
+            self.app_config.max_new_tokens if self.app_config else None,
+        )
 
     def llm_temperature(self):
         """Get the temperature for LLM generation.

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
@@ -4,6 +4,38 @@ import pytest
 
 from dbgpt.util.configure.manager import ConfigurationManager
 from dbgpt_app.config import AgentContextParameters
+from dbgpt_app.scene.base_chat import DEFAULT_MAX_NEW_TOKENS, resolve_max_new_tokens
+
+
+def test_resolve_max_new_tokens_request_takes_precedence():
+    """The per-request value wins over the application config."""
+    assert resolve_max_new_tokens(2048, 1024) == 2048
+
+
+def test_resolve_max_new_tokens_config_used_when_request_omitted():
+    """Fall back to the configured value when the request omits the field."""
+    assert resolve_max_new_tokens(None, 2048) == 2048
+
+
+def test_resolve_max_new_tokens_default_when_both_omitted():
+    """Fall back to the shared 4096 default so clients are not regressed."""
+    assert resolve_max_new_tokens(None, None) == DEFAULT_MAX_NEW_TOKENS
+    assert DEFAULT_MAX_NEW_TOKENS == 4096
+
+
+@pytest.mark.parametrize("requested", [0, -1])
+def test_resolve_max_new_tokens_non_positive_request_falls_through(
+    requested,
+):
+    """Treat non-positive request values as unset, matching the agent resolver."""
+    assert resolve_max_new_tokens(requested, 2048) == 2048
+    assert resolve_max_new_tokens(requested, None) == DEFAULT_MAX_NEW_TOKENS
+
+
+def test_resolve_max_new_tokens_accepts_numeric_strings():
+    """Keep the previous behavior of coercing numeric strings to ints."""
+    assert resolve_max_new_tokens("2048", 1024) == 2048
+    assert resolve_max_new_tokens(None, "2048") == 2048
 
 
 def test_max_new_tokens_accepts_config_value():

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
@@ -6,6 +6,27 @@ from dbgpt.util.configure.manager import ConfigurationManager
 from dbgpt_app.config import AgentContextParameters
 
 
+def test_max_new_tokens_accepts_config_value():
+    config = AgentContextParameters(max_new_tokens=16384)
+
+    assert config.max_new_tokens == 16384
+
+
+@pytest.mark.parametrize("configured_value", [0, -1])
+def test_non_positive_max_new_tokens_uses_default(configured_value):
+    config = AgentContextParameters(max_new_tokens=configured_value)
+
+    assert config.max_new_tokens == 4096
+
+
+def test_configuration_manager_parses_max_new_tokens():
+    manager = ConfigurationManager({"agent_context": {"max_new_tokens": 16384}})
+
+    config = manager.parse_config(AgentContextParameters, "agent_context")
+
+    assert config.max_new_tokens == 16384
+
+
 def test_max_parallel_subagents_uses_builtin_default(monkeypatch):
     """Use the built-in limit when neither TOML nor the environment sets it."""
     monkeypatch.delenv("DBGPT_MAX_PARALLEL_SUBAGENTS", raising=False)

--- a/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
+++ b/packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py
@@ -127,3 +127,33 @@ def test_non_positive_max_parallel_subagents_environment_keeps_config(
     config = AgentContextParameters(max_parallel_subagents=5)
 
     assert config.max_parallel_subagents == 5
+
+
+def test_llm_max_new_tokens_standard_chat_path_omitted_field():
+    """Standard chat path omitting ``max_new_tokens`` falls back to 4096.
+
+    This is the regression chen-alan flagged: with
+    ``ConversationVo.max_new_tokens`` defaulting to ``None``, external clients
+    that omit the field must still get ``DEFAULT_MAX_NEW_TOKENS`` (4096)
+    through ``BaseChat.llm_max_new_tokens()`` instead of a lower scene
+    fallback.
+    """
+    from types import SimpleNamespace
+
+    from dbgpt_app.scene.base_chat import BaseChat
+
+    class _StubChat(BaseChat):
+        """Minimal subclass exposing the max_new_tokens resolution path."""
+
+        @classmethod
+        def param_class(cls):
+            return None
+
+    chat = object.__new__(_StubChat)
+    chat._chat_param = SimpleNamespace(max_new_tokens=None)
+    chat.app_config = None
+    assert chat.llm_max_new_tokens() == DEFAULT_MAX_NEW_TOKENS
+
+    # The per-request value still wins when explicitly provided.
+    chat._chat_param = SimpleNamespace(max_new_tokens=2048)
+    assert chat.llm_max_new_tokens() == 2048

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/agents/expand/report_generation_agent.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/agents/expand/report_generation_agent.py
@@ -70,15 +70,6 @@ class ReportGenerationAgent(ConversableAgent):
         super().__init__(**kwargs)
         self._init_actions([ReportGenerationAction])
 
-    async def build(self, is_retry_chat: bool = False) -> "ConversableAgent":
-        """Build the agent."""
-        # Build the parent class first
-        agent = await super().build(is_retry_chat)
-        # Set higher max_new_tokens for report generation to allow longer reports
-        if self.agent_context:
-            self.agent_context.max_new_tokens = 4096
-        return agent
-
 
 agent_manage = get_agent_manager()
 agent_manage.register_agent(ReportGenerationAgent)

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1893,7 +1893,6 @@ const Playground: NextPage = () => {
       model_name: model,
       select_param: selectParam,
       temperature: 0.6,
-      max_new_tokens: 4000,
       ext_info: extInfo,
     };
 
@@ -1909,7 +1908,6 @@ const Playground: NextPage = () => {
           model_name: model,
           user_input: finalQuery,
           temperature: 0.6,
-          max_new_tokens: 4000,
           select_param: selectParam,
           ext_info: extInfo,
         }),


### PR DESCRIPTION
### Description

Part of #3151.

Agent model calls were capped at 4096 output tokens regardless of
configuration, truncating long reports and responses. The limit came from
three hardcoded sources:

1. `ReportGenerationAgent.build()` unconditionally overrode
   `agent_context.max_new_tokens` to 4096;
2. `ConversationVo.max_new_tokens` defaulted to 4000 and the Playground UI
   always sent 4000;
3. No config option was consumed by agent calls.

This PR makes `max_new_tokens` configurable and honors it end-to-end:

- Add `max_new_tokens` to `AgentContextParameters` (default 4096) with
  validation, and document it in the example TOML configs.
- Resolve the effective value with request > config > default precedence
  (`_resolve_agent_max_new_tokens`).
- Thread the value into the ReAct agent and sub-agent dispatch so sub-agents
  inherit the parent's limit.
- Bump `reserved_tokens` in the context-budget config to at least
  `max_new_tokens`, so long outputs are not truncated by the budget.
- Remove the hardcoded 4000/4096 defaults from the API view model, the
  Playground UI, and the report generation agent.

### How Has This Been Tested?

- `packages/dbgpt-app/src/dbgpt_app/tests/test_agent_context_config.py`
- `packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/subagent/tests/test_dispatch_tool.py`
- `packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_agentic_data_api_lifecycle.py`

All pass locally (35/35).

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform
  to the project standard
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation