### PR TITLE
feat(datasource): add editable display_name alias for connections (#2987)

### DIFF
--- a/assets/schema/dbgpt.sql
+++ b/assets/schema/dbgpt.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS `connect_config`
     `id`       int          NOT NULL AUTO_INCREMENT COMMENT 'autoincrement id',
     `db_type`  varchar(255) NOT NULL COMMENT 'db type',
     `db_name`  varchar(255) NOT NULL COMMENT 'db name',
+    `display_name` varchar(255) DEFAULT NULL COMMENT 'Human-friendly alias for display; falls back to db_name when empty',
     `db_path`  varchar(255) DEFAULT NULL COMMENT 'file db path',
     `db_host`  varchar(255) DEFAULT NULL COMMENT 'db connect host(not file db)',
     `db_port`  varchar(255) DEFAULT NULL COMMENT 'db cnnect port(not file db)',

--- a/assets/schema/upgrade/v0_8_1/upgrade_to_v0.8.1.sql
+++ b/assets/schema/upgrade/v0_8_1/upgrade_to_v0.8.1.sql
@@ -59,3 +59,6 @@ CREATE TABLE IF NOT EXISTS `dbgpt_serve_scheduled_run` (
   KEY `ix_scheduled_run_task_id` (`task_id`),
   KEY `ix_scheduled_run_started_at` (`started_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Scheduled task execution history table';
+
+-- connect_config, add editable display_name alias (#2987)
+ALTER TABLE `connect_config` ADD COLUMN `display_name` varchar(255) DEFAULT NULL COMMENT 'Human-friendly alias for display; falls back to db_name when empty';

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/schemas.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/api/schemas.py
@@ -12,6 +12,11 @@ class DatasourceServeRequest(BaseModel):
     id: Optional[int] = Field(None, description="The datasource id")
     db_type: str = Field(..., description="Database type, e.g. sqlite, mysql, etc.")
     db_name: str = Field(..., description="Database name.")
+    display_name: Optional[str] = Field(
+        "",
+        description="Human-friendly alias for display; falls back to db_name "
+        "when empty.",
+    )
     db_path: Optional[str] = Field("", description="File path for file-based database.")
     db_host: Optional[str] = Field("", description="Database host.")
     db_port: Optional[int] = Field(0, description="Database port.")
@@ -34,6 +39,11 @@ class DatasourceServeResponse(BaseModel):
     id: int = Field(None, description="The datasource id")
     db_type: str = Field(..., description="Database type, e.g. sqlite, mysql, etc.")
     db_name: str = Field(..., description="Database name.")
+    display_name: Optional[str] = Field(
+        "",
+        description="Human-friendly alias for display; falls back to db_name "
+        "when empty.",
+    )
     db_path: Optional[str] = Field("", description="File path for file-based database.")
     db_host: Optional[str] = Field("", description="Database host.")
     db_port: Optional[int] = Field(0, description="Database port.")
@@ -74,6 +84,11 @@ class DatasourceCreateRequest(BaseModel):
     )
     description: Optional[str] = Field(
         None, description="Optional description of the datasource."
+    )
+    display_name: Optional[str] = Field(
+        None,
+        description="Human-friendly alias for display; falls back to db_name "
+        "when empty.",
     )
     id: Optional[int] = Field(None, description="The datasource id")
 

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/manages/connect_config_db.py
@@ -35,6 +35,11 @@ class ConnectConfigEntity(Model):
 
     db_type = Column(String(255), nullable=False, comment="db type")
     db_name = Column(String(255), nullable=False, comment="db name")
+    display_name = Column(
+        String(255),
+        nullable=True,
+        comment="Human-friendly alias for display; falls back to db_name when empty",
+    )
     db_path = Column(String(255), nullable=True, comment="file db path")
     db_host = Column(String(255), nullable=True, comment="db connect host(not file db)")
     db_port = Column(String(255), nullable=True, comment="db connect port(not file db)")
@@ -298,6 +303,7 @@ class ConnectConfigDao(BaseDao):
             id=entity.id,
             db_type=entity.db_type,
             db_name=entity.db_name,
+            display_name=entity.display_name,
             db_path=entity.db_path,
             db_host=entity.db_host,
             db_port=entity.db_port,
@@ -333,6 +339,7 @@ class ConnectConfigDao(BaseDao):
             id=entity.id,
             db_type=entity.db_type,
             db_name=entity.db_name,
+            display_name=entity.display_name,
             db_path=entity.db_path,
             db_host=entity.db_host,
             db_port=entity.db_port,

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/service.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/service/service.py
@@ -117,15 +117,18 @@ class Service(
             else request.db_type
         )
         desc = ""
+        display_name = None
         if isinstance(request, DatasourceCreateRequest):
             connector_params: BaseDatasourceParameters = (
                 self.datasource_manager._create_parameters(request)
             )
             persisted_state = connector_params.persisted_state()
             desc = request.description
+            display_name = request.display_name
         else:
             persisted_state = model_to_dict(request)
             desc = request.comment
+            display_name = request.display_name
         if "ext_config" in persisted_state and isinstance(
             persisted_state["ext_config"], dict
         ):
@@ -133,6 +136,7 @@ class Service(
                 persisted_state["ext_config"], ensure_ascii=False
             )
         persisted_state["comment"] = desc
+        persisted_state["display_name"] = display_name
         db_name = persisted_state.get("db_name")
         datasource = self._dao.get_by_names(db_name)
         if datasource:
@@ -181,15 +185,18 @@ class Service(
             else request.db_type
         )
         desc = ""
+        display_name = None
         if isinstance(request, DatasourceCreateRequest):
             connector_params: BaseDatasourceParameters = (
                 self.datasource_manager._create_parameters(request)
             )
             persisted_state = connector_params.persisted_state()
             desc = request.description
+            display_name = request.display_name
         else:
             persisted_state = model_to_dict(request)
             desc = request.comment
+            display_name = request.display_name
         if "ext_config" in persisted_state and isinstance(
             persisted_state["ext_config"], dict
         ):
@@ -197,6 +204,7 @@ class Service(
                 persisted_state["ext_config"], ensure_ascii=False
             )
         persisted_state["comment"] = desc
+        persisted_state["display_name"] = display_name
         db_name = persisted_state.get("db_name")
         if not db_name:
             raise HTTPException(status_code=400, detail="datasource name is required")
@@ -271,6 +279,7 @@ class Service(
             type=res.db_type,
             params=param_dict,
             description=res.comment,
+            display_name=res.display_name,
             id=res.id,
             db_name=res.db_name,
             gmt_created=res.gmt_created,

--- a/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connect_config_db.py
+++ b/packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connect_config_db.py
@@ -1,0 +1,77 @@
+"""Tests for the editable display_name alias on datasource configs (#2987)."""
+
+import pytest
+
+from dbgpt.storage.metadata import db
+
+from ..manages.connect_config_db import ConnectConfigDao, ConnectConfigEntity
+
+
+@pytest.fixture(autouse=True)
+def setup_and_teardown():
+    db.init_db("sqlite:///:memory:")
+    db.create_all()
+
+    yield
+
+
+@pytest.fixture
+def dao():
+    return ConnectConfigDao()
+
+
+def test_table_has_display_name_column():
+    table = ConnectConfigEntity.__table__
+    assert "display_name" in table.columns
+
+
+def test_create_and_read_alias(dao):
+    entity = dao.create(
+        {
+            "db_type": "mysql",
+            "db_name": "prod_orders",
+            "display_name": "生产订单库(10.0.0.1)",
+            "db_host": "10.0.0.1",
+            "db_port": 3306,
+        }
+    )
+    assert entity.display_name == "生产订单库(10.0.0.1)"
+
+    stored = dao.get_by_names("prod_orders")
+    assert stored is not None
+    assert stored.display_name == "生产订单库(10.0.0.1)"
+
+
+def test_alias_optional_defaults_to_none(dao):
+    # When no alias is provided the column stays empty and callers fall back
+    # to db_name for display.
+    entity = dao.create(
+        {
+            "db_type": "mysql",
+            "db_name": "analytics",
+            "db_host": "10.0.0.2",
+            "db_port": 3306,
+        }
+    )
+    assert not entity.display_name
+
+
+def test_update_alias(dao):
+    dao.create(
+        {
+            "db_type": "mysql",
+            "db_name": "warehouse",
+            "display_name": "old-name",
+            "db_host": "10.0.0.3",
+            "db_port": 3306,
+        }
+    )
+    created = dao.get_by_names("warehouse")
+
+    dao.update(
+        {"id": created.id},
+        {"db_type": "mysql", "db_name": "warehouse", "display_name": "new-name"},
+    )
+
+    updated = dao.get_by_names("warehouse")
+    assert updated.display_name == "new-name"

--- a/web/components/chat/db-editor.tsx
+++ b/web/components/chat/db-editor.tsx
@@ -196,9 +196,7 @@ function DbEditor() {
     if (newEditorValue?.sql !== undefined) {
       return newEditorValue.sql.trim();
     }
-    const persisted = Array.isArray(editorValue)
-      ? editorValue?.[currentTabIndex ?? 0]?.sql
-      : editorValue?.sql;
+    const persisted = Array.isArray(editorValue) ? editorValue?.[currentTabIndex ?? 0]?.sql : editorValue?.sql;
     return (persisted || '').trim();
   };
 
@@ -691,7 +689,7 @@ function DbEditor() {
                     <DbEditorContent
                       layout={layout}
                       editorValue={item}
-                      liveSql={index === currentTabIndex ? newEditorValue?.sql ?? item.sql : item.sql}
+                      liveSql={index === currentTabIndex ? (newEditorValue?.sql ?? item.sql) : item.sql}
                       handleChange={value => {
                         const { sql, thoughts } = resolveSqlAndThoughts(value);
                         latestSqlRef.current = sql ?? '';

--- a/web/components/database/database-form.tsx
+++ b/web/components/database/database-form.tsx
@@ -18,6 +18,7 @@ interface DatabaseFormProps {
   getFromRenderData?: ConfigurableParams[];
   dbNames?: string[];
   description?: string; // Add description prop
+  displayName?: string; // Editable alias shown in lists
 }
 
 function DatabaseForm({
@@ -29,6 +30,7 @@ function DatabaseForm({
   getFromRenderData,
   dbNames = [],
   description = '', // Default value for description
+  displayName = '', // Default value for alias
 }: DatabaseFormProps) {
   const { t } = useTranslation();
   const [form] = Form.useForm();
@@ -50,8 +52,10 @@ function DatabaseForm({
       setParams(getFromRenderData);
       // set description
       form.setFieldValue('description', description);
+      // set alias
+      form.setFieldValue('display_name', displayName);
     }
-  }, [editValue, getFromRenderData, description, form]);
+  }, [editValue, getFromRenderData, description, displayName, form]);
 
   const handleTypeChange = (value: DBType) => {
     setSelectedType(value);
@@ -75,12 +79,13 @@ function DatabaseForm({
       //   return;
       // }
 
-      const { description, type, ...values } = formValues;
+      const { description, display_name, type, ...values } = formValues;
 
       const data = {
         type: selectedType,
         params: values,
         description: description || '',
+        display_name: display_name || '',
       };
 
       // If in edit mode, add id
@@ -131,6 +136,10 @@ function DatabaseForm({
       </FormItem>
 
       {params && <ConfigurableForm params={params} form={form} />}
+
+      <FormItem label={t('datasource_alias')} name='display_name'>
+        <Input placeholder={t('input_datasource_alias')} />
+      </FormItem>
 
       <FormItem label={t('description')} name='description'>
         <Input.TextArea rows={2} placeholder={t('input_description')} />

--- a/web/components/database/form-dialog.tsx
+++ b/web/components/database/form-dialog.tsx
@@ -15,6 +15,7 @@ interface NewFormDialogProps {
   dbNames?: string[];
   dbTypeData?: DBOption[];
   description?: string;
+  displayName?: string;
 }
 
 function FormDialog({
@@ -27,6 +28,7 @@ function FormDialog({
   getFromRenderData,
   dbNames,
   description,
+  displayName,
 }: NewFormDialogProps) {
   const { t } = useTranslation();
 
@@ -48,6 +50,7 @@ function FormDialog({
         getFromRenderData={getFromRenderData}
         dbNames={dbNames}
         description={description}
+        displayName={displayName}
       />
     </Modal>
   );

--- a/web/locales/en/common.ts
+++ b/web/locales/en/common.ts
@@ -94,6 +94,8 @@ export const CommonEn = {
   select_database_type: 'Select database type',
   description: 'Description',
   input_description: 'Please input description',
+  datasource_alias: 'Alias',
+  input_datasource_alias: 'Optional. A friendly name shown in lists; falls back to the database name when empty',
   Port: 'Port',
   Username: 'Username',
   Password: 'Password',

--- a/web/locales/zh/common.ts
+++ b/web/locales/zh/common.ts
@@ -102,6 +102,8 @@ export const CommonZh: Resources['translation'] = {
   select_database_type: '选择数据库类型',
   description: '描述',
   input_description: '请输入描述',
+  datasource_alias: '别名',
+  input_datasource_alias: '可选。展示在数据源列表中的友好名称，为空时回退显示数据库名',
   Port: '端口',
   Username: '用户名',
   Password: '密码',

--- a/web/pages/construct/database.tsx
+++ b/web/pages/construct/database.tsx
@@ -31,6 +31,7 @@ function Database() {
     dbType?: DBType;
     dbTypeData?: any[];
     description?: string;
+    displayName?: string;
   }>({ open: false });
   const [draw, setDraw] = useState<{
     open: boolean;
@@ -84,7 +85,13 @@ function Database() {
         element.default_value = item.params[element.param_name];
       }
     }
-    setModal({ open: true, info: item.id, dbType: item.type, description: item.description });
+    setModal({
+      open: true,
+      info: item.id,
+      dbType: item.type,
+      description: item.description,
+      displayName: item.display_name,
+    });
   };
 
   const onDelete = (item: DBItem) => {
@@ -204,6 +211,7 @@ function Database() {
           dbTypeList={dbTypeList}
           getFromRenderData={getFromRenderData}
           description={modal.description}
+          displayName={modal.displayName}
           choiceDBType={modal.dbType}
           editValue={modal.info}
           dbTypeData={modal.dbTypeData}
@@ -239,7 +247,7 @@ function Database() {
               {dbListByType[draw.type].map(item => (
                 <Card
                   key={item.params?.database || item.params?.path || ''}
-                  title={item.params?.database || getFileName(item.params?.path) || ''}
+                  title={item.display_name || item.params?.database || getFileName(item.params?.path) || ''}
                   extra={
                     <>
                       <RedoOutlined

--- a/web/types/db.ts
+++ b/web/types/db.ts
@@ -39,6 +39,7 @@ export type IChatDbSchema = {
   name: string;
   label: string;
   description: string;
+  display_name?: string;
   params: any[];
   parameters: any[];
   comment: string;


### PR DESCRIPTION
## Description

Closes #2987.

Datasource connections are currently displayed by their raw database name. In real deployments it is common to have multiple instances that share the **same** database name (e.g. several Oracle servers on different hosts), which makes them indistinguishable in the datasource list and Chat selector.

This PR adds an optional, **display-only** alias (`display_name`) for a datasource connection.

## Design

The connection identity in DB-GPT is `db_name`, which:
- has a `UNIQUE` constraint (`uk_db`) on `connect_config`,
- is derived from the `database` connection param (`parameter.py`: `"database": "db_name"`),
- is used everywhere as the lookup key (connector cache, db-summary embedding, the `db_name` URL param in Chat).

To keep the change safe and non-invasive, the alias is a **separate, purely presentational field** and does **not** touch `db_name` or its unique constraint:

- **Schema**: new nullable `display_name` column on `connect_config` (added to `assets/schema/dbgpt.sql` and to the `v0.8.1` upgrade script as an `ALTER TABLE` for existing MySQL deployments). The name `display_name` follows the existing convention already used by the `connector_instance` table.
- **Backend**: the field is threaded through `DatasourceCreateRequest` / `DatasourceQueryResponse` / `DatasourceServeRequest` / `DatasourceServeResponse`, the `ConnectConfigDao` (`to_request` / `to_response`), and the service `create` / `update` paths.
- **Frontend**: an alias input in the connection form (populated on edit, submitted alongside `description`), and datasource card titles now show the alias first, falling back to the database name when it is empty.
- **i18n**: added zh/en strings.
- **Tests**: added a DAO round-trip test (`test_connect_config_db.py`) covering create/read, empty-alias fallback, and update.

## Known limitations / open questions

- This PR resolves the **display** ambiguity only. Because `db_name` still equals `database` and keeps its unique constraint, you still cannot create **two** datasources whose `database` name is identical. Fully supporting that would require decoupling the connection identity from the `database` name (e.g. a dedicated surrogate key), which is a larger, higher-risk change — I left it out deliberately and am happy to follow up if maintainers prefer that direction.
- Existing **SQLite** metadata stores won't get the new column automatically (`create_all` only creates missing tables, and there's no auto-migration for existing tables in the repo). New installs are fine; existing MySQL installs are covered by the upgrade script; existing SQLite installs would need a manual `ALTER TABLE connect_config ADD COLUMN display_name VARCHAR(255)`.

## How Has This Been Tested?

- `python -m py_compile` on all changed backend files.
- Added `packages/dbgpt-serve/src/dbgpt_serve/datasource/tests/test_connect_config_db.py` (SQLite in-memory DAO round-trip).

> Note: I was unable to run the full `pytest` suite or the frontend `next build` in my local environment (missing build toolchain / node_modules), so I'd appreciate a CI run to confirm.

## Naming decision to confirm

I went with `display_name` for consistency with the existing `connector_instance.display_name`. If you'd prefer `alias`, I'm glad to rename.

---

**Note:** This branch also includes one incidental commit fixing two pre-existing `prettier/prettier` errors in `web/components/chat/db-editor.tsx` (introduced by #3199), which currently break the `build-web` check for every PR based on `main`. Happy to drop it into a separate PR if you prefer.
