### PR TITLE
fix(examples/rag): retriever_evaluation_example.py raises TypeError on every run

### DIFF
--- a/examples/rag/retriever_evaluation_example.py
+++ b/examples/rag/retriever_evaluation_example.py
@@ -27,7 +27,7 @@ def _create_embeddings(
     ).create()
 
 
-def _create_vector_connector():
+def _create_vector_connector(embeddings: Embeddings):
     """Create vector connector."""
     config = ChromaVectorConfig(
         persist_path=PILOT_PATH,
@@ -36,7 +36,7 @@ def _create_vector_connector():
     return ChromaStore(
         config,
         name="embedding_rag_test",
-        embedding_fn=_create_embeddings(),
+        embedding_fn=embeddings,
     )
 
 


### PR DESCRIPTION
## Problem

`examples/rag/retriever_evaluation_example.py` cannot run. `main()` calls the helper with one argument:

```python
embeddings = _create_embeddings()
vector_connector = _create_vector_connector(embeddings)   # line 47
```

but the helper takes none:

```python
def _create_vector_connector():          # line 30
    ...
    return ChromaStore(config, name="embedding_rag_test", embedding_fn=_create_embeddings())
```

```
TypeError: _create_vector_connector() takes 0 positional arguments but 1 was given
```

The file ends in `if __name__ == "__main__": asyncio.run(main())`, and the failure happens on the third statement of `main()` — before any knowledge is loaded or any metric is computed. The example has never been runnable in this state.

## Why the parameter, rather than dropping the argument

`examples/` defines `_create_vector_connector` nine times, once per example. Eight of them are called with no arguments and bind fine; this file is the lone call site that passes one — and it passes one because `main()` has already built the embeddings on the line above, for use by `RetrieverEvaluator(embeddings=embeddings)` and `RetrieverSimilarityMetric(embeddings=embeddings)` further down.

So the call site is expressing a real intent that the `def` never picked up. Accepting the argument both fixes the `TypeError` and stops the helper from constructing a second `text2vec-large-chinese` instance via its own `_create_embeddings()` call, which is pure duplicated model load.

(The alternative — changing line 47 to `_create_vector_connector()` — also removes the `TypeError`, but keeps the redundant second embedding model. Happy to switch to that if you prefer the examples to stay uniformly zero-argument.)

## Verification

Every `_create_vector_connector` call site under `examples/` was replayed against the `def` in its own file with `ast` + `inspect.Signature.bind` (parse only, nothing imported), before and after the change:

```
                                              BEFORE
rag/cross_encoder_rerank_example.py     :42   def()            call _create_vector_connector()           -> OK
rag/db_schema_rag_example.py            :62   def()            call _create_vector_connector()           -> OK
rag/embedding_rag_example.py            :42   def()            call _create_vector_connector()           -> OK
rag/metadata_filter_example.py          :40   def()            call _create_vector_connector()           -> OK
rag/rag_embedding_api_example.py        :71   def()            call _create_vector_connector()           -> OK
rag/retriever_evaluation_example.py     :47   def()            call _create_vector_connector(embeddings) -> TypeError: too many positional arguments
rag/simple_dbschema_retriever_example.py:105  def()            call _create_vector_connector()           -> OK
rag/simple_rag_embedding_example.py     :75   def()            call _create_vector_connector()           -> OK
rag/simple_rag_retriever_example.py     :91   def()            call _create_vector_connector()           -> OK
8/9 call sites bind cleanly.

                                              AFTER
rag/retriever_evaluation_example.py     :47   def(embeddings)  call _create_vector_connector(embeddings) -> OK
(all others unchanged)
9/9 call sites bind cleanly.
```

`Embeddings` is already imported in this file (`from dbgpt.core import Embeddings`), so the annotation adds no import.

Formatting checked against the repo's own gate (`make fmt-check`) with `ruff 0.9.10` and the root `pyproject.toml`:

```
ruff format --check examples/rag/retriever_evaluation_example.py   -> 1 file already formatted
ruff check --select I examples/rag/retriever_evaluation_example.py -> All checks passed!
```

(The file also reports one `E501` at line 67, inside the long prompt-text literal — that is pre-existing on the unpatched file and is not part of the `examples/` gate.)

Net diff: **+2 / −2**, one file, `examples/` only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
