### PR TITLE
fix(agent): bound database context and load schemas on demand

### DIFF
--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -31,6 +31,7 @@ from dbgpt_app.openapi.api_view_model import (
 from dbgpt_serve.datasource.manages import ConnectorManager
 from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 
+from .database_context import build_database_context
 from .react_final import AgentFinalAnswer, FinalAnswerAssembler
 from .subagent.dispatcher import DISPATCH_PROMPT_SECTION, make_dispatch_tool
 from .subagent.history import (
@@ -1398,20 +1399,17 @@ async def _react_agent_stream_impl(
         try:
             local_db_manager = ConnectorManager.get_instance(CFG.SYSTEM_APP)
             database_connector = local_db_manager.get_connector(database_name)
-            table_names = list(database_connector.get_table_names())
-            table_info = database_connector.get_table_info_no_throw()
-            database_context = f"""
-## 数据库信息
-- 数据库名: {database_name}
-- 可用表: {", ".join(table_names)}
-- 表结构:
-{table_info}
-- 使用 'sql_query' 工具执行 SQL 查询
-- **只允许 SELECT 查询，禁止 INSERT/UPDATE/DELETE/DROP/ALTER/TRUNCATE**
-"""
+            database_context, table_names, mentioned_tables = build_database_context(
+                database_name,
+                user_input,
+                database_connector,
+                database_tools_enabled=tool_mode != "knowledge",
+            )
             logger.info(
-                f"Loaded database connector: {database_name} "
-                f"(tables: {', '.join(table_names)})"
+                "Loaded database connector: %s (tables=%d, mentioned=%s)",
+                database_name,
+                len(table_names),
+                mentioned_tables,
             )
         except Exception as e:
             logger.warning(f"Failed to load database connector: {e}", exc_info=e)
@@ -1904,6 +1902,7 @@ print(json.dumps(summary, ensure_ascii=False))
     # ── Import built-in tools from tools/ directory ──
     from dbgpt_app.openapi.api_v1.tools import (
         make_code_interpreter,
+        make_database_tools,
         make_execute_analysis,
         make_execute_skill_script_file,
         make_execute_tool,
@@ -1916,7 +1915,6 @@ print(json.dumps(summary, ensure_ascii=False))
         make_question,
         make_read_file,
         make_shell_interpreter,
-        make_sql_query,
         make_todowrite,
     )
     # ── Build tool instances via factory functions ──────────────────────────
@@ -1958,7 +1956,7 @@ print(json.dumps(summary, ensure_ascii=False))
     else:
         # No knowledge space connected — use legacy knowledge_retrieve (no-op without resources)
         kb_tool_list = [make_knowledge_retrieve(react_state, knowledge_resources)]
-    sql_query_tool = make_sql_query(react_state, database_connector)
+    database_tools = make_database_tools(react_state, database_connector)
     code_interpreter_tool = make_code_interpreter(react_state)
     shell_interpreter_tool = make_shell_interpreter(react_state)
     html_interpreter_tool = make_html_interpreter(react_state, DEFAULT_SKILLS_DIR)
@@ -2372,6 +2370,10 @@ If template_path returns "Template not found", immediately switch to the default
    {available_images_hint}
 6. **sql_query**: Execute a read-only SQL query against the selected database.
 Parameters: {{"sql": "SELECT statement"}}
+6.1. **list_database_tables**: List or search table names without loading schemas.
+Parameters: {{"query": "optional name fragment", "limit": 50}}
+6.2. **get_table_schema**: Load one table schema on demand.
+Parameters: {{"table_name": "exact table name"}}
 7. **todowrite**: Create and manage a structured task list. Use for complex tasks
 (3+ steps) to plan and track progress. Pass the FULL list every time. Each item:
 {{"content": "description", "status": "pending|in_progress|completed|cancelled",
@@ -2439,7 +2441,9 @@ Action Input: The JSON format of tool parameters
                     execute_skill_script_file_tool,
                     shell_interpreter_tool,
                     html_interpreter_tool,
-                    sql_query_tool,
+                ]
+                + database_tools
+                + [
                     todowrite_tool,
                     question_tool,
                     Terminate(),
@@ -2573,6 +2577,10 @@ Parameters: {{"path": "file path like src/main.py", "start_line": "start line (o
 Parameters: {{"query": "search query in natural language", "top_k": "number of results (optional)"}}
 {codegraph_section}14. **sql_query**: Execute a read-only SQL query against the selected database.
 Parameters: {{"sql": "SELECT statement"}}
+14.1. **list_database_tables**: List or search table names without loading schemas.
+Parameters: {{"query": "optional name fragment", "limit": 50}}
+14.2. **get_table_schema**: Load one table schema on demand.
+Parameters: {{"table_name": "exact table name"}}
 15. **load_tools**: Resolve required tools for the selected skill. Parameters: none.
 16. **execute_tool**: Execute a tool by name with JSON args.
 Parameters: {{"tool_name": "tool name", "args": {{parameters}}}}
@@ -2646,7 +2654,9 @@ Action Input: The JSON format of tool parameters
                     execute_analysis_tool,
                     shell_interpreter_tool,
                     html_interpreter_tool,
-                    sql_query_tool,
+                ]
+                + database_tools
+                + [
                     read_file_tool,
                     todowrite_tool,
                     execute_tool_tool,

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/agentic_data_api.py
@@ -31,7 +31,7 @@ from dbgpt_app.openapi.api_view_model import (
 from dbgpt_serve.datasource.manages import ConnectorManager
 from dbgpt_serve.utils.auth import UserRequest, get_user_from_headers
 
-from .database_context import build_database_context
+from .database_context import build_database_context, build_database_tools_prompt
 from .react_final import AgentFinalAnswer, FinalAnswerAssembler
 from .subagent.dispatcher import DISPATCH_PROMPT_SECTION, make_dispatch_tool
 from .subagent.history import (
@@ -1957,6 +1957,8 @@ print(json.dumps(summary, ensure_ascii=False))
         # No knowledge space connected — use legacy knowledge_retrieve (no-op without resources)
         kb_tool_list = [make_knowledge_retrieve(react_state, knowledge_resources)]
     database_tools = make_database_tools(react_state, database_connector)
+    skill_database_tools_prompt = build_database_tools_prompt(tool_mode, 6)
+    full_database_tools_prompt = build_database_tools_prompt(tool_mode, 14)
     code_interpreter_tool = make_code_interpreter(react_state)
     shell_interpreter_tool = make_shell_interpreter(react_state)
     html_interpreter_tool = make_html_interpreter(react_state, DEFAULT_SKILLS_DIR)
@@ -2368,12 +2370,7 @@ to this tool.
 If template_path returns "Template not found", immediately switch to the default
 `html` parameter usage.
    {available_images_hint}
-6. **sql_query**: Execute a read-only SQL query against the selected database.
-Parameters: {{"sql": "SELECT statement"}}
-6.1. **list_database_tables**: List or search table names without loading schemas.
-Parameters: {{"query": "optional name fragment", "limit": 50}}
-6.2. **get_table_schema**: Load one table schema on demand.
-Parameters: {{"table_name": "exact table name"}}
+{skill_database_tools_prompt}
 7. **todowrite**: Create and manage a structured task list. Use for complex tasks
 (3+ steps) to plan and track progress. Pass the FULL list every time. Each item:
 {{"content": "description", "status": "pending|in_progress|completed|cancelled",
@@ -2575,12 +2572,7 @@ Parameters: {{"query": "search keyword", "path": "directory filter (optional)", 
 Parameters: {{"path": "file path like src/main.py", "start_line": "start line (optional)", "end_line": "end line (optional, 0 = to end)"}}
 13. **semantic_search**: Semantic search in the knowledge base. Use when kb_grep returns insufficient results.
 Parameters: {{"query": "search query in natural language", "top_k": "number of results (optional)"}}
-{codegraph_section}14. **sql_query**: Execute a read-only SQL query against the selected database.
-Parameters: {{"sql": "SELECT statement"}}
-14.1. **list_database_tables**: List or search table names without loading schemas.
-Parameters: {{"query": "optional name fragment", "limit": 50}}
-14.2. **get_table_schema**: Load one table schema on demand.
-Parameters: {{"table_name": "exact table name"}}
+{codegraph_section}{full_database_tools_prompt}
 15. **load_tools**: Resolve required tools for the selected skill. Parameters: none.
 16. **execute_tool**: Execute a tool by name with JSON args.
 Parameters: {{"tool_name": "tool name", "args": {{parameters}}}}

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
@@ -9,7 +9,26 @@ logger = logging.getLogger(__name__)
 DATABASE_CONTEXT_MAX_CHARS = 12_000
 DATABASE_SCHEMA_CONTEXT_MAX_CHARS = 8_000
 DATABASE_TABLE_PREVIEW_LIMIT = 40
+DATABASE_TABLE_PREVIEW_MAX_CHARS = 2_000
 DATABASE_MENTIONED_TABLE_LIMIT = 5
+DATABASE_MENTIONED_TABLES_MAX_CHARS = 1_000
+DATABASE_NAME_MAX_CHARS = 256
+
+
+def build_database_tools_prompt(tool_mode: str, section_number: int) -> str:
+    """Describe database tools only when the current mode registers them."""
+    if tool_mode == "knowledge":
+        return ""
+    return f"""
+{section_number}. **sql_query**: Execute a read-only SQL query against the selected
+database.
+Parameters: {{"sql": "SELECT statement"}}
+{section_number}.1. **list_database_tables**: List or search table names without
+loading schemas.
+Parameters: {{"query": "optional name fragment", "limit": 50}}
+{section_number}.2. **get_table_schema**: Load one table schema on demand.
+Parameters: {{"table_name": "exact table name"}}
+""".strip()
 
 
 def truncate_text(text: str, max_chars: int) -> str:
@@ -91,9 +110,13 @@ def build_database_context(
             )
             schema = f"Schema lookup failed: {error}"
         schema = truncate_text(schema, DATABASE_SCHEMA_CONTEXT_MAX_CHARS)
+        formatted_mentioned_tables = truncate_text(
+            format_table_names(mentioned_tables),
+            DATABASE_MENTIONED_TABLES_MAX_CHARS,
+        )
         schema_section = (
             f"- Tables detected in the user request: "
-            f"{format_table_names(mentioned_tables)}\n"
+            f"{formatted_mentioned_tables}\n"
             f"- Schemas for detected tables:\n{schema}"
         )
     else:
@@ -102,16 +125,20 @@ def build_database_context(
             "- No schema is embedded. Discover tables and request schemas on demand."
         )
 
-    safe_database_name = str(database_name).replace("\r", " ").replace("\n", " ")
-    formatted_preview = format_table_names(preview_tables)
+    safe_database_name = (str(database_name).replace("\r", " ").replace("\n", " "))[
+        :DATABASE_NAME_MAX_CHARS
+    ]
+    formatted_preview = truncate_text(
+        format_table_names(preview_tables), DATABASE_TABLE_PREVIEW_MAX_CHARS
+    )
     context = f"""
 ## Database
+{tool_guidance}
+- Only run read-only SELECT statements. Never run write or DDL statements.
 - Name: {safe_database_name}
 - Total tables: {len(table_names)}
 - Table preview (up to {DATABASE_TABLE_PREVIEW_LIMIT}): {formatted_preview}
-{tool_guidance}
 {schema_section}
-- Only run read-only SELECT statements. Never run write or DDL statements.
 """.strip()
     return (
         truncate_text(context, DATABASE_CONTEXT_MAX_CHARS),

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
@@ -1,0 +1,120 @@
+"""Build bounded database context for the ReAct agent."""
+
+import logging
+import re
+from typing import Any, Iterable, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+DATABASE_CONTEXT_MAX_CHARS = 12_000
+DATABASE_SCHEMA_CONTEXT_MAX_CHARS = 8_000
+DATABASE_TABLE_PREVIEW_LIMIT = 40
+DATABASE_MENTIONED_TABLE_LIMIT = 5
+
+
+def truncate_text(text: str, max_chars: int) -> str:
+    """Truncate text to a strict character budget."""
+    if len(text) <= max_chars:
+        return text
+    suffix = f"\n... [truncated at {max_chars} characters]"
+    return text[: max_chars - len(suffix)] + suffix
+
+
+def get_database_table_names(database_connector: Any) -> List[str]:
+    """Return stable, unique table names exposed by a connector."""
+    names: Iterable[Any] = database_connector.get_table_names()
+    return sorted({str(name) for name in names}, key=str.casefold)
+
+
+def find_mentioned_tables(
+    user_input: str,
+    table_names: Sequence[str],
+    limit: int = DATABASE_MENTIONED_TABLE_LIMIT,
+) -> List[str]:
+    """Find explicitly named tables using identifier-safe, exact matching."""
+    matches: List[Tuple[int, str]] = []
+    for table_name in table_names:
+        pattern = rf"(?<![\w$]){re.escape(table_name)}(?![\w$])"
+        match = re.search(pattern, user_input, flags=re.IGNORECASE)
+        if match:
+            matches.append((match.start(), table_name))
+    matches.sort(key=lambda item: (item[0], item[1].casefold()))
+    return [table_name for _, table_name in matches[: max(0, limit)]]
+
+
+def format_table_names(table_names: Sequence[str]) -> str:
+    """Format table names as escaped inline code for prompt/tool output."""
+    escaped_names = [
+        str(name).replace("`", "``").replace("\r", " ").replace("\n", " ")
+        for name in table_names
+    ]
+    return ", ".join(f"`{name}`" for name in escaped_names)
+
+
+def build_database_context(
+    database_name: str,
+    user_input: str,
+    database_connector: Any,
+    database_tools_enabled: bool = True,
+) -> Tuple[str, List[str], List[str]]:
+    """Build a bounded prompt context without dumping the whole database schema."""
+    table_names = get_database_table_names(database_connector)
+    mentioned_tables = find_mentioned_tables(user_input, table_names)
+
+    preview_tables = list(mentioned_tables)
+    for table_name in table_names:
+        if table_name not in preview_tables:
+            preview_tables.append(table_name)
+        if len(preview_tables) >= DATABASE_TABLE_PREVIEW_LIMIT:
+            break
+
+    if database_tools_enabled:
+        tool_guidance = """
+- The `list_database_tables`, `get_table_schema`, and `sql_query` tools are already
+  registered. Call them directly when database information is needed.
+- Do not terminate or claim that database tools are unavailable merely because a
+  table schema is not embedded below.
+""".strip()
+    else:
+        tool_guidance = (
+            "- Database tools are disabled because this request is in knowledge-only "
+            "mode."
+        )
+
+    if mentioned_tables:
+        try:
+            schema = database_connector.get_table_info_no_throw(mentioned_tables)
+        except Exception as error:
+            logger.warning(
+                "Failed to load schemas for explicitly mentioned tables",
+                exc_info=error,
+            )
+            schema = f"Schema lookup failed: {error}"
+        schema = truncate_text(schema, DATABASE_SCHEMA_CONTEXT_MAX_CHARS)
+        schema_section = (
+            f"- Tables detected in the user request: "
+            f"{format_table_names(mentioned_tables)}\n"
+            f"- Schemas for detected tables:\n{schema}"
+        )
+    else:
+        schema_section = (
+            "- Tables detected in the user request: none\n"
+            "- No schema is embedded. Discover tables and request schemas on demand."
+        )
+
+    safe_database_name = str(database_name).replace("\r", " ").replace("\n", " ")
+    formatted_preview = format_table_names(preview_tables)
+    context = f"""
+## Database
+- Name: {safe_database_name}
+- Total tables: {len(table_names)}
+- Table preview (up to {DATABASE_TABLE_PREVIEW_LIMIT}): {formatted_preview}
+{tool_guidance}
+{schema_section}
+- Only run read-only SELECT statements. Never run write or DDL statements.
+""".strip()
+    return (
+        truncate_text(context, DATABASE_CONTEXT_MAX_CHARS),
+        table_names,
+        mentioned_tables,
+    )

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/database_context.py
@@ -70,6 +70,26 @@ def format_table_names(table_names: Sequence[str]) -> str:
     return ", ".join(f"`{name}`" for name in escaped_names)
 
 
+def format_table_names_bounded(table_names: Sequence[str], max_chars: int) -> str:
+    """Format a prefix of whole table names within a strict character budget."""
+    if max_chars <= 0 or not table_names:
+        return ""
+
+    formatted_names = [format_table_names([name]) for name in table_names]
+    for included_count in range(len(formatted_names), -1, -1):
+        parts = formatted_names[:included_count]
+        omitted_count = len(formatted_names) - included_count
+        if omitted_count:
+            noun = "table name" if omitted_count == 1 else "table names"
+            parts.append(f"... [{omitted_count} {noun} omitted]")
+        candidate = ", ".join(parts)
+        if len(candidate) <= max_chars:
+            return candidate
+
+    omitted_marker = f"... [{len(formatted_names)} table names omitted]"
+    return omitted_marker[:max_chars]
+
+
 def build_database_context(
     database_name: str,
     user_input: str,
@@ -110,8 +130,8 @@ def build_database_context(
             )
             schema = f"Schema lookup failed: {error}"
         schema = truncate_text(schema, DATABASE_SCHEMA_CONTEXT_MAX_CHARS)
-        formatted_mentioned_tables = truncate_text(
-            format_table_names(mentioned_tables),
+        formatted_mentioned_tables = format_table_names_bounded(
+            mentioned_tables,
             DATABASE_MENTIONED_TABLES_MAX_CHARS,
         )
         schema_section = (
@@ -128,8 +148,8 @@ def build_database_context(
     safe_database_name = (str(database_name).replace("\r", " ").replace("\n", " "))[
         :DATABASE_NAME_MAX_CHARS
     ]
-    formatted_preview = truncate_text(
-        format_table_names(preview_tables), DATABASE_TABLE_PREVIEW_MAX_CHARS
+    formatted_preview = format_table_names_bounded(
+        preview_tables, DATABASE_TABLE_PREVIEW_MAX_CHARS
     )
     context = f"""
 ## Database

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
@@ -5,6 +5,7 @@ from dbgpt_app.openapi.api_v1.database_context import (
     DATABASE_SCHEMA_CONTEXT_MAX_CHARS,
     DATABASE_TABLE_PREVIEW_LIMIT,
     build_database_context,
+    build_database_tools_prompt,
 )
 
 
@@ -80,3 +81,25 @@ def test_knowledge_mode_does_not_claim_database_tools_are_registered():
 
     assert "database tools are disabled" in context.lower()
     assert "tools are already" not in context
+
+
+def test_database_tool_prompt_matches_tool_mode():
+    assert build_database_tools_prompt("knowledge", 6) == ""
+
+    prompt = build_database_tools_prompt("full", 14)
+    assert "14. **sql_query**" in prompt
+    assert "14.1. **list_database_tables**" in prompt
+    assert "14.2. **get_table_schema**" in prompt
+
+
+def test_mandatory_guidance_survives_long_table_names_and_schema():
+    table_names = [f"table_{index}_{'x' * 220}" for index in range(40)]
+    connector = _Connector(table_names, schema_size=50_000)
+
+    context, _, _ = build_database_context(
+        "warehouse", f"Inspect {table_names[0]}", connector
+    )
+
+    assert len(context) <= DATABASE_CONTEXT_MAX_CHARS
+    assert "Only run read-only SELECT statements" in context
+    assert "tools are already\n  registered" in context

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
@@ -1,0 +1,82 @@
+"""Tests for bounded ReAct database context construction."""
+
+from dbgpt_app.openapi.api_v1.database_context import (
+    DATABASE_CONTEXT_MAX_CHARS,
+    DATABASE_SCHEMA_CONTEXT_MAX_CHARS,
+    DATABASE_TABLE_PREVIEW_LIMIT,
+    build_database_context,
+)
+
+
+class _Connector:
+    def __init__(self, table_names, schema_size=0):
+        self.table_names = table_names
+        self.schema_calls = []
+        self.schema_size = schema_size
+
+    def get_table_names(self):
+        return self.table_names
+
+    def get_table_info_no_throw(self, table_names=None):
+        self.schema_calls.append(table_names)
+        tables = table_names or self.table_names
+        schema = "\n".join(f"CREATE TABLE `{name}` (`id` BIGINT);" for name in tables)
+        if self.schema_size:
+            schema += "x" * self.schema_size
+        return schema
+
+
+def test_large_database_context_is_bounded_without_eager_schema_loading():
+    connector = _Connector([f"table_{index:04d}" for index in range(1000)])
+
+    context, table_names, mentioned_tables = build_database_context(
+        "warehouse", "summarize recent activity", connector
+    )
+
+    assert len(context) <= DATABASE_CONTEXT_MAX_CHARS
+    assert len(table_names) == 1000
+    assert mentioned_tables == []
+    assert connector.schema_calls == []
+    assert context.count("`table_") == DATABASE_TABLE_PREVIEW_LIMIT
+    assert "CREATE TABLE" not in context
+
+
+def test_context_only_embeds_schema_for_explicitly_mentioned_table():
+    connector = _Connector(
+        ["ads_risk_user_risk_1h", "ads_risk_user_risk_1h_archive", "other_table"]
+    )
+
+    context, _, mentioned_tables = build_database_context(
+        "uat",
+        "Build a dashboard from ads_risk_user_risk_1h.",
+        connector,
+    )
+
+    assert mentioned_tables == ["ads_risk_user_risk_1h"]
+    assert connector.schema_calls == [["ads_risk_user_risk_1h"]]
+    assert "CREATE TABLE `ads_risk_user_risk_1h`" in context
+    assert "CREATE TABLE `ads_risk_user_risk_1h_archive`" not in context
+    assert "already\n  registered" in context
+
+
+def test_embedded_schema_has_a_strict_budget():
+    connector = _Connector(["wide_table"], schema_size=50_000)
+
+    context, _, _ = build_database_context("warehouse", "Inspect wide_table", connector)
+
+    assert len(context) <= DATABASE_CONTEXT_MAX_CHARS
+    assert f"truncated at {DATABASE_SCHEMA_CONTEXT_MAX_CHARS} characters" in context
+
+
+def test_knowledge_mode_does_not_claim_database_tools_are_registered():
+    connector = _Connector(["events"])
+
+    context, _, _ = build_database_context(
+        "warehouse",
+        "Summarize the knowledge base",
+        connector,
+        database_tools_enabled=False,
+    )
+
+    assert "database tools are disabled" in context.lower()
+    assert "tools are already" not in context

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_context.py
@@ -2,10 +2,13 @@
 
 from dbgpt_app.openapi.api_v1.database_context import (
     DATABASE_CONTEXT_MAX_CHARS,
+    DATABASE_MENTIONED_TABLES_MAX_CHARS,
     DATABASE_SCHEMA_CONTEXT_MAX_CHARS,
     DATABASE_TABLE_PREVIEW_LIMIT,
+    DATABASE_TABLE_PREVIEW_MAX_CHARS,
     build_database_context,
     build_database_tools_prompt,
+    format_table_names_bounded,
 )
 
 
@@ -103,3 +106,61 @@ def test_mandatory_guidance_survives_long_table_names_and_schema():
     assert len(context) <= DATABASE_CONTEXT_MAX_CHARS
     assert "Only run read-only SELECT statements" in context
     assert "tools are already\n  registered" in context
+
+
+def test_bounded_table_names_never_split_an_identifier():
+    table_names = [f"table_{index}_{'x' * 300}" for index in range(5)]
+
+    formatted = format_table_names_bounded(table_names, 1_000)
+
+    assert len(formatted) <= 1_000
+    assert formatted.endswith("[2 table names omitted]")
+    assert all(f"`{name}`" in formatted for name in table_names[:3])
+    assert all(name not in formatted for name in table_names[3:])
+    assert formatted.count("`") == 6
+
+
+def test_bounded_table_names_omit_an_individually_oversized_name():
+    table_name = "table_" + "x" * 1_100
+
+    formatted = format_table_names_bounded([table_name], 100)
+
+    assert formatted == "... [1 table name omitted]"
+    assert table_name[:50] not in formatted
+
+
+def test_context_keeps_multiple_long_mentioned_names_intact():
+    table_names = [f"table_{index}_{'x' * 300}" for index in range(8)]
+    connector = _Connector(table_names)
+
+    context, _, mentioned_tables = build_database_context(
+        "warehouse", "Inspect " + " and ".join(table_names[:5]), connector
+    )
+
+    detected_line = next(
+        line
+        for line in context.splitlines()
+        if line.startswith("- Tables detected in the user request:")
+    )
+    detected_names = detected_line.split(": ", 1)[1]
+    preview_line = next(
+        line for line in context.splitlines() if line.startswith("- Table preview")
+    )
+    preview_names = preview_line.split(": ", 1)[1]
+
+    assert mentioned_tables == table_names[:5]
+    assert connector.schema_calls == [table_names[:5]]
+    assert len(detected_names) <= DATABASE_MENTIONED_TABLES_MAX_CHARS
+    assert len(preview_names) <= DATABASE_TABLE_PREVIEW_MAX_CHARS
+    assert detected_names.endswith("[2 table names omitted]")
+    assert preview_names.endswith("[2 table names omitted]")
+    assert all(
+        fragment.strip("`") in table_names
+        for fragment in detected_names.split(", ")
+        if fragment.startswith("`")
+    )
+    assert all(
+        fragment.strip("`") in table_names
+        for fragment in preview_names.split(", ")
+        if fragment.startswith("`")
+    )

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
@@ -87,6 +87,25 @@ def test_list_database_tables_filters_and_limits_results():
     assert "`sales_monthly`" not in content
 
 
+def test_list_database_tables_never_splits_long_names():
+    table_names = [f"table_{index}_{'x' * 300}" for index in range(100)]
+    list_tool = make_list_database_tables(_Connector(table_names))
+
+    content = _content(list_tool(limit=100))
+    formatted_names = content.splitlines()[1]
+    rendered_names = [
+        fragment for fragment in formatted_names.split(", ") if fragment.startswith("`")
+    ]
+
+    assert len(content) <= DATABASE_TOOL_OUTPUT_MAX_CHARS
+    assert "table names omitted" in formatted_names
+    assert rendered_names
+    assert all(
+        fragment.endswith("`") and fragment.strip("`") in table_names
+        for fragment in rendered_names
+    )
+
+
 def test_database_tool_factory_is_shared_by_agent_modes():
     tools = make_database_tools({}, _Connector(["events"]))
 

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
@@ -1,0 +1,80 @@
+"""Tests for bounded database schema-discovery tools."""
+
+import json
+
+from dbgpt_app.openapi.api_v1.tools.database import (
+    DATABASE_TOOL_OUTPUT_MAX_CHARS,
+    make_database_tools,
+    make_get_table_schema,
+    make_list_database_tables,
+)
+
+
+class _Connector:
+    def __init__(self, table_names, schema_size=0):
+        self.table_names = table_names
+        self.schema_calls = []
+        self.schema_size = schema_size
+
+    def get_table_names(self):
+        return self.table_names
+
+    def get_table_info_no_throw(self, table_names=None):
+        self.schema_calls.append(table_names)
+        tables = table_names or self.table_names
+        schema = "\n".join(f"CREATE TABLE `{name}` (`id` BIGINT);" for name in tables)
+        if self.schema_size:
+            schema += "x" * self.schema_size
+        return schema
+
+    def run(self, sql):
+        return [[("value",)], (1,)]
+
+
+def _content(tool_result: str) -> str:
+    return json.loads(tool_result)["chunks"][0]["content"]
+
+
+def test_get_table_schema_validates_name_and_caches_result():
+    connector = _Connector(["Events"])
+    schema_tool = make_get_table_schema(connector)
+
+    unknown = _content(schema_tool("missing"))
+    first = _content(schema_tool("events"))
+    second = _content(schema_tool("`Events`"))
+
+    assert "Unknown or ambiguous table" in unknown
+    assert "CREATE TABLE `Events`" in first
+    assert second == first
+    assert connector.schema_calls == [["Events"]]
+
+
+def test_get_table_schema_output_is_bounded():
+    connector = _Connector(["wide_table"], schema_size=50_000)
+    schema_tool = make_get_table_schema(connector)
+
+    content = _content(schema_tool("wide_table"))
+
+    assert len(content) <= DATABASE_TOOL_OUTPUT_MAX_CHARS
+    assert f"truncated at {DATABASE_TOOL_OUTPUT_MAX_CHARS} characters" in content
+
+
+def test_list_database_tables_filters_and_limits_results():
+    connector = _Connector(["sales_daily", "sales_monthly", "users"])
+    list_tool = make_list_database_tables(connector)
+
+    content = _content(list_tool(query="SALES", limit=1))
+
+    assert "Matched 2 of 3 tables; showing 1" in content
+    assert "`sales_daily`" in content
+    assert "`sales_monthly`" not in content
+
+
+def test_database_tool_factory_is_shared_by_agent_modes():
+    tools = make_database_tools({}, _Connector(["events"]))
+
+    assert [tool.__name__ for tool in tools] == [
+        "sql_query",
+        "list_database_tables",
+        "get_table_schema",
+    ]

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tests/test_database_tools.py
@@ -3,6 +3,7 @@
 import json
 
 from dbgpt_app.openapi.api_v1.tools.database import (
+    DATABASE_SCHEMA_CACHE_MAX_ENTRIES,
     DATABASE_TOOL_OUTPUT_MAX_CHARS,
     make_database_tools,
     make_get_table_schema,
@@ -57,6 +58,22 @@ def test_get_table_schema_output_is_bounded():
 
     assert len(content) <= DATABASE_TOOL_OUTPUT_MAX_CHARS
     assert f"truncated at {DATABASE_TOOL_OUTPUT_MAX_CHARS} characters" in content
+
+
+def test_get_table_schema_cache_evicts_least_recently_used_entry():
+    table_names = [
+        f"table_{index}" for index in range(DATABASE_SCHEMA_CACHE_MAX_ENTRIES + 1)
+    ]
+    connector = _Connector(table_names, schema_size=50_000)
+    schema_tool = make_get_table_schema(connector)
+
+    for table_name in table_names:
+        content = _content(schema_tool(table_name))
+        assert len(content) <= DATABASE_TOOL_OUTPUT_MAX_CHARS
+
+    _content(schema_tool(table_names[0]))
+
+    assert connector.schema_calls.count([table_names[0]]) == 2
 
 
 def test_list_database_tables_filters_and_limits_results():

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/__init__.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/__init__.py
@@ -1,6 +1,7 @@
 """Built-in tools for the ReAct agent in agentic_data_api."""
 
 from .code_interpreter import make_code_interpreter
+from .database import make_database_tools
 from .execute_analysis import make_execute_analysis
 from .execute_tool import make_execute_tool
 from .html_interpreter import make_html_interpreter
@@ -18,6 +19,7 @@ from .todowrite import make_todowrite
 
 __all__ = [
     "make_code_interpreter",
+    "make_database_tools",
     "make_execute_analysis",
     "make_execute_tool",
     "make_html_interpreter",

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence
 from dbgpt.agent.resource.tool.base import tool
 
 from ..database_context import (
-    format_table_names,
+    format_table_names_bounded,
     get_database_table_names,
     truncate_text,
 )
@@ -75,13 +75,14 @@ def make_list_database_tables(database_connector: Optional[Any]):
             ]
             safe_limit = max(1, min(int(limit), DATABASE_TABLE_LIST_LIMIT))
             displayed = matched[:safe_limit]
-            content = (
+            prefix = (
                 f"Matched {len(matched)} of {len(table_names)} tables; "
-                f"showing {len(displayed)}:\n{format_table_names(displayed)}"
+                f"showing {len(displayed)}:\n"
             )
-            return _tool_response(
-                truncate_text(content, DATABASE_TOOL_OUTPUT_MAX_CHARS), "markdown"
+            formatted_names = format_table_names_bounded(
+                displayed, DATABASE_TOOL_OUTPUT_MAX_CHARS - len(prefix)
             )
+            return _tool_response(prefix + formatted_names, "markdown")
         except Exception as error:
             return _tool_response(f"Failed to list database tables: {error}")
 

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
@@ -1,0 +1,132 @@
+"""Bounded database schema-discovery tools for the ReAct agent."""
+
+import json
+from typing import Any, Dict, List, Optional, Sequence
+
+from dbgpt.agent.resource.tool.base import tool
+
+from ..database_context import (
+    format_table_names,
+    get_database_table_names,
+    truncate_text,
+)
+from .sql_query import make_sql_query
+
+DATABASE_TOOL_OUTPUT_MAX_CHARS = 20_000
+DATABASE_TABLE_LIST_LIMIT = 100
+
+
+def _tool_response(content: str, output_type: str = "text") -> str:
+    return json.dumps(
+        {"chunks": [{"output_type": output_type, "content": content}]},
+        ensure_ascii=False,
+    )
+
+
+def _resolve_table_name(
+    requested_name: str, table_names: Sequence[str]
+) -> Optional[str]:
+    candidate = requested_name.strip().strip("`\"'")
+    if candidate in table_names:
+        return candidate
+
+    if "." in candidate:
+        unqualified = candidate.rsplit(".", 1)[1].strip().strip("`\"'")
+        if unqualified in table_names:
+            return unqualified
+        candidate = unqualified
+
+    case_insensitive_matches = [
+        table_name
+        for table_name in table_names
+        if table_name.casefold() == candidate.casefold()
+    ]
+    if len(case_insensitive_matches) == 1:
+        return case_insensitive_matches[0]
+    return None
+
+
+def make_list_database_tables(database_connector: Optional[Any]):
+    """Create a bounded table-discovery tool."""
+
+    @tool(
+        description=(
+            "List tables in the selected database. Use query for a case-insensitive "
+            "substring search. Parameters: "
+            '{"query": "optional table-name fragment", "limit": 50}'
+        )
+    )
+    def list_database_tables(query: str = "", limit: int = 50) -> str:
+        if database_connector is None:
+            return _tool_response("No database is selected.")
+
+        try:
+            table_names = get_database_table_names(database_connector)
+            normalized_query = query.strip().casefold()
+            matched = [
+                table_name
+                for table_name in table_names
+                if not normalized_query or normalized_query in table_name.casefold()
+            ]
+            safe_limit = max(1, min(int(limit), DATABASE_TABLE_LIST_LIMIT))
+            displayed = matched[:safe_limit]
+            content = (
+                f"Matched {len(matched)} of {len(table_names)} tables; "
+                f"showing {len(displayed)}:\n{format_table_names(displayed)}"
+            )
+            return _tool_response(
+                truncate_text(content, DATABASE_TOOL_OUTPUT_MAX_CHARS), "markdown"
+            )
+        except Exception as error:
+            return _tool_response(f"Failed to list database tables: {error}")
+
+    return list_database_tables
+
+
+def make_get_table_schema(database_connector: Optional[Any]):
+    """Create a validated, bounded, per-table schema lookup tool."""
+    schema_cache: Dict[str, str] = {}
+
+    @tool(
+        description=(
+            "Get the schema for one table in the selected database. The table must "
+            "exist in list_database_tables. Parameters: "
+            '{"table_name": "exact table name"}'
+        )
+    )
+    def get_table_schema(table_name: str) -> str:
+        if database_connector is None:
+            return _tool_response("No database is selected.")
+
+        try:
+            table_names = get_database_table_names(database_connector)
+            resolved_name = _resolve_table_name(table_name, table_names)
+            if resolved_name is None:
+                return _tool_response(
+                    f"Unknown or ambiguous table: {table_name}. "
+                    "Use list_database_tables to find the exact name."
+                )
+
+            if resolved_name not in schema_cache:
+                schema_cache[resolved_name] = (
+                    database_connector.get_table_info_no_throw([resolved_name])
+                )
+            schema = truncate_text(
+                schema_cache[resolved_name], DATABASE_TOOL_OUTPUT_MAX_CHARS
+            )
+            return _tool_response(schema, "markdown")
+        except Exception as error:
+            return _tool_response(f"Failed to load table schema: {error}")
+
+    return get_table_schema
+
+
+def make_database_tools(
+    react_state: Dict[str, Any], database_connector: Optional[Any]
+) -> List[Any]:
+    """Build the database tools shared by skill and full ReAct modes."""
+    return [
+        make_sql_query(react_state, database_connector),
+        make_list_database_tables(database_connector),
+        make_get_table_schema(database_connector),
+    ]

--- a/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
+++ b/packages/dbgpt-app/src/dbgpt_app/openapi/api_v1/tools/database.py
@@ -1,6 +1,7 @@
 """Bounded database schema-discovery tools for the ReAct agent."""
 
 import json
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Sequence
 
 from dbgpt.agent.resource.tool.base import tool
@@ -14,9 +15,11 @@ from .sql_query import make_sql_query
 
 DATABASE_TOOL_OUTPUT_MAX_CHARS = 20_000
 DATABASE_TABLE_LIST_LIMIT = 100
+DATABASE_SCHEMA_CACHE_MAX_ENTRIES = 32
 
 
 def _tool_response(content: str, output_type: str = "text") -> str:
+    """Serialize one tool result chunk."""
     return json.dumps(
         {"chunks": [{"output_type": output_type, "content": content}]},
         ensure_ascii=False,
@@ -26,6 +29,7 @@ def _tool_response(content: str, output_type: str = "text") -> str:
 def _resolve_table_name(
     requested_name: str, table_names: Sequence[str]
 ) -> Optional[str]:
+    """Resolve an exact or unambiguous case-insensitive table name."""
     candidate = requested_name.strip().strip("`\"'")
     if candidate in table_names:
         return candidate
@@ -57,6 +61,7 @@ def make_list_database_tables(database_connector: Optional[Any]):
         )
     )
     def list_database_tables(query: str = "", limit: int = 50) -> str:
+        """List table names using a bounded optional substring filter."""
         if database_connector is None:
             return _tool_response("No database is selected.")
 
@@ -85,7 +90,7 @@ def make_list_database_tables(database_connector: Optional[Any]):
 
 def make_get_table_schema(database_connector: Optional[Any]):
     """Create a validated, bounded, per-table schema lookup tool."""
-    schema_cache: Dict[str, str] = {}
+    schema_cache: OrderedDict[str, str] = OrderedDict()
 
     @tool(
         description=(
@@ -95,6 +100,7 @@ def make_get_table_schema(database_connector: Optional[Any]):
         )
     )
     def get_table_schema(table_name: str) -> str:
+        """Return a bounded schema for one validated table name."""
         if database_connector is None:
             return _tool_response("No database is selected.")
 
@@ -107,14 +113,16 @@ def make_get_table_schema(database_connector: Optional[Any]):
                     "Use list_database_tables to find the exact name."
                 )
 
-            if resolved_name not in schema_cache:
-                schema_cache[resolved_name] = (
-                    database_connector.get_table_info_no_throw([resolved_name])
+            if resolved_name in schema_cache:
+                schema_cache.move_to_end(resolved_name)
+            else:
+                schema_cache[resolved_name] = truncate_text(
+                    database_connector.get_table_info_no_throw([resolved_name]),
+                    DATABASE_TOOL_OUTPUT_MAX_CHARS,
                 )
-            schema = truncate_text(
-                schema_cache[resolved_name], DATABASE_TOOL_OUTPUT_MAX_CHARS
-            )
-            return _tool_response(schema, "markdown")
+                if len(schema_cache) > DATABASE_SCHEMA_CACHE_MAX_ENTRIES:
+                    schema_cache.popitem(last=False)
+            return _tool_response(schema_cache[resolved_name], "markdown")
         except Exception as error:
             return _tool_response(f"Failed to load table schema: {error}")
 


### PR DESCRIPTION
## Summary

- Stop injecting the complete database schema into the ReAct workflow prompt.
- Limit initial database context to the table count, a 40-table preview, and schemas explicitly mentioned by the user.
- Enforce strict prompt and database-tool output limits.
- Add `list_database_tables` and `get_table_schema` for on-demand discovery.
- Share the database tool set between skill and full ReAct modes.
- Log table counts and detected tables instead of the complete table list.

## Related issues

Related to #3171 and #3005. This PR reduces immutable prompt size and improves schema discovery without changing the existing ReAct protocol to native function calling.

## Validation

- Database context tests: `4 passed`.
- Verified the 1,000-table case does not eagerly load schema and remains within the configured context limit.
- Verified exact table-name matching and per-table schema injection.
- Database tool execution smoke test passed in an installed DB-GPT 0.8.1 runtime.
- Ruff lint and format checks passed for the changed files.
- Python syntax compilation and `git diff --check` passed.

The lightweight WSL environment did not contain all optional `dbgpt-app` dependencies, so the complete database-tool pytest module could not be collected locally; the same tool factories were exercised directly in the installed runtime.