### PR TITLE
fix(client): include flow uid in update endpoint

### DIFF
--- a/docs/docs/api/flow.md
+++ b/docs/docs/api/flow.md
@@ -113,7 +113,7 @@ Return <a href="#the-flow-object">Flow Object</a>
 
 ### Update Flow
 ```python
-PUT /api/v2/serve/awel/flows
+PUT /api/v2/serve/awel/flows/{flow_id}
 ```
 
 #### Request body

--- a/packages/dbgpt-client/src/dbgpt_client/flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/flow.py
@@ -40,7 +40,7 @@ async def update_flow(client: Client, flow: FlowPanel) -> FlowPanel:
         ClientException: If the request failed.
     """
     try:
-        res = await client.put("/awel/flows", flow.to_dict())
+        res = await client.put(f"/awel/flows/{flow.uid}", flow.to_dict())
         result: Result = res.json()
         if result["success"]:
             return FlowPanel(**result["data"])

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dbgpt.core.awel.flow.flow_factory import FlowPanel
-from dbgpt_client.flow import create_flow
+from dbgpt_client.flow import create_flow, update_flow
 
 
 class _Response:
@@ -39,6 +39,16 @@ class _CreateFlowClient:
         return _Response(self.payload)
 
 
+class _UpdateFlowClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    async def put(self, path, body):
+        self.requests.append(("put", path, body))
+        return _Response(self.payload)
+
+
 @pytest.mark.asyncio
 async def test_create_flow_posts_instead_of_get():
     client = _CreateFlowClient(
@@ -57,3 +67,21 @@ async def test_create_flow_posts_instead_of_get():
     assert client.requests[0][0] == "post"
     assert client.requests[0][1] == "/awel/flows"
     assert client.requests[0][2] == request.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_update_flow_puts_to_flow_uid_path():
+    request = FlowPanel(uid="flow-123", label="test-flow", name="test_flow")
+    client = _UpdateFlowClient(
+        {
+            "success": True,
+            "err_code": None,
+            "err_msg": None,
+            "data": request.to_dict(),
+        }
+    )
+
+    updated = await update_flow(client, request)
+
+    assert updated.uid == "flow-123"
+    assert client.requests == [("put", "/awel/flows/flow-123", request.to_dict())]

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -72,16 +72,18 @@ async def test_create_flow_posts_instead_of_get():
 @pytest.mark.asyncio
 async def test_update_flow_puts_to_flow_uid_path():
     request = FlowPanel(uid="flow-123", label="test-flow", name="test_flow")
+    response = FlowPanel(uid="flow-123", label="updated-flow", name="updated_flow")
     client = _UpdateFlowClient(
         {
             "success": True,
             "err_code": None,
             "err_msg": None,
-            "data": request.to_dict(),
+            "data": response.to_dict(),
         }
     )
 
     updated = await update_flow(client, request)
 
     assert updated.uid == "flow-123"
+    assert updated.label == "updated-flow"
     assert client.requests == [("put", "/awel/flows/flow-123", request.to_dict())]


### PR DESCRIPTION
# Description
Fixes #3193

`update_flow()` was sending requests to `/awel/flows`, while the server expects `/awel/flows/{uid}`.

This PR:
- includes the flow UID in the update endpoint
- adds a regression test
- updates the API documentation


# How Has This Been Tested?

Added `test_update_flow_puts_to_flow_uid_path`, which verifies that:

- `update_flow()` sends a `PUT` request to `/awel/flows/{uid}`
- the flow payload is passed unchanged
- the returned flow is parsed correctly


# Snapshots:

N/A (no UI change).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
