### PR TITLE
fix(agent): use LONGTEXT for large agent messages on MySQL

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/chat/tests/test_gpts_messages_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/chat/tests/test_gpts_messages_db.py
@@ -1,0 +1,19 @@
+"""Tests for database-specific GPT message column types."""
+
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+
+from dbgpt_serve.agent.db.gpts_messages_db import GptsMessagesEntity
+
+
+def test_large_message_columns_use_longtext_on_mysql():
+    for column_name in ("content", "action_report"):
+        column_type = GptsMessagesEntity.__table__.c[column_name].type
+
+        assert column_type.dialect_impl(mysql.dialect()).compile() == "LONGTEXT"
+
+
+def test_large_message_columns_remain_portable_text():
+    content_type = GptsMessagesEntity.__table__.c.content.type
+
+    assert content_type.dialect_impl(sqlite.dialect()).compile() == "TEXT"
+    assert content_type.dialect_impl(postgresql.dialect()).compile() == "TEXT"

--- a/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_messages_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/agent/db/gpts_messages_db.py
@@ -14,9 +14,12 @@ from sqlalchemy import (
     desc,
     or_,
 )
+from sqlalchemy.dialects.mysql import LONGTEXT
 
 from dbgpt.agent.util.conv_utils import parse_conv_id
 from dbgpt.storage.metadata import BaseDao, Model
+
+_LARGE_TEXT = Text().with_variant(LONGTEXT(), "mysql")
 
 
 class GptsMessagesEntity(Model):
@@ -49,9 +52,7 @@ class GptsMessagesEntity(Model):
         nullable=False,
         comment="The message in which app name",
     )
-    content = Column(
-        Text(length=2**31 - 1), nullable=True, comment="Content of the speech"
-    )
+    content = Column(_LARGE_TEXT, nullable=True, comment="Content of the speech")
     current_goal = Column(
         Text, nullable=True, comment="The target corresponding to the current message"
     )
@@ -60,9 +61,7 @@ class GptsMessagesEntity(Model):
         Text, nullable=True, comment="Current conversation review info"
     )
     action_report = Column(
-        Text(length=2**31 - 1),
-        nullable=True,
-        comment="Current conversation action report",
+        _LARGE_TEXT, nullable=True, comment="Current conversation action report"
     )
     resource_info = Column(
         Text,


### PR DESCRIPTION
### Description

Part of #3151.

Long agent messages (e.g. full HTML reports) fail to persist on MySQL with:

`(pymysql.err.DataError) (1406, "Data too long for column 'content'")`

`Text(length=2**31-1)` still compiles to `TEXT` on MySQL (64 KB limit). This
PR switches `content` and `action_report` to
`Text().with_variant(LONGTEXT(), "mysql")`, so MySQL uses `LONGTEXT` while
SQLite/PostgreSQL keep portable `TEXT`.

### Migration for existing databases

This change only affects newly created tables (`create_all`). Existing
installations must run the following before deploying:

```sql
ALTER TABLE gpts_messages MODIFY COLUMN content LONGTEXT;
ALTER TABLE gpts_messages MODIFY COLUMN action_report LONGTEXT;
```

### How Has This Been Tested?

```bash
uv run --no-sync pytest packages/dbgpt-serve/src/dbgpt_serve/agent/chat/tests/test_gpts_messages_db.py -v
```

Expected result: 2 passed. The tests assert the columns compile to `LONGTEXT`
on MySQL and remain `TEXT` on SQLite and PostgreSQL. Verified locally on
Windows with Python 3.11.

### Snapshots

No UI snapshots apply — this is a database schema/type change. The compiled
dialect output is covered by the unit tests above.

### Dependencies

None. No new packages or configuration options are introduced.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules