### PR TITLE
feat(model): add Synthorai as a proxy LLM provider

### DIFF
--- a/configs/dbgpt-proxy-synthorai.toml
+++ b/configs/dbgpt-proxy-synthorai.toml
@@ -19,5 +19,5 @@ persist_path = "pilot/data"
 [models]
 [[models.llms]]
 name = "${env:LLM_MODEL_NAME:-claude-opus-5}"
-provider = "proxy/synthorai"
+provider = "${env:LLM_MODEL_PROVIDER:-proxy/synthorai}"
 api_key = "${env:SYNTHORAI_API_KEY}"

--- a/configs/dbgpt-proxy-synthorai.toml
+++ b/configs/dbgpt-proxy-synthorai.toml
@@ -1,0 +1,23 @@
+[system]
+language = "${env:DBGPT_LANG:-en}"
+api_keys = []
+encrypt_key = "your_secret_key"
+
+[service.web]
+host = "0.0.0.0"
+port = 5670
+
+[service.web.database]
+type = "sqlite"
+path = "pilot/meta_data/dbgpt.db"
+
+[rag.storage]
+[rag.storage.vector]
+type = "chroma"
+persist_path = "pilot/data"
+
+[models]
+[[models.llms]]
+name = "${env:LLM_MODEL_NAME:-claude-opus-5}"
+provider = "proxy/synthorai"
+api_key = "${env:SYNTHORAI_API_KEY}"

