### PR TITLE
fix(client): include flow uid in update_flow PUT path (#3193)

### DIFF
--- a/docs/docs/api/flow.md
+++ b/docs/docs/api/flow.md
@@ -113,7 +113,7 @@ Return <a href="#the-flow-object">Flow Object</a>
 
 ### Update Flow
 ```python
-PUT /api/v2/serve/awel/flows
+PUT /api/v2/serve/awel/flows/{uid}
 ```
 
 #### Request body
@@ -125,7 +125,7 @@ Return <a href="#the-flow-object">Flow Object</a>
 ### Delete Flow
 
 ```python
-DELETE /api/v2/serve/awel/flows
+DELETE /api/v2/serve/awel/flows/{uid}
 ```
 
 <Tabs

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/api/flow.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/api/flow.md
@@ -113,7 +113,7 @@ Return <a href="#the-flow-object">Flow Object</a>
 
 ### Update Flow
 ```python
-PUT /api/v2/serve/awel/flows
+PUT /api/v2/serve/awel/flows/{uid}
 ```
 
 #### Request body
@@ -125,7 +125,7 @@ Return <a href="#the-flow-object">Flow Object</a>
 ### Delete Flow
 
 ```python
-DELETE /api/v2/serve/awel/flows
+DELETE /api/v2/serve/awel/flows/{uid}
 ```
 
 <Tabs

--- a/packages/dbgpt-client/src/dbgpt_client/flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/flow.py
@@ -41,9 +41,7 @@ async def update_flow(client: Client, flow: FlowPanel) -> FlowPanel:
     """
     try:
         if not flow.uid:
-            raise ClientException(
-                reason="Failed to update flow: flow.uid is required"
-            )
+            raise ClientException(reason="Failed to update flow: flow.uid is required")
         res = await client.put(f"/awel/flows/{flow.uid}", flow.to_dict())
         result: Result = res.json()
         if result["success"]:
@@ -53,7 +51,7 @@ async def update_flow(client: Client, flow: FlowPanel) -> FlowPanel:
     except ClientException:
         raise
     except Exception as e:
-        raise ClientException(reason=f"Failed to update flow: {e}")
+        raise ClientException(reason=f"Failed to update flow: {e}") from e
 
 
 async def delete_flow(client: Client, flow_id: str) -> FlowPanel:

--- a/packages/dbgpt-client/src/dbgpt_client/flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/flow.py
@@ -40,7 +40,9 @@ async def update_flow(client: Client, flow: FlowPanel) -> FlowPanel:
         ClientException: If the request failed.
     """
     try:
-        res = await client.put("/awel/flows", flow.to_dict())
+        if not flow.uid:
+            raise ClientException("Failed to update flow: flow.uid is required")
+        res = await client.put(f"/awel/flows/{flow.uid}", flow.to_dict())
         result: Result = res.json()
         if result["success"]:
             return FlowPanel(**result["data"])

--- a/packages/dbgpt-client/src/dbgpt_client/flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/flow.py
@@ -41,15 +41,19 @@ async def update_flow(client: Client, flow: FlowPanel) -> FlowPanel:
     """
     try:
         if not flow.uid:
-            raise ClientException("Failed to update flow: flow.uid is required")
+            raise ClientException(
+                reason="Failed to update flow: flow.uid is required"
+            )
         res = await client.put(f"/awel/flows/{flow.uid}", flow.to_dict())
         result: Result = res.json()
         if result["success"]:
             return FlowPanel(**result["data"])
         else:
             raise ClientException(status=result["err_code"], reason=result)
+    except ClientException:
+        raise
     except Exception as e:
-        raise ClientException(f"Failed to update flow: {e}")
+        raise ClientException(reason=f"Failed to update flow: {e}")
 
 
 async def delete_flow(client: Client, flow_id: str) -> FlowPanel:

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dbgpt.core.awel.flow.flow_factory import FlowPanel
-from dbgpt_client.flow import create_flow
+from dbgpt_client.flow import create_flow, update_flow
 
 
 class _Response:
@@ -38,6 +38,10 @@ class _CreateFlowClient:
         self.requests.append(("post", path, body))
         return _Response(self.payload)
 
+    async def put(self, path, body):
+        self.requests.append(("put", path, body))
+        return _Response(self.payload)
+
 
 @pytest.mark.asyncio
 async def test_create_flow_posts_instead_of_get():
@@ -57,3 +61,24 @@ async def test_create_flow_posts_instead_of_get():
     assert client.requests[0][0] == "post"
     assert client.requests[0][1] == "/awel/flows"
     assert client.requests[0][2] == request.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_update_flow_puts_to_uid_path():
+    """Server route is PUT /awel/flows/{uid}; the client must include the uid."""
+    flow = FlowPanel(uid="flow-123", label="demo", name="demo")
+    client = _CreateFlowClient(
+        {
+            "success": True,
+            "err_code": None,
+            "err_msg": None,
+            "data": flow.to_dict(),
+        }
+    )
+
+    updated = await update_flow(client, flow)
+
+    assert updated.uid == "flow-123"
+    assert client.requests[0][0] == "put"
+    assert client.requests[0][1] == "/awel/flows/flow-123"
+    assert client.requests[0][2]["uid"] == "flow-123"

--- a/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
+++ b/packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dbgpt.core.awel.flow.flow_factory import FlowPanel
+from dbgpt_client.client import ClientException
 from dbgpt_client.flow import create_flow, update_flow
 
 
@@ -82,3 +83,17 @@ async def test_update_flow_puts_to_uid_path():
     assert client.requests[0][0] == "put"
     assert client.requests[0][1] == "/awel/flows/flow-123"
     assert client.requests[0][2]["uid"] == "flow-123"
+
+
+@pytest.mark.asyncio
+async def test_update_flow_requires_uid():
+    client = _CreateFlowClient(
+        {"success": True, "err_code": None, "err_msg": None, "data": {}}
+    )
+    flow = FlowPanel(uid="", label="demo", name="demo")
+
+    with pytest.raises(ClientException) as exc:
+        await update_flow(client, flow)
+
+    assert client.requests == []
+    assert "flow.uid is required" in str(exc.value.reason)


### PR DESCRIPTION
## Summary
- `dbgpt_client.flow.update_flow()` sent `PUT /awel/flows`, but the server only mounts `PUT /awel/flows/{uid}`, so updates were rejected at routing (typically 405) and never reached `Service.update_flow()`.
- Put the flow UID in the request path and require `flow.uid`.
- Align the Flow API docs with the server routes.

## Test plan
- [x] `python -m pytest packages/dbgpt-client/src/dbgpt_client/tests/test_flow.py -q`
- [ ] Call `update_flow()` against a running server and confirm `PUT /api/v2/serve/awel/flows/{uid}` succeeds.

Closes #3193
