### PR TITLE
fix: parse LOCAL_DB_SSL_VERIFY as a boolean

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/_private/config.py
+++ b/packages/dbgpt-core/src/dbgpt/_private/config.py
@@ -215,7 +215,9 @@ class Config(metaclass=Singleton):
         self.LOCAL_DB_PASSWORD = os.getenv("LOCAL_DB_PASSWORD", "aa123456")
         self.LOCAL_DB_POOL_SIZE = int(os.getenv("LOCAL_DB_POOL_SIZE", 10))
         self.LOCAL_DB_POOL_OVERFLOW = int(os.getenv("LOCAL_DB_POOL_OVERFLOW", 20))
-        self.LOCAL_DB_SSL_VERIFY = bool(os.getenv("LOCAL_DB_SSL_VERIFY", False))
+        self.LOCAL_DB_SSL_VERIFY = (
+            os.getenv("LOCAL_DB_SSL_VERIFY", "False").lower() == "true"
+        )
 
         self.CHAT_HISTORY_STORE_TYPE = os.getenv("CHAT_HISTORY_STORE_TYPE", "db")
 

--- a/packages/dbgpt-core/src/dbgpt/_private/tests/test_config.py
+++ b/packages/dbgpt-core/src/dbgpt/_private/tests/test_config.py
@@ -1,0 +1,18 @@
+import pytest
+
+from dbgpt._private.config import Config
+from dbgpt.util.singleton import Singleton
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [("true", True), ("TRUE", True), ("false", False), ("False", False)],
+)
+def test_local_db_ssl_verify_parses_boolean_env(monkeypatch, env_value, expected):
+    monkeypatch.setenv("LOCAL_DB_SSL_VERIFY", env_value)
+    Singleton._instances.pop(Config, None)
+
+    try:
+        assert Config().LOCAL_DB_SSL_VERIFY is expected
+    finally:
+        Singleton._instances.pop(Config, None)


### PR DESCRIPTION
## Summary

- parse `LOCAL_DB_SSL_VERIFY` using the same case-insensitive boolean convention as other DB-GPT flags
- keep explicit `false` values disabled instead of treating every non-empty string as true
- add focused coverage for true and false spellings

## Validation

- focused before/after environment-value reproduction (`false`: true before, false after; `TRUE`: true after)
- `python3 -m compileall -q packages/dbgpt-core/src/dbgpt/_private/config.py packages/dbgpt-core/src/dbgpt/_private/tests/test_config.py`
- `git diff --cached --check`