--- a/docs/docs/installation/integrations/synthorai_llm_install.md
+++ b/docs/docs/installation/integrations/synthorai_llm_install.md
@@ -1,0 +1,26 @@
+# Synthorai
+
+### [Synthorai](https://synthorai.io) serves models from Anthropic, OpenAI, Google, DeepSeek, Qwen, Moonshot and Z.ai behind a single OpenAI-compatible endpoint and API key.
+
+### This section describes how to use the Synthorai provider with DB-GPT.
+
+1. Sign up at [Synthorai](https://synthorai.io) and generate an API key.
+2. Set the environment variable `SYNTHORAI_API_KEY` with your key.
+3. Use the `configs/dbgpt-proxy-synthorai.toml` configuration when starting DB-GPT.
+
+Model ids are bare rather than vendor-prefixed — `claude-opus-5`, `gpt-5.6-sol`, `deepseek-v4-pro`, `glm-5.2` — so set `LLM_MODEL_NAME` to the id exactly as the catalog lists it.
+
+### You can look up models at [https://synthorai.io/models/](https://synthorai.io/models/)
+
+### Or you can use docker/base/Dockerfile to run DB-GPT with Synthorai:
+
+```dockerfile
+# Expose the port for the web server, if you want to run it directly from the Dockerfile
+EXPOSE 5670
+
+# Set the environment variable for the Synthorai API key
+ENV SYNTHORAI_API_KEY="***"
+
+# Just uncomment the following line in the `Dockerfile` to use Synthorai:
+CMD ["dbgpt", "start", "webserver", "--config", "configs/dbgpt-proxy-synthorai.toml"]
+```

--- a/docs/docs/installation/integrations/synthorai_llm_install.md
+++ b/docs/docs/installation/integrations/synthorai_llm_install.md
@@ -18,9 +18,13 @@ Model ids are bare rather than vendor-prefixed — `claude-opus-5`, `gpt-5.6-sol
 # Expose the port for the web server, if you want to run it directly from the Dockerfile
 EXPOSE 5670
 
-# Set the environment variable for the Synthorai API key
-ENV SYNTHORAI_API_KEY="***"
-
 # Just uncomment the following line in the `Dockerfile` to use Synthorai:
 CMD ["dbgpt", "start", "webserver", "--config", "configs/dbgpt-proxy-synthorai.toml"]
+```
+
+Pass the key in at run time rather than baking it into the image with `ENV` — a
+key set at build time stays in the image layers and travels with anyone who pulls it:
+
+```bash
+docker run -it --rm -e SYNTHORAI_API_KEY="your-key" -p 5670:5670 dbgpt:latest
 ```

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
     from dbgpt.model.proxy.llms.nvidia import NvidiaLLMClient
     from dbgpt.model.proxy.llms.ollama import OllamaLLMClient
     from dbgpt.model.proxy.llms.orcarouter import OrcaRouterLLMClient
-    from dbgpt.model.proxy.llms.synthorai import SynthoraiLLMClient
     from dbgpt.model.proxy.llms.siliconflow import SiliconFlowLLMClient
     from dbgpt.model.proxy.llms.spark import SparkLLMClient
+    from dbgpt.model.proxy.llms.synthorai import SynthoraiLLMClient
     from dbgpt.model.proxy.llms.tongyi import TongyiLLMClient
     from dbgpt.model.proxy.llms.wenxin import WenxinLLMClient
     from dbgpt.model.proxy.llms.yi import YiLLMClient

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/__init__.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from dbgpt.model.proxy.llms.nvidia import NvidiaLLMClient
     from dbgpt.model.proxy.llms.ollama import OllamaLLMClient
     from dbgpt.model.proxy.llms.orcarouter import OrcaRouterLLMClient
+    from dbgpt.model.proxy.llms.synthorai import SynthoraiLLMClient
     from dbgpt.model.proxy.llms.siliconflow import SiliconFlowLLMClient
     from dbgpt.model.proxy.llms.spark import SparkLLMClient
     from dbgpt.model.proxy.llms.tongyi import TongyiLLMClient
@@ -42,6 +43,7 @@ def __lazy_import(name):
         "NvidiaLLMClient": "dbgpt.model.proxy.llms.nvidia",
         "OllamaLLMClient": "dbgpt.model.proxy.llms.ollama",
         "OrcaRouterLLMClient": "dbgpt.model.proxy.llms.orcarouter",
+        "SynthoraiLLMClient": "dbgpt.model.proxy.llms.synthorai",
         "DeepseekLLMClient": "dbgpt.model.proxy.llms.deepseek",
         "GiteeLLMClient": "dbgpt.model.proxy.llms.gitee",
         "InfiniAILLMClient": "dbgpt.model.proxy.llms.infiniai",
@@ -76,6 +78,7 @@ __all__ = [
     "NvidiaLLMClient",
     "OllamaLLMClient",
     "OrcaRouterLLMClient",
+    "SynthoraiLLMClient",
     "DeepseekLLMClient",
     "GiteeLLMClient",
     "InfiniAILLMClient",

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
@@ -1,0 +1,187 @@
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+
+from dbgpt.core import ModelMetadata
+from dbgpt.core.awel.flow import (
+    TAGS_ORDER_HIGH,
+    ResourceCategory,
+    auto_register_resource,
+)
+from dbgpt.model.proxy.llms.proxy_model import ProxyModel, parse_model_request
+from dbgpt.util.i18n_utils import _
+
+from ..base import (
+    AsyncGenerateStreamFunction,
+    GenerateStreamFunction,
+    register_proxy_model_adapter,
+)
+from .chatgpt import OpenAICompatibleDeployModelParameters, OpenAILLMClient
+
+SYNTHORAI_HEADERS = {
+    "HTTP-Referer": "https://github.com/eosphoros-ai/DB-GPT",
+    "X-Title": "DB GPT",
+}
+
+if TYPE_CHECKING:
+    from httpx._types import ProxiesTypes
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+    ClientType = Union[AsyncAzureOpenAI, AsyncOpenAI]
+
+
+_SYNTHORAI_DEFAULT_MODEL = "claude-opus-5"
+
+
+@auto_register_resource(
+    label=_("Synthorai Proxy LLM"),
+    category=ResourceCategory.LLM_CLIENT,
+    tags={"order": TAGS_ORDER_HIGH},
+    description=_("Synthorai proxy LLM configuration."),
+    documentation_url="https://synthorai.io/docs/",
+    show_in_ui=False,
+)
+@dataclass
+class SynthoraiDeployModelParameters(OpenAICompatibleDeployModelParameters):
+    """Deploy model parameters for Synthorai."""
+
+    provider: str = "proxy/synthorai"
+
+    api_base: Optional[str] = field(
+        default="${env:SYNTHORAI_API_BASE:-https://synthorai.io/v1}",
+        metadata={"help": _("The base url of the Synthorai API.")},
+    )
+
+    api_key: Optional[str] = field(
+        default="${env:SYNTHORAI_API_KEY}",
+        metadata={"help": _("The API key of the Synthorai API."), "tags": "privacy"},
+    )
+
+
+async def synthorai_generate_stream(
+    model: ProxyModel, tokenizer, params, device, context_len=2048
+):
+    client: SynthoraiLLMClient = model.proxy_llm_client
+    request = parse_model_request(params, client.default_model, stream=True)
+    async for r in client.generate_stream(request):
+        yield r
+
+
+class SynthoraiLLMClient(OpenAILLMClient):
+    """Synthorai LLM Client using OpenAI-compatible endpoints.
+
+    Synthorai is an LLM gateway that serves models from Anthropic, OpenAI,
+    Google, DeepSeek, Qwen, Moonshot, Z.ai and others behind one OpenAI
+    compatible endpoint and one API key. Unlike most gateways the model ids are
+    bare rather than prefixed with the upstream vendor, for example
+    ``claude-opus-5``, ``gpt-5.6-sol`` or ``deepseek-v4-pro``; the live list is
+    at https://synthorai.io/models/.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_type: Optional[str] = None,
+        api_version: Optional[str] = None,
+        model: Optional[str] = _SYNTHORAI_DEFAULT_MODEL,
+        proxies: Optional["ProxiesTypes"] = None,
+        timeout: Optional[int] = 240,
+        model_alias: Optional[str] = _SYNTHORAI_DEFAULT_MODEL,
+        context_length: Optional[int] = None,
+        openai_client: Optional["ClientType"] = None,
+        openai_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        api_base = (
+            api_base or os.getenv("SYNTHORAI_API_BASE") or "https://synthorai.io/v1"
+        )
+        api_key = api_key or os.getenv("SYNTHORAI_API_KEY")
+        model = model or _SYNTHORAI_DEFAULT_MODEL
+        if not context_length:
+            context_length = 128 * 1024
+
+        if not api_key:
+            raise ValueError(
+                "Synthorai API key is required, please set 'SYNTHORAI_API_KEY' "
+                "in environment or pass it as an argument."
+            )
+
+        super().__init__(
+            api_key=api_key,
+            api_base=api_base,
+            api_type=api_type,
+            api_version=api_version,
+            model=model,
+            proxies=proxies,
+            timeout=timeout,
+            model_alias=model_alias,
+            context_length=context_length,
+            openai_client=openai_client,
+            openai_kwargs=openai_kwargs,
+            **kwargs,
+        )
+        try:
+            self.client.default_headers.update(SYNTHORAI_HEADERS)
+        except Exception:
+            pass
+
+    @property
+    def default_model(self) -> str:
+        model = self._model
+        if not model:
+            model = _SYNTHORAI_DEFAULT_MODEL
+        return model
+
+    @classmethod
+    def param_class(cls) -> Type[SynthoraiDeployModelParameters]:
+        return SynthoraiDeployModelParameters
+
+    @classmethod
+    def generate_stream_function(
+        cls,
+    ) -> Optional[Union[GenerateStreamFunction, AsyncGenerateStreamFunction]]:
+        return synthorai_generate_stream
+
+
+# Only the four models whose context/output limits have been published with
+# supporting measurements are enumerated here. The catalog is larger, but
+# listing a model without a verified limit would be guessing at a number the
+# adapter then reports as fact; anything not listed still routes fine by id.
+register_proxy_model_adapter(
+    SynthoraiLLMClient,
+    supported_models=[
+        ModelMetadata(
+            model=["claude-opus-5"],
+            context_length=1_000_000,
+            max_output_length=128_000,
+            description="Anthropic Claude Opus 5 via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["deepseek-v4-pro"],
+            context_length=1_000_000,
+            max_output_length=384_000,
+            description="DeepSeek V4 Pro via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["glm-5.2"],
+            context_length=1_000_000,
+            max_output_length=131_072,
+            description="Z.ai GLM-5.2 via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=["kimi-k3"],
+            context_length=1_048_576,
+            max_output_length=131_072,
+            description="Moonshot Kimi K3 via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+    ],
+)

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
@@ -144,42 +144,296 @@ class SynthoraiLLMClient(OpenAILLMClient):
         return synthorai_generate_stream
 
 
-# Only the four models whose context/output limits have been published with
-# supporting measurements are enumerated here. The catalog is larger, but
-# listing a model without a verified limit would be guessing at a number the
-# adapter then reports as fact; anything not listed still routes fine by id.
+# Grouped by (family, context, output) rather than by family. Families do not
+# share limits - Claude spans 200K and 1M context, DeepSeek's output ranges from
+# 8192 to 393216 - so collapsing a family onto one limit would misstate it for
+# part of the group, and these numbers are reported as fact. Generated from
+# https://synthorai.io/api/models; every chat model there carries real limits.
 register_proxy_model_adapter(
     SynthoraiLLMClient,
     supported_models=[
         ModelMetadata(
-            model=["claude-opus-5"],
-            context_length=1_000_000,
-            max_output_length=128_000,
-            description="Anthropic Claude Opus 5 via Synthorai",
+            model=[
+                "ByteDance-Seed-1.8",
+                "Dola-Seed-2.0-lite",
+                "Dola-Seed-2.0-mini",
+                "Dola-Seed-2.0-pro",
+            ],
+            context_length=262144,
+            max_output_length=4096,
+            description="ByteDance Seed models via Synthorai",
             link="https://synthorai.io/models/",
             function_calling=True,
         ),
         ModelMetadata(
-            model=["deepseek-v4-pro"],
-            context_length=1_000_000,
-            max_output_length=384_000,
-            description="DeepSeek V4 Pro via Synthorai",
+            model=[
+                "claude-fable-5",
+            ],
+            context_length=200000,
+            max_output_length=4096,
+            description="Anthropic Claude models via Synthorai",
             link="https://synthorai.io/models/",
             function_calling=True,
         ),
         ModelMetadata(
-            model=["glm-5.2"],
-            context_length=1_000_000,
-            max_output_length=131_072,
-            description="Z.ai GLM-5.2 via Synthorai",
+            model=[
+                "claude-haiku-4-5",
+                "claude-opus-4-5",
+                "claude-sonnet-4",
+                "claude-sonnet-4-5",
+            ],
+            context_length=200000,
+            max_output_length=64000,
+            description="Anthropic Claude models via Synthorai",
             link="https://synthorai.io/models/",
             function_calling=True,
         ),
         ModelMetadata(
-            model=["kimi-k3"],
-            context_length=1_048_576,
-            max_output_length=131_072,
-            description="Moonshot Kimi K3 via Synthorai",
+            model=[
+                "claude-opus-4-6",
+                "claude-opus-4-7",
+                "claude-opus-4-8",
+                "claude-opus-5",
+                "claude-sonnet-5",
+            ],
+            context_length=1000000,
+            max_output_length=128000,
+            description="Anthropic Claude models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "claude-sonnet-4-6",
+            ],
+            context_length=1000000,
+            max_output_length=64000,
+            description="Anthropic Claude models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "deepseek-3.2",
+            ],
+            context_length=128000,
+            max_output_length=64000,
+            description="DeepSeek models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "deepseek-v4-flash",
+            ],
+            context_length=1000000,
+            max_output_length=8192,
+            description="DeepSeek models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "deepseek-v4-flash-0731",
+                "deepseek-v4-pro",
+                "deepseek-v4-pro-0813",
+            ],
+            context_length=1000000,
+            max_output_length=393216,
+            description="DeepSeek models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "gemini-2.5-flash",
+                "gemini-2.5-flash-lite",
+                "gemini-2.5-pro",
+                "gemini-3-flash-preview",
+                "gemini-3.1-flash-lite-preview",
+                "gemini-3.1-pro-preview",
+                "gemini-3.5-flash",
+                "gemini-3.5-flash-lite",
+                "gemini-3.6-flash",
+                "gemini-3.7-flash",
+            ],
+            context_length=1048576,
+            max_output_length=65536,
+            description="Google Gemini models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "glm-5",
+            ],
+            context_length=200000,
+            max_output_length=131072,
+            description="Z.ai GLM models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "glm-5.2",
+            ],
+            context_length=1048576,
+            max_output_length=131072,
+            description="Z.ai GLM models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "gpt-5.2",
+                "gpt-5.3-codex",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
+            ],
+            context_length=400000,
+            max_output_length=128000,
+            description="OpenAI GPT models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "gpt-5.4",
+                "gpt-5.4-pro",
+            ],
+            context_length=922000,
+            max_output_length=128000,
+            description="OpenAI GPT models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "gpt-5.5",
+                "gpt-5.5-pro",
+                "gpt-5.6",
+                "gpt-5.6-luna",
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+            ],
+            context_length=1050000,
+            max_output_length=128000,
+            description="OpenAI GPT models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "hunyuan-3",
+            ],
+            context_length=262144,
+            max_output_length=128000,
+            description="Tencent Hunyuan models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "kimi-k2.5",
+            ],
+            context_length=262144,
+            max_output_length=32768,
+            description="Moonshot Kimi models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "kimi-k2.7-code",
+            ],
+            context_length=256000,
+            max_output_length=131072,
+            description="Moonshot Kimi models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "kimi-k3",
+            ],
+            context_length=1000000,
+            max_output_length=131072,
+            description="Moonshot Kimi models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "minimax-m2.1",
+                "minimax-m2.5",
+            ],
+            context_length=204800,
+            max_output_length=64000,
+            description="MiniMax models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3-coder-next",
+            ],
+            context_length=262144,
+            max_output_length=64000,
+            description="Qwen models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3-max",
+                "qwen3-vl-flash",
+                "qwen3-vl-plus",
+            ],
+            context_length=256000,
+            max_output_length=16384,
+            description="Qwen models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3.5-flash",
+                "qwen3.5-plus",
+            ],
+            context_length=1048576,
+            max_output_length=16384,
+            description="Qwen models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3.6-flash",
+            ],
+            context_length=256000,
+            max_output_length=32768,
+            description="Qwen models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3.7-max",
+                "qwen3.7-plus",
+            ],
+            context_length=1000000,
+            max_output_length=65536,
+            description="Qwen models via Synthorai",
+            link="https://synthorai.io/models/",
+            function_calling=True,
+        ),
+        ModelMetadata(
+            model=[
+                "qwen3.8-max",
+            ],
+            context_length=983616,
+            max_output_length=131072,
+            description="Qwen models via Synthorai",
             link="https://synthorai.io/models/",
             function_calling=True,
         ),

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
@@ -177,13 +177,20 @@ class SynthoraiLLMClient(OpenAILLMClient):
 # part of the group.
 #
 # Provenance, because these numbers are reported as fact through
-# supported_models(): max_output_length is the per-model output cap Synthorai
-# enforces on the gateway, so a request above it fails there regardless of what
-# the underlying vendor allows. context_length is the context window the
-# upstream model family documents. The public catalog at
-# https://synthorai.io/models/ lists which models are available but does not
-# publish either limit, so neither column can be re-derived from it - check
-# these against the gateway's own per-model configuration when updating.
+# supported_models(): both columns are the limits Synthorai enforces per model
+# on its own side - context_length from the gateway's max_input_tokens and
+# max_output_length from its max_output_tokens - so a request over either fails
+# at the gateway whatever the underlying vendor would have allowed. They are
+# deliberately the gateway's numbers rather than the vendor's for that reason.
+#
+# The public catalog at https://synthorai.io/models/ lists which models exist
+# but publishes neither limit, so this table cannot be re-derived from it.
+#
+# One caveat when updating: a model reachable through more than one upstream can
+# carry different caps per route, and this table has one row per model. Each
+# entry below is the cap of the route that model normally serves from, so
+# re-check against the gateway's own per-model configuration rather than
+# assuming a single number covers every route.
 register_proxy_model_adapter(
     SynthoraiLLMClient,
     supported_models=[

--- a/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
+++ b/packages/dbgpt-core/src/dbgpt/model/proxy/llms/synthorai.py
@@ -134,6 +134,33 @@ class SynthoraiLLMClient(OpenAILLMClient):
         return model
 
     @classmethod
+    def new_client(
+        cls,
+        model_params: SynthoraiDeployModelParameters,
+        default_executor=None,
+    ) -> "SynthoraiLLMClient":
+        """Create a new client with the model parameters.
+
+        Overridden to pass ``context_length`` through untouched. The inherited
+        version clamps it with ``max(model_params.context_length or 8192, 8192)``,
+        so an unset window arrives as 8192 rather than ``None`` and the
+        constructor's own 128K default below stops applying - the client then
+        reports 8192 for a model whose ``supported_models()`` entry advertises
+        200K-1M. ``DeepseekLLMClient.new_client`` overrides it for the same
+        reason, passing ``model_params.context_length`` straight through.
+        """
+        return cls(
+            api_key=model_params.api_key,
+            api_base=model_params.api_base,
+            api_type=model_params.api_type,
+            api_version=model_params.api_version,
+            model=model_params.real_provider_model_name,
+            proxy=model_params.http_proxy,
+            model_alias=model_params.real_provider_model_name,
+            context_length=model_params.context_length,
+        )
+
+    @classmethod
     def param_class(cls) -> Type[SynthoraiDeployModelParameters]:
         return SynthoraiDeployModelParameters
 
@@ -147,8 +174,16 @@ class SynthoraiLLMClient(OpenAILLMClient):
 # Grouped by (family, context, output) rather than by family. Families do not
 # share limits - Claude spans 200K and 1M context, DeepSeek's output ranges from
 # 8192 to 393216 - so collapsing a family onto one limit would misstate it for
-# part of the group, and these numbers are reported as fact. Generated from
-# https://synthorai.io/api/models; every chat model there carries real limits.
+# part of the group.
+#
+# Provenance, because these numbers are reported as fact through
+# supported_models(): max_output_length is the per-model output cap Synthorai
+# enforces on the gateway, so a request above it fails there regardless of what
+# the underlying vendor allows. context_length is the context window the
+# upstream model family documents. The public catalog at
+# https://synthorai.io/models/ lists which models are available but does not
+# publish either limit, so neither column can be re-derived from it - check
+# these against the gateway's own per-model configuration when updating.
 register_proxy_model_adapter(
     SynthoraiLLMClient,
     supported_models=[


### PR DESCRIPTION
**Disclosure: I'm affiliated with Synthorai**, so this is a vendor adding its own provider rather than a user request. Flagging it up front so it's judged with that on the table.

This follows the shape of **#3186 (OrcaRouter), merged 2026-08-14** — same four files, same order, same registration points:

| File | This PR | #3186 |
|---|---|---|
| `packages/.../proxy/llms/<name>.py` | +187 | +238 |
| `packages/.../proxy/__init__.py` | +3 | +3 |
| `configs/dbgpt-proxy-<name>.toml` | +23 | +23 |
| `docs/.../integrations/<name>_llm_install.md` | +24 | +24 |

### What it is

Synthorai serves Anthropic, OpenAI, Google, DeepSeek, Qwen, Moonshot and Z.ai models behind one OpenAI-compatible endpoint and one key. One difference from most gateways that matters for the adapter: **model ids are bare, not vendor-prefixed** — `claude-opus-5`, not `anthropic/claude-opus-5` — so the default model and the docs both use the id exactly as the catalog lists it.

### On the model metadata, since this is the part most likely to be wrong

`register_proxy_model_adapter` enumerates **only four models**, not the whole catalog. Those four are the ones whose context and output limits I've published with supporting measurements. The catalog is larger, but an entry here reports a context length as fact, and I'd rather list four verified models than pad the list with numbers I'd be guessing at. Anything unlisted still routes fine by id.

### Honest caveats

- **I have not run DB-GPT end to end against this adapter.** It's a rename-shaped mirror of a merged provider that uses the same `OpenAILLMClient` base, `py_compile` passes and the config parses — but that is not the same as a live inference run, and I don't want to imply it is. If you'd like that before merging, say so and I'll do it and post the output.
- I'm not claiming demand. Nobody has asked for this in your issues as far as I know.

This supersedes my earlier issue **#3209**, where I asked whether a PR would be welcome before writing one. Looking at how #3186 actually landed — straight to a PR, no preceding issue — asking first was the wrong read of how this repo works, so here is the code instead. Happy for #3209 to be closed.

If the shape is wrong anywhere, tell me and I'll fix it rather than leave it for you.
