### PR TITLE
fix(datasource): avoid eager StarRocks schema reflection

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/datasource/parameter.py
+++ b/packages/dbgpt-core/src/dbgpt/datasource/parameter.py
@@ -24,6 +24,19 @@ class BaseDatasourceParameters(BaseParameters, RegisterParameters):
         """Create a connector."""
         raise NotImplementedError("Current connector does not support create_connector")
 
+    def test_connection(self) -> bool:
+        """Test whether the datasource can create a working connector.
+
+        Datasource implementations with a cheaper connectivity probe should override
+        this method. The default keeps the existing connector-construction behavior
+        while ensuring temporary resources are released promptly.
+        """
+        connector = self.create_connector()
+        try:
+            return True
+        finally:
+            connector.close()
+
     @classmethod
     def from_persisted_state(
         cls: Type["BaseDatasourceParameters"], state: Dict[str, Any]

--- a/packages/dbgpt-core/src/dbgpt/datasource/rdbms/base.py
+++ b/packages/dbgpt-core/src/dbgpt/datasource/rdbms/base.py
@@ -27,7 +27,7 @@ import sqlalchemy
 import sqlparse
 from sqlalchemy import MetaData, Table, create_engine, inspect, select, text
 from sqlalchemy.engine import CursorResult
-from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
+from sqlalchemy.exc import CompileError, ProgrammingError, SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session
 from sqlalchemy.schema import CreateTable
@@ -101,6 +101,16 @@ class RDBMSDatasourceParameters(BaseDatasourceParameters):
         """Create connector"""
         return RDBMSConnector.from_parameters(self)
 
+    def test_connection(self) -> bool:
+        """Test connectivity without reflecting the database schema."""
+        engine = create_engine(self.db_url(), **(self.engine_args() or {}))
+        try:
+            with engine.connect() as connection:
+                connection.execute(select(1))
+                return True
+        finally:
+            engine.dispose()
+
     def db_url(self, ssl: bool = False, charset: Optional[str] = None) -> str:
         """Return database engine url."""
         url = f"{self.driver}://{quote(self.user)}:{urlquote(self.password)}@{self.host}:{str(self.port)}/{self.database}"
@@ -163,9 +173,13 @@ class RDBMSConnector(BaseConnector):
         self._indexes_in_table_info = indexes_in_table_info
 
         self._metadata = metadata or MetaData()
-        self._metadata.reflect(bind=self._engine)
+        self._reflect_metadata()
 
         self._all_tables: Set[str] = cast(Set[str], self._sync_tables_from_db())
+
+    def _reflect_metadata(self) -> None:
+        """Populate SQLAlchemy metadata for connectors that rely on reflection."""
+        self._metadata.reflect(bind=self._engine)
 
     @classmethod
     def param_class(cls) -> Type[RDBMSDatasourceParameters]:
@@ -422,7 +436,7 @@ class RDBMSConnector(BaseConnector):
         """Get information about specified tables."""
         try:
             return self.get_table_info(table_names)
-        except ValueError as e:
+        except (CompileError, ValueError) as e:
             """Format the error message"""
             return f"Error: {e}"
 

--- a/packages/dbgpt-core/src/dbgpt/datasource/rdbms/tests/__init__.py
+++ b/packages/dbgpt-core/src/dbgpt/datasource/rdbms/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for relational datasource base classes."""

--- a/packages/dbgpt-core/src/dbgpt/datasource/rdbms/tests/test_base.py
+++ b/packages/dbgpt-core/src/dbgpt/datasource/rdbms/tests/test_base.py
@@ -1,0 +1,121 @@
+import pytest
+from sqlalchemy.exc import CompileError
+
+from dbgpt.datasource.parameter import BaseDatasourceParameters
+from dbgpt.datasource.rdbms import base as rdbms_base
+from dbgpt.datasource.rdbms.base import RDBMSConnector, RDBMSDatasourceParameters
+
+
+class _Connection:
+    def __init__(self, execute_error=None):
+        self.execute_error = execute_error
+        self.executed_statements = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def execute(self, statement):
+        if self.execute_error:
+            raise self.execute_error
+        self.executed_statements.append(statement)
+
+
+class _Engine:
+    def __init__(self, connect_error=None, execute_error=None):
+        self.connect_error = connect_error
+        self.connected = False
+        self.disposed = False
+        self.connection = _Connection(execute_error)
+
+    def connect(self):
+        if self.connect_error:
+            raise self.connect_error
+        self.connected = True
+        return self.connection
+
+    def dispose(self):
+        self.disposed = True
+
+
+def _parameters() -> RDBMSDatasourceParameters:
+    return RDBMSDatasourceParameters(
+        host="localhost",
+        port=9030,
+        user="root",
+        database="test",
+        driver="starrocks",
+        password="secret",
+    )
+
+
+def test_rdbms_connection_probe_does_not_create_connector(monkeypatch):
+    engine = _Engine()
+    monkeypatch.setattr(rdbms_base, "create_engine", lambda *args, **kwargs: engine)
+    monkeypatch.setattr(
+        RDBMSDatasourceParameters,
+        "create_connector",
+        lambda self: pytest.fail("connection probing must not create a connector"),
+    )
+
+    assert _parameters().test_connection() is True
+    assert engine.connected is True
+    assert len(engine.connection.executed_statements) == 1
+    assert str(engine.connection.executed_statements[0]).startswith("SELECT ")
+    assert engine.disposed is True
+
+
+def test_rdbms_connection_probe_disposes_engine_after_failure(monkeypatch):
+    engine = _Engine(connect_error=RuntimeError("access denied"))
+    monkeypatch.setattr(rdbms_base, "create_engine", lambda *args, **kwargs: engine)
+
+    with pytest.raises(RuntimeError, match="access denied"):
+        _parameters().test_connection()
+
+    assert engine.disposed is True
+
+
+def test_rdbms_connection_probe_disposes_engine_after_query_failure(monkeypatch):
+    engine = _Engine(execute_error=RuntimeError("query denied"))
+    monkeypatch.setattr(rdbms_base, "create_engine", lambda *args, **kwargs: engine)
+
+    with pytest.raises(RuntimeError, match="query denied"):
+        _parameters().test_connection()
+
+    assert engine.disposed is True
+
+
+def test_get_table_info_no_throw_handles_compile_errors(monkeypatch):
+    connector = object.__new__(RDBMSConnector)
+    connector._is_closed = True
+    monkeypatch.setattr(
+        connector,
+        "get_table_info",
+        lambda table_names=None: (_ for _ in ()).throw(
+            CompileError("VARCHAR requires a length")
+        ),
+    )
+
+    assert connector.get_table_info_no_throw() == ("Error: VARCHAR requires a length")
+
+
+def test_default_connection_probe_closes_temporary_connector():
+    class _Connector:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Parameters:
+        def __init__(self):
+            self.connector = _Connector()
+
+        def create_connector(self):
+            return self.connector
+
+    parameters = _Parameters()
+
+    assert BaseDatasourceParameters.test_connection(parameters) is True
+    assert parameters.connector.closed is True

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_starrocks.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_starrocks.py
@@ -1,11 +1,13 @@
 """StarRocks connector."""
 
+import logging
 from dataclasses import dataclass, field
-from typing import Any, Iterable, List, Optional, Tuple, Type, cast
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, cast
 from urllib.parse import quote
 from urllib.parse import quote_plus as urlquote
 
 from sqlalchemy import text
+from sqlalchemy.exc import NoSuchTableError
 
 from dbgpt.core.awel.flow import (
     TAGS_ORDER_HIGH,
@@ -16,6 +18,8 @@ from dbgpt.datasource.rdbms.base import RDBMSConnector, RDBMSDatasourceParameter
 from dbgpt.util.i18n_utils import _
 
 from .dialect.starrocks.sqlalchemy import *  # noqa
+
+logger = logging.getLogger(__name__)
 
 
 @auto_register_resource(
@@ -45,6 +49,8 @@ class StarRocksParameters(RDBMSDatasourceParameters):
 class StarRocksConnector(RDBMSConnector):
     """StarRocks connector."""
 
+    _UNSUPPORTED_SAMPLE_TYPES = {"BITMAP", "HLL", "PERCENTILE"}
+
     driver = "starrocks"
     db_type = "starrocks"
     db_dialect = "starrocks"
@@ -53,6 +59,14 @@ class StarRocksConnector(RDBMSConnector):
     def param_class(cls) -> Type[StarRocksParameters]:
         """Return the parameter class."""
         return StarRocksParameters
+
+    def _reflect_metadata(self) -> None:
+        """Skip eager schema reflection for StarRocks.
+
+        StarRocks exposes all schema information needed by this connector through
+        ``information_schema``. Avoiding eager reflection prevents one unsupported or
+        concurrently dropped table from making the whole connector unusable.
+        """
 
     @classmethod
     def from_uri_db(
@@ -76,16 +90,16 @@ class StarRocksConnector(RDBMSConnector):
         with self.session_scope() as session:
             table_results = session.execute(
                 text(
-                    "SELECT TABLE_NAME FROM information_schema.tables where "
-                    f'TABLE_SCHEMA="{db_name}"'
-                )
+                    "SELECT TABLE_NAME FROM information_schema.tables "
+                    "WHERE TABLE_SCHEMA=:db_name"
+                ),
+                {"db_name": db_name},
             )
             # view_results = session.execute(text(f'SELECT TABLE_NAME from
             # information_schema.materialized_views where TABLE_SCHEMA="{db_name}"'))
             table_results = set(row[0] for row in table_results)  # noqa: C401
             # view_results = set(row[0] for row in view_results)
             self._all_tables = table_results
-            self._metadata.reflect(bind=self._engine)
             return self._all_tables
 
     def get_grants(self):
@@ -115,22 +129,156 @@ class StarRocksConnector(RDBMSConnector):
         """Get user info."""
         return []
 
-    def get_fields(self, table_name, db_name="database()") -> List[Tuple]:
+    def get_fields(self, table_name: str, db_name: str = "database()") -> List[Tuple]:
         """Get column fields about specified table."""
+        if db_name == "database()":
+            db_name = self.get_current_db_name()
         with self.session_scope() as session:
-            if db_name != "database()":
-                db_name = f'"{db_name}"'
             cursor = session.execute(
                 text(
-                    "select COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAULT, IS_NULLABLE, "
-                    "COLUMN_COMMENT from information_schema.columns where "
-                    f'TABLE_NAME="{table_name}" and TABLE_SCHEMA = {db_name}'
-                )
+                    "SELECT COLUMN_NAME, COLUMN_TYPE, COLUMN_DEFAULT, IS_NULLABLE, "
+                    "COLUMN_COMMENT FROM information_schema.columns "
+                    "WHERE TABLE_NAME=:table_name AND TABLE_SCHEMA=:db_name "
+                    "ORDER BY ORDINAL_POSITION"
+                ),
+                {"table_name": table_name, "db_name": db_name},
             )
             fields = cursor.fetchall()
             return [
                 (field[0], field[1], field[2], field[3], field[4]) for field in fields
             ]
+
+    def get_columns(self, table_name: str) -> List[Dict[str, Any]]:
+        """Return columns without routing through SQLAlchemy metadata reflection."""
+        return [
+            {
+                "name": field[0],
+                "type": field[1],
+                "default": field[2],
+                "nullable": field[3] == "YES",
+                "comment": field[4],
+            }
+            for field in self.get_fields(table_name)
+        ]
+
+    def get_table_info(self, table_names: Optional[List[str]] = None) -> str:
+        """Get table information directly from ``information_schema``."""
+        all_table_names = sorted(self.get_usable_table_names())
+        if table_names is not None:
+            missing_tables = set(table_names).difference(all_table_names)
+            if missing_tables:
+                raise ValueError(f"table_names {missing_tables} not found in database")
+            all_table_names = table_names
+
+        tables = []
+        for table_name in all_table_names:
+            if self._custom_table_info and table_name in self._custom_table_info:
+                tables.append(self._custom_table_info[table_name])
+                continue
+            try:
+                table_info = self._build_table_info(table_name)
+            except Exception as error:
+                if self._is_missing_table_error(error):
+                    logger.warning(
+                        "Skipping StarRocks table %s because it no longer exists",
+                        table_name,
+                    )
+                    continue
+                raise
+            if table_info:
+                tables.append(table_info)
+        return "\n\n".join(tables)
+
+    def _build_table_info(self, table_name: str) -> str:
+        """Build table information without constructing SQLAlchemy ``Table`` objects."""
+        fields = self.get_fields(table_name)
+        if not fields:
+            logger.warning(
+                "Skipping StarRocks table %s because it has no visible columns",
+                table_name,
+            )
+            return ""
+
+        quote_identifier = self._engine.dialect.identifier_preparer.quote_identifier
+        column_definitions = []
+        for name, column_type, default, nullable, comment in fields:
+            definition = f"  {quote_identifier(name)} {column_type}"
+            if nullable == "NO":
+                definition += " NOT NULL"
+            if default is not None:
+                definition += f" DEFAULT {default}"
+            if comment:
+                escaped_comment = str(comment).replace("'", "''")
+                definition += f" COMMENT '{escaped_comment}'"
+            column_definitions.append(definition)
+
+        quoted_table = quote_identifier(table_name)
+        table_info = (
+            f"CREATE TABLE {quoted_table} (\n" + ",\n".join(column_definitions) + "\n)"
+        )
+        if self._sample_rows_in_table_info:
+            sample_columns = [
+                name
+                for name, column_type, *_ in fields
+                if self._base_type_name(column_type)
+                not in self._UNSUPPORTED_SAMPLE_TYPES
+            ]
+            table_info += self._get_sample_rows_by_name(table_name, sample_columns)
+        if self._indexes_in_table_info:
+            table_info += self._get_indexes_info_by_name(table_name)
+        return table_info
+
+    @staticmethod
+    def _base_type_name(column_type: str) -> str:
+        """Return the top-level StarRocks type name."""
+        return str(column_type).split("(", 1)[0].split("<", 1)[0].strip().upper()
+
+    def _get_sample_rows_by_name(self, table_name: str, column_names: List[str]) -> str:
+        """Return formatted sample rows without requiring reflected metadata."""
+        if not column_names:
+            return ""
+        quote_identifier = self._engine.dialect.identifier_preparer.quote_identifier
+        quoted_table = quote_identifier(table_name)
+        selected_columns = ", ".join(
+            quote_identifier(column_name) for column_name in column_names
+        )
+        with self.session_scope() as session:
+            cursor = session.execute(
+                text(
+                    f"SELECT {selected_columns} FROM {quoted_table} "
+                    f"LIMIT {int(self._sample_rows_in_table_info)}"
+                )
+            )
+            rows = cursor.fetchall()
+
+        columns_str = "\t".join(column_names)
+        sample_rows_str = "\n".join(
+            "\t".join("NULL" if value is None else str(value)[:100] for value in row)
+            for row in rows
+        )
+        return (
+            f"\n\n/*\n{self._sample_rows_in_table_info} rows from "
+            f"{table_name} table:\n{columns_str}\n{sample_rows_str}\n*/"
+        )
+
+    def _get_indexes_info_by_name(self, table_name: str) -> str:
+        """Return formatted index information without reflected metadata."""
+        indexes = self.get_indexes(table_name)
+        if not indexes:
+            return ""
+        indexes_str = "\n".join(
+            f"Name: {name}, Column: {column}" for name, column in indexes
+        )
+        return f"\n\n/*\nTable Indexes:\n{indexes_str}\n*/"
+
+    @staticmethod
+    def _is_missing_table_error(error: Exception) -> bool:
+        """Return whether an exception represents a concurrently removed table."""
+        if isinstance(error, NoSuchTableError):
+            return True
+        original = getattr(error, "orig", error)
+        args = getattr(original, "args", ())
+        return bool(args and args[0] in (1146, 5502))
 
     def get_charset(self):
         """Get character_set."""
@@ -153,8 +301,9 @@ class StarRocksConnector(RDBMSConnector):
             cur = session.execute(
                 text(
                     "SELECT TABLE_COMMENT FROM information_schema.tables where "
-                    f'TABLE_NAME="{table_name}" and TABLE_SCHEMA=database()'
-                )
+                    "TABLE_NAME=:table_name and TABLE_SCHEMA=database()"
+                ),
+                {"table_name": table_name},
             )
             table = cur.fetchone()
             if table:
@@ -170,8 +319,9 @@ class StarRocksConnector(RDBMSConnector):
             cur = session.execute(
                 text(
                     "SELECT TABLE_NAME,TABLE_COMMENT FROM information_schema.tables "
-                    f'where TABLE_SCHEMA="{db_name}"'
-                )
+                    "where TABLE_SCHEMA=:db_name"
+                ),
+                {"db_name": db_name},
             )
             tables = cur.fetchall()
             return [(table[0], table[1]) for table in tables]
@@ -206,7 +356,14 @@ class StarRocksConnector(RDBMSConnector):
 
     def get_indexes(self, table_name):
         """Get table indexes about specified table."""
-        with self.session_scope() as session:
-            cursor = session.execute(text(f"SHOW INDEX FROM {table_name}"))
-            indexes = cursor.fetchall()
-            return [(index[2], index[4]) for index in indexes]
+        quote_identifier = self._engine.dialect.identifier_preparer.quote_identifier
+        quoted_table = quote_identifier(table_name)
+        try:
+            with self.session_scope() as session:
+                cursor = session.execute(text(f"SHOW INDEX FROM {quoted_table}"))
+                indexes = cursor.fetchall()
+                return [(index[2], index[4]) for index in indexes]
+        except Exception as error:
+            if self._is_missing_table_error(error):
+                return []
+            raise

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/datatype.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/datatype.py
@@ -148,4 +148,18 @@ def parse_sqltype(type_str: str) -> TypeEngine:
         logger.warning(f"Did not recognize type '{type_name}'")
         return sqltypes.NULLTYPE
     type_class = _type_map[type_name]
+    options = match.group("options")
+    if not options:
+        return type_class()
+
+    try:
+        values = [int(value.strip()) for value in options.split(",")]
+        if type_name in {"binary", "char", "varbinary", "varchar"}:
+            return type_class(length=values[0])
+        if type_name == "decimal":
+            precision = values[0]
+            scale = values[1] if len(values) > 1 else None
+            return type_class(precision=precision, scale=scale)
+    except (IndexError, ValueError):
+        logger.warning("Could not parse options for type '%s'", type_str)
     return type_class()

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/dialect.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/dialect/starrocks/sqlalchemy/dialect.py
@@ -49,12 +49,13 @@ class StarRocksDialect(MySQLDialect_pymysql):  # type: ignore
 
         assert schema is not None
 
-        quote = self.identifier_preparer.quote_identifier
-        full_name = quote(table_name)
-        if schema:
-            full_name = "{}.{}".format(quote(schema), full_name)
-
-        res = connection.execute(text(f"DESCRIBE {full_name}"))
+        res = connection.execute(
+            text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE TABLE_SCHEMA=:schema AND TABLE_NAME=:table_name LIMIT 1"
+            ),
+            {"schema": schema, "table_name": table_name},
+        )
         return res.first() is not None
 
     def get_schema_names(self, connection, **kw):
@@ -103,25 +104,29 @@ class StarRocksDialect(MySQLDialect_pymysql):  # type: ignore
         **kw,
     ) -> List[Dict[str, Any]]:  # type: ignore
         """Return information about columns in `table_name`."""
-        if not self.has_table(connection, table_name, schema):
-            raise exc.NoSuchTableError(f"schema={schema}, table={table_name}")
         schema = schema or self._get_default_schema_name(connection)
-
-        quote = self.identifier_preparer.quote_identifier
-        full_name = quote(table_name)
-        if schema:
-            full_name = "{}.{}".format(quote(schema), full_name)
-
-        res = connection.execute(text(f"SHOW COLUMNS FROM {full_name}"))
+        assert schema is not None
+        res = connection.execute(
+            text(
+                "SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, "
+                "COLUMN_COMMENT FROM information_schema.columns "
+                "WHERE TABLE_SCHEMA=:schema AND TABLE_NAME=:table_name "
+                "ORDER BY ORDINAL_POSITION"
+            ),
+            {"schema": schema, "table_name": table_name},
+        )
         columns = []
         for record in res:
             column = dict(
-                name=record.Field,
-                type=datatype.parse_sqltype(record.Type),
-                nullable=record.Null == "YES",
-                default=record.Default,
+                name=record[0],
+                type=datatype.parse_sqltype(record[1]),
+                nullable=record[2] == "YES",
+                default=record[3],
+                comment=record[4],
             )
             columns.append(column)
+        if not columns:
+            raise exc.NoSuchTableError(f"schema={schema}, table={table_name}")
         return columns
 
     def get_pk_constraint(

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_starrocks.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_starrocks.py
@@ -1,0 +1,190 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import exc
+from sqlalchemy.sql import sqltypes
+
+from dbgpt_ext.datasource.rdbms.conn_starrocks import StarRocksConnector
+from dbgpt_ext.datasource.rdbms.dialect.starrocks.sqlalchemy.datatype import (
+    parse_sqltype,
+)
+from dbgpt_ext.datasource.rdbms.dialect.starrocks.sqlalchemy.dialect import (
+    StarRocksDialect,
+)
+
+
+class _IdentifierPreparer:
+    @staticmethod
+    def quote_identifier(identifier):
+        return f"`{identifier.replace('`', '``')}`"
+
+
+class _Dialect:
+    identifier_preparer = _IdentifierPreparer()
+
+
+class _Engine:
+    dialect = _Dialect()
+
+
+def _connector() -> StarRocksConnector:
+    connector = object.__new__(StarRocksConnector)
+    connector._is_closed = True
+    connector._engine = _Engine()
+    connector._custom_table_info = {}
+    connector._sample_rows_in_table_info = 0
+    connector._indexes_in_table_info = False
+    return connector
+
+
+def test_starrocks_skips_eager_metadata_reflection():
+    connector = _connector()
+    connector._metadata = MagicMock()
+
+    connector._reflect_metadata()
+
+    connector._metadata.reflect.assert_not_called()
+
+
+def test_starrocks_columns_preserve_special_type_names(monkeypatch):
+    connector = _connector()
+    monkeypatch.setattr(
+        connector,
+        "get_fields",
+        lambda table_name: [
+            ("bitmap_value", "BITMAP", None, "NO", "bitmap column"),
+            ("hll_value", "HLL", None, "YES", None),
+            ("array_value", "ARRAY<INT>", None, "YES", None),
+        ],
+    )
+
+    columns = connector.get_columns("events")
+
+    assert [column["type"] for column in columns] == ["BITMAP", "HLL", "ARRAY<INT>"]
+    assert columns[0]["nullable"] is False
+    assert columns[0]["comment"] == "bitmap column"
+
+
+def test_starrocks_table_info_does_not_require_reflected_metadata(monkeypatch):
+    connector = _connector()
+    monkeypatch.setattr(connector, "get_usable_table_names", lambda: {"events"})
+    monkeypatch.setattr(
+        connector,
+        "get_fields",
+        lambda table_name: [
+            ("bitmap_value", "BITMAP", None, "NO", "bitmap's value"),
+            ("array_value", "ARRAY<INT>", None, "YES", None),
+        ],
+    )
+
+    table_info = connector.get_table_info()
+
+    assert "CREATE TABLE `events`" in table_info
+    assert "`bitmap_value` BITMAP NOT NULL COMMENT 'bitmap''s value'" in table_info
+    assert "`array_value` ARRAY<INT>" in table_info
+
+
+def test_starrocks_table_info_does_not_sample_aggregate_columns(monkeypatch):
+    connector = _connector()
+    connector._sample_rows_in_table_info = 3
+    monkeypatch.setattr(connector, "get_usable_table_names", lambda: {"events"})
+    monkeypatch.setattr(
+        connector,
+        "get_fields",
+        lambda table_name: [
+            ("bitmap_value", "BITMAP", None, "YES", None),
+            ("hll_value", "HLL", None, "YES", None),
+            ("event_id", "BIGINT", None, "NO", None),
+        ],
+    )
+    sample_rows = MagicMock(return_value="")
+    monkeypatch.setattr(connector, "_get_sample_rows_by_name", sample_rows)
+
+    connector.get_table_info()
+
+    sample_rows.assert_called_once_with("events", ["event_id"])
+
+
+def test_starrocks_table_info_skips_concurrently_removed_table(monkeypatch):
+    connector = _connector()
+    monkeypatch.setattr(
+        connector, "get_usable_table_names", lambda: {"events", "temporary_table"}
+    )
+
+    class _OriginalError(Exception):
+        pass
+
+    class _DatabaseError(Exception):
+        def __init__(self):
+            self.orig = _OriginalError(5502, "Unknown table")
+
+    def _build_table_info(table_name):
+        if table_name == "temporary_table":
+            raise _DatabaseError()
+        return "CREATE TABLE `events` (`id` INT)"
+
+    monkeypatch.setattr(connector, "_build_table_info", _build_table_info)
+
+    assert connector.get_table_info() == "CREATE TABLE `events` (`id` INT)"
+
+
+def test_starrocks_table_info_does_not_hide_connection_errors(monkeypatch):
+    connector = _connector()
+    monkeypatch.setattr(connector, "get_usable_table_names", lambda: {"events"})
+    monkeypatch.setattr(
+        connector,
+        "_build_table_info",
+        lambda table_name: (_ for _ in ()).throw(RuntimeError("connection lost")),
+    )
+
+    with pytest.raises(RuntimeError, match="connection lost"):
+        connector.get_table_info()
+
+
+def test_starrocks_dialect_has_table_uses_information_schema(monkeypatch):
+    dialect = StarRocksDialect()
+    monkeypatch.setattr(
+        dialect, "_ensure_has_table_connection", lambda connection: None
+    )
+    result = MagicMock()
+    result.first.return_value = (1,)
+    connection = MagicMock()
+    connection.execute.return_value = result
+
+    assert dialect.has_table(connection, "events", schema="analytics") is True
+    statement, parameters = connection.execute.call_args.args
+    assert "information_schema.tables" in str(statement)
+    assert parameters == {"schema": "analytics", "table_name": "events"}
+
+
+def test_starrocks_dialect_parses_columns_without_describe():
+    dialect = StarRocksDialect()
+    connection = MagicMock()
+    connection.execute.return_value = [
+        ("bitmap_value", "BITMAP", "NO", None, "bitmap column"),
+        ("unknown_value", "FUTURE_TYPE(20)", "YES", None, None),
+    ]
+
+    columns = dialect.get_columns(connection, "events", schema="analytics")
+
+    assert columns[0]["type"].__visit_name__ == "BITMAP"
+    assert isinstance(columns[1]["type"], sqltypes.NullType)
+    assert columns[0]["comment"] == "bitmap column"
+
+
+def test_starrocks_dialect_reports_missing_table():
+    dialect = StarRocksDialect()
+    connection = MagicMock()
+    connection.execute.return_value = []
+
+    with pytest.raises(exc.NoSuchTableError):
+        dialect.get_columns(connection, "missing", schema="analytics")
+
+
+def test_starrocks_type_parser_preserves_length_and_precision():
+    varchar = parse_sqltype("VARCHAR(255)")
+    decimal = parse_sqltype("DECIMAL(18, 2)")
+
+    assert varchar.length == 255
+    assert decimal.precision == 18
+    assert decimal.scale == 2

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connector_manager.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connector_manager.py
@@ -419,8 +419,7 @@ class ConnectorManager(BaseComponent):
                 request.params["password"] = _resolve_env_vars(pwd)
 
             param = self._create_parameters(request)
-            _connector = self.create_connector(param)
-            return True
+            return param.test_connection()
         except Exception as e:
             logger.error(f"Test connection Failure!{str(e)}")
             raise ValueError(f"Test connection Failure!{str(e)}")

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connector_manager.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connector_manager.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dbgpt_serve.datasource.api.schemas import DatasourceCreateRequest
+from dbgpt_serve.datasource.manages.connector_manager import ConnectorManager
+
+
+def test_connection_delegates_to_parameter_probe(monkeypatch):
+    manager = object.__new__(ConnectorManager)
+    parameters = MagicMock()
+    parameters.test_connection.return_value = True
+    monkeypatch.setattr(manager, "_create_parameters", lambda request: parameters)
+    request = DatasourceCreateRequest(type="starrocks", params={})
+
+    assert manager.test_connection(request) is True
+    parameters.test_connection.assert_called_once_with()
+    parameters.create_connector.assert_not_called()
+
+
+def test_connection_preserves_authentication_failure(monkeypatch):
+    manager = object.__new__(ConnectorManager)
+    parameters = MagicMock()
+    parameters.test_connection.side_effect = RuntimeError("1045 Access denied")
+    monkeypatch.setattr(manager, "_create_parameters", lambda request: parameters)
+    request = DatasourceCreateRequest(type="starrocks", params={})
+
+    with pytest.raises(ValueError, match="1045 Access denied"):
+        manager.test_connection(request)
+
+
+def test_connection_reports_missing_password_environment_variable(monkeypatch):
+    manager = object.__new__(ConnectorManager)
+    create_parameters = MagicMock()
+    monkeypatch.setattr(manager, "_create_parameters", create_parameters)
+    monkeypatch.delenv("DBGPT_TEST_MISSING_PASSWORD", raising=False)
+    request = DatasourceCreateRequest(
+        type="starrocks",
+        params={"password": "${env:DBGPT_TEST_MISSING_PASSWORD}"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Environment variable DBGPT_TEST_MISSING_PASSWORD not found",
+    ):
+        manager.test_connection(request)
+
+    create_parameters.assert_not_called()


### PR DESCRIPTION
## Summary

- Test RDBMS connectivity without constructing a connector or reflecting schemas.
- Skip eager SQLAlchemy metadata reflection for StarRocks.
- Read StarRocks table metadata directly from `information_schema`.
- Preserve VARCHAR lengths and DECIMAL precision/scale during type parsing.
- Skip only concurrently removed tables while preserving authentication and network failures.
- Avoid sampling StarRocks aggregate-state columns.

## Related issue

Related to #1698. That issue describes the same eager-reflection failure class, while this change is intentionally scoped to StarRocks.

## Validation

- RDBMS regression suite: `47 passed, 1 deselected`.
- The deselected SQLite `test_query_ex` assertion also fails on the current `main` branch and is unrelated to this change.
- Ruff lint and format checks passed for the changed files.
- `git diff --check` passed.

## Compatibility

Non-RDBMS datasources retain connector-based connection testing. RDBMS probes use SQLAlchemy `select(1)`, allowing each dialect to render the appropriate connectivity query. Authentication and network errors are not swallowed.

A real StarRocks integration environment was not available, so StarRocks behavior is covered by focused connector and dialect tests.