### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.hi.md
+++ b/README.hi.md
@@ -376,4 +376,4 @@ DB-GPT में योगदान करने वाले सभी लो�
 - [ट्विटर](https://x.com/DBGPT_AI) ⭐️: कृपया हमसे बात करने के लिए स्वतंत्र महसूस करें।  
 
 
-[![स्टार इतिहास चार्ट](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![स्टार इतिहास चार्ट](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)

--- a/README.ja.md
+++ b/README.ja.md
@@ -365,4 +365,4 @@ DB-GPTを使用してAgent開発に関する内容について知りたい場合
 コミュニティを構築するために取り組んでいます。コミュニティの構築に関するアイデアがあれば、お気軽にお問い合わせください。
 [![](https://dcbadge.vercel.app/api/server/7uQnPuveTY?compact=true&style=flat)](https://discord.gg/7uQnPuveTY)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![Star History Chart](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)

--- a/README.ma.md
+++ b/README.ma.md
@@ -378,5 +378,5 @@ DB-GPT-യിലേക്ക് സംഭാവന ചെയ്ത എല്ല�
 - [ട്വിറ്റർ](https://x.com/DBGPT_AI) ⭐️：ദയവായി ഞങ്ങളോട് സംസാരിക്കാൻ മടിക്കരുത്.  
 
 
-[![സ്റ്റാർ ചരിത്ര ചാർട്ട്](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![സ്റ്റാർ ചരിത്ര ചാർട്ട്](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)
 

--- a/README.md
+++ b/README.md
@@ -488,4 +488,4 @@ We are working on building a community, if you have any ideas for building the c
 - [Twitter](https://x.com/DBGPT_AI) ⭐️：Please feel free to talk to us.  
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![Star History Chart](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)

--- a/README.ta.md
+++ b/README.ta.md
@@ -372,4 +372,4 @@ DB-GPT-க்கு பங்களித்த அனைவருக்கு�
 - [Github விவாதங்கள்](https://github.com/orgs/eosphoros-ai/discussions) ⭐️: உங்கள் அனுபவத்தை அல்லது தனித்துவமான பயன்பாடுகளைப் பகிரவும். 
 - [Twitter](https://x.com/DBGPT_AI) ⭐️: தயவுசெய்து எங்களுடன் பேச தயங்க வேண்டாம். 
 
-[![நட்சத்திர வரலாற்று விளக்கப்படம்](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![நட்சத்திர வரலாற்று விளக்கப்படம்](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)

--- a/README.zh.md
+++ b/README.zh.md
@@ -528,4 +528,4 @@ The MIT License (MIT)
     </figure>
 </div>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![Star History Chart](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)

--- a/READMR.hi.md
+++ b/READMR.hi.md
@@ -359,4 +359,4 @@ DB-GPT में योगदान करने वाले सभी लो�
 - [ट्विटर](https://x.com/DBGPT_AI) ⭐️: कृपया हमसे बात करने के लिए स्वतंत्र महसूस करें।  
 
 
-[![स्टार इतिहास चार्ट](https://api.star-history.com/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.com/#csunny/DB-GPT)
+[![स्टार इतिहास चार्ट](https://star-history.dera.page/svg?repos=csunny/DB-GPT&type=Date)](https://star-history.dera.page/#csunny/DB-GPT)


### PR DESCRIPTION
The star history chart in the README is broken due to the GitHub stargazer API restrictions. This change updates the chart links across all localized README files to a reliable provider that requires no API token, so the chart renders correctly again.