### PR TITLE
fix(datasource): SparkConnector.table_simple_info raises TypeError on every call

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/conn_spark.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/conn_spark.py
@@ -168,7 +168,7 @@ class SparkConnector(BaseConnector):
 
     def table_simple_info(self):
         """Get table simple info."""
-        return f"{self.table_name}{self.get_fields()}"
+        return f"{self.table_name}{self.get_fields(self.table_name)}"
 
     def get_table_comments(self, db_name):
         """Get table comments."""


### PR DESCRIPTION
## Problem

`SparkConnector.table_simple_info()` raises `TypeError` on every call.

`SparkConnector.get_fields` is declared with a required `table_name`, matching the
`BaseConnector.get_fields(self, table_name: str)` contract
(`packages/dbgpt-core/src/dbgpt/datasource/base.py:203`):

```python
def get_fields(self, table_name: str):
    """Get column meta about dataframe.

    TODO: Support table_name.
    """
    return ",".join([f"({name}: {dtype})" for name, dtype in self.df.dtypes])
```

but `table_simple_info` calls it with no arguments
(`packages/dbgpt-ext/src/dbgpt_ext/datasource/conn_spark.py:171`):

```python
def table_simple_info(self):
    """Get table simple info."""
    return f"{self.table_name}{self.get_fields()}"
```

`self.get_fields()` resolves to `SparkConnector.get_fields`, which needs
`table_name`, so the f-string never gets evaluated:

```
TypeError: SparkConnector.get_fields() missing 1 required positional argument: 'table_name'
```

## Reachability

`table_simple_info()` is called generically on whatever connector the datasource
resolves to, so a Spark datasource hits this:

- `packages/dbgpt-serve/src/dbgpt_serve/agent/resource/datasource.py:170`
  — `table_infos = conn.table_simple_info()`, the fallback path when
  `get_db_summary` returns nothing.
- `packages/dbgpt-serve/src/dbgpt_serve/evaluate/service/fetchdata/benchmark_data_manager.py:1009`
  — `return list(self._connector.table_simple_info())`

## Fix

Pass the table name the method already has in hand. `__init__` sets
`self.table_name = "temp"`, and the same attribute is already interpolated on the
preceding part of that very f-string.

```diff
-        return f"{self.table_name}{self.get_fields()}"
+        return f"{self.table_name}{self.get_fields(self.table_name)}"
```

`SparkConnector.get_fields` currently ignores `table_name` (it has an explicit
`TODO: Support table_name` and reads `self.df.dtypes`), so this changes no output
— it only lets the call succeed. When that TODO is implemented, the call site is
already passing the right thing.

## Verification

No Spark cluster is needed to show this. The two method bodies were extracted from
the real file with `ast` and executed against a stub DataFrame:

```
extracted: ['get_fields', 'table_simple_info']
signature get_fields: (self, table_name: str)
UNPATCHED -> TypeError: SparkConnectorStub.get_fields() missing 1 required positional argument: 'table_name'
PATCHED   -> 'temp(id: bigint),(name: string)'
```

The unpatched run reproduces the exact `TypeError`; the patched run returns the
intended summary string.

## Scope

Deliberately limited to the one broken call. Not changed here:

- `get_fields` still ignores `table_name` — that is the pre-existing `TODO`, and
  implementing it is a separate change.
- `SparkConnector.table_simple_info` returns a `str` while the RDBMS/Neo4j/TuGraph
  implementations return a sequence. That inconsistency is real but predates this
  bug and is out of scope for a crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
