### PR TITLE
fix(scheduled-task): inherit database context from [Database:] prefix (#3180)

### DIFF
--- a/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/service/chat_replay_runner.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/service/chat_replay_runner.py
@@ -190,8 +190,8 @@ class ChatReplayRunner:
     # ── Database context enrichment ──────────────────────────────────
 
     # Pattern produced by the frontend: "[Database: my_db]" or
-    # "[Database: my_db] [Knowledge: ...] user question ..."
-    _DB_FROM_INPUT_RE = re.compile(r"\[Database:\s*(\S+?)\]")
+    # "[Database: sales warehouse] [Knowledge: ...] user question ..."
+    _DB_FROM_INPUT_RE = re.compile(r"\[Database:\s*([^\]]+)\]")
 
     @staticmethod
     def _enrich_database_context(payload: dict) -> None:
@@ -224,7 +224,9 @@ class ChatReplayRunner:
         if not m:
             return
 
-        database_name = m.group(1)
+        database_name = m.group(1).strip()
+        if not database_name:
+            return
         logger.info(
             "Enriched database_name='%s' from user_input pattern",
             database_name,

--- a/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/service/chat_replay_runner.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/service/chat_replay_runner.py
@@ -15,9 +15,10 @@ unpicklable SQLAlchemy sessions.
 import asyncio
 import json
 import logging
+import re
 import uuid
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from ..dao.run_dao import ScheduledRunDao
 from ..dao.task_dao import ScheduledTaskDao
@@ -101,6 +102,13 @@ class ChatReplayRunner:
             payload["user_name"] = task.get("user_name")
             payload.pop("version", None)  # internal field, not a ConversationVo key
 
+            # 3b. Backfill database_name into ext_info if missing.
+            #     Existing tasks saved from a restored history conversation
+            #     may only have "[Database: xxx]" in user_input, not in
+            #     ext_info. Parse that prefix so replay can load the
+            #     connector (issue #3180).
+            self._enrich_database_context(payload)
+
             # 4. Replay in-process with a hard timeout
             final_texts, step_texts, artifact_count = await asyncio.wait_for(
                 self._run_agent_stream(payload),
@@ -178,6 +186,53 @@ class ChatReplayRunner:
             # done/react-agent) are ignored.
 
         return final_texts, step_texts, artifact_count
+
+    # ── Database context enrichment ──────────────────────────────────
+
+    # Pattern produced by the frontend: "[Database: my_db]" or
+    # "[Database: my_db] [Knowledge: ...] user question ..."
+    _DB_FROM_INPUT_RE = re.compile(r"\[Database:\s*(\S+?)\]")
+
+    @staticmethod
+    def _enrich_database_context(payload: dict) -> None:
+        """Backfill ``database_name`` into ``payload["ext_info"]`` when missing.
+
+        Scheduled tasks replay from a frozen ``payload_json``. If the
+        original conversation used a database but ``ext_info`` omitted
+        ``database_name``, ``_react_agent_stream`` fails with
+        "No database selected".
+
+        The UI prefixes ``user_input`` with ``[Database: xxx]`` when a
+        data source is selected. Parse that prefix as a backward-compat
+        fallback for snapshots that only kept the context string.
+
+        ``database_type`` is not required to load the connector, so it
+        is left unset rather than reflecting the full schema at cron
+        time.
+
+        Args:
+            payload: The deserialized ChatReplayPayload dict (modified
+                in-place).
+        """
+        ext_info: Dict = payload.get("ext_info") or {}
+
+        if ext_info.get("database_name"):
+            return
+
+        user_input = payload.get("user_input") or ""
+        m = ChatReplayRunner._DB_FROM_INPUT_RE.search(user_input)
+        if not m:
+            return
+
+        database_name = m.group(1)
+        logger.info(
+            "Enriched database_name='%s' from user_input pattern",
+            database_name,
+        )
+        ext_info["database_name"] = database_name
+        payload["ext_info"] = ext_info
+
+    # ── Helpers ──────────────────────────────────────────────────────
 
     def _fail(self, run_id: str, message: str, conv_uid: str) -> None:
         """Record a failed run with the given error message."""

--- a/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/tests/test_runner.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/tests/test_runner.py
@@ -411,3 +411,90 @@ async def test_runner_collects_final_event_as_summary(runner: ChatReplayRunner):
     assert "查询中" not in summary, (
         f"summary should prefer 'final' over step.chunk text, got '{summary}'"
     )
+
+
+# ---------------------------------------------------------------------------
+# Database context enrichment tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichDatabaseContext:
+    """Tests for ChatReplayRunner._enrich_database_context."""
+
+    def test_noop_when_database_name_already_present(self):
+        """Should not modify ext_info if database_name is already set."""
+        payload = {
+            "user_input": "query orders",
+            "ext_info": {"database_name": "my_db", "database_type": "mysql"},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "my_db"
+        assert payload["ext_info"]["database_type"] == "mysql"
+
+    def test_parse_database_from_user_input(self):
+        """Should extract database_name from [Database: xxx] in user_input."""
+        payload = {
+            "user_input": "[Database: postgres] 查询最近7天订单量",
+            "ext_info": {},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "postgres"
+
+    def test_parse_database_with_knowledge_prefix(self):
+        """Should handle [Database: xxx] followed by [Knowledge: yyy]."""
+        payload = {
+            "user_input": "[Database: my_mysql] [Knowledge: docs] 查询",
+            "ext_info": {},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "my_mysql"
+
+    def test_no_modification_when_no_database_hint(self):
+        """Should not modify payload if no database hint found anywhere."""
+        payload = {
+            "user_input": "generate daily report",
+            "ext_info": {"skill_name": "report-skill"},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert "database_name" not in payload["ext_info"]
+
+    def test_skill_name_alone_does_not_invent_database(self):
+        """skill_name without a [Database:] prefix is not a data source."""
+        payload = {
+            "user_input": "generate daily report",
+            "ext_info": {"skill_name": "customs-data-assistant"},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert "database_name" not in payload["ext_info"]
+
+    def test_preserves_existing_database_type(self):
+        """Should not overwrite database_type if already in ext_info."""
+        payload = {
+            "user_input": "[Database: my_db] query",
+            "ext_info": {"database_type": "custom_type"},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "my_db"
+        assert payload["ext_info"]["database_type"] == "custom_type"
+
+    def test_does_not_set_database_type_from_name_only(self):
+        """Name parsed from user_input is enough; type stays unset."""
+        payload = {
+            "user_input": "[Database: my_pg] query",
+            "ext_info": {},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "my_pg"
+        assert "database_type" not in payload["ext_info"]
+
+    def test_handles_null_ext_info(self):
+        """Should handle payload with no ext_info key at all."""
+        payload = {"user_input": "[Database: testdb] query"}
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "testdb"
+
+    def test_handles_empty_user_input(self):
+        """Should not crash on empty user_input."""
+        payload = {"user_input": "", "ext_info": {}}
+        ChatReplayRunner._enrich_database_context(payload)
+        assert "database_name" not in payload["ext_info"]

--- a/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/tests/test_runner.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/tests/test_runner.py
@@ -440,6 +440,15 @@ class TestEnrichDatabaseContext:
         ChatReplayRunner._enrich_database_context(payload)
         assert payload["ext_info"]["database_name"] == "postgres"
 
+    def test_parse_database_name_with_spaces(self):
+        """Names may contain spaces (CodeRabbit: \\S+ stopped at the first space)."""
+        payload = {
+            "user_input": "[Database: sales warehouse] query orders",
+            "ext_info": {},
+        }
+        ChatReplayRunner._enrich_database_context(payload)
+        assert payload["ext_info"]["database_name"] == "sales warehouse"
+
     def test_parse_database_with_knowledge_prefix(self):
         """Should handle [Database: xxx] followed by [Knowledge: yyy]."""
         payload = {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -2523,18 +2523,25 @@ const Playground: NextPage = () => {
     }
     // Fallback (e.g. conversation restored from history, where no send
     // happened this session): reconstruct from the first question + current
-    // selections. Keeps the old behavior so this path never regresses.
+    // selections. If the UI selection was lost but the question still
+    // carries "[Database: xxx]", keep that name so the snapshot can replay.
     const firstUserMsg = messages.find(m => m.role === 'human');
+    const userInput = firstUserMsg?.context ?? '';
+    const dbFromInput = userInput.match(/\[Database:\s*(\S+?)\]/)?.[1];
     return {
       version: 1,
-      user_input: firstUserMsg?.context ?? '',
+      user_input: userInput,
       chat_mode: 'chat_react_agent',
       model_name: model,
       select_param: '',
       ext_info: {
         ...(uploadedFilePath ? { file_path: uploadedFilePath } : {}),
         ...(selectedSkill ? { skill_id: selectedSkill.id, skill_name: selectedSkill.name } : {}),
-        ...(selectedDb ? { database_name: selectedDb.db_name, database_type: selectedDb.db_type } : {}),
+        ...(selectedDb
+          ? { database_name: selectedDb.db_name, database_type: selectedDb.db_type }
+          : dbFromInput
+            ? { database_name: dbFromInput }
+            : {}),
         ...(selectedKnowledge
           ? { knowledge_space_name: selectedKnowledge.name, knowledge_space_id: selectedKnowledge.id }
           : {}),

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -2527,7 +2527,7 @@ const Playground: NextPage = () => {
     // carries "[Database: xxx]", keep that name so the snapshot can replay.
     const firstUserMsg = messages.find(m => m.role === 'human');
     const userInput = firstUserMsg?.context ?? '';
-    const dbFromInput = userInput.match(/\[Database:\s*(\S+?)\]/)?.[1];
+    const dbFromInput = userInput.match(/\[Database:\s*([^\]]+)\]/)?.[1]?.trim();
     return {
       version: 1,
       user_input: userInput,


### PR DESCRIPTION
﻿## Summary
- Fixes scheduled-task replay failing with "No database selected" when `payload_json.ext_info` omitted `database_name` even though the original question still carried the UI `[Database: xxx]` prefix (issue #3180).
- On replay, backfill `ext_info.database_name` from that prefix so existing frozen tasks can load the connector.
- When saving a task from a restored history conversation (no in-session send), also copy the prefix into `ext_info` so new snapshots are complete.

## Test plan
- [x] `python -m pytest packages/dbgpt-serve/src/dbgpt_serve/scheduled_task/tests/test_runner.py -q`
- [ ] Save a conversation that includes `[Database: postgres]` in the first user message from a reloaded history tab (no re-run) and confirm `payload_json.ext_info.database_name` is set.
- [ ] Trigger an existing scheduled task whose payload only has the `[Database:]` prefix (no `database_name`) and confirm it no longer fails with "No database selected".

Closes #3180
