### PR TITLE
fix(datasource): avoid creating an empty SQLite parent directory

### DIFF
--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_sqlite.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/conn_sqlite.py
@@ -99,7 +99,7 @@ class SQLiteConnector(RDBMSConnector):
         _engine_args["connect_args"] = {"check_same_thread": False}
         # _engine_args["echo"] = True
         directory = os.path.dirname(file_path)
-        if not os.path.exists(directory):
+        if directory and not os.path.exists(directory):
             os.makedirs(directory)
         return cls(create_engine("sqlite:///" + file_path, **_engine_args), **kwargs)
 

--- a/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_sqlite.py
+++ b/packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_sqlite.py
@@ -139,3 +139,14 @@ def test_db_dir_exist_dir():
         db = SQLiteConnector.from_file_path(file_path)
         assert os.path.exists(existing_dir) is True
         assert list(db.get_table_names()) == []
+
+
+def test_db_file_path_without_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    db = SQLiteConnector.from_file_path("relative.db")
+    try:
+        assert (tmp_path / "relative.db").is_file()
+        assert list(db.get_table_names()) == []
+    finally:
+        db.close()


### PR DESCRIPTION
# Description

Fix `SQLiteConnector.from_file_path()` for filename-only relative paths such as `relative.db`.

For this input, `os.path.dirname("relative.db")` returns an empty string. The previous implementation called `os.makedirs("")`, raising `FileNotFoundError` before SQLite was opened.

The change creates a parent directory only when one is present. A regression test covers creating and using the database in a temporary working directory.

# How Has This Been Tested?

```bash
PYTHONPATH=packages .venv.make/bin/pytest -q \
  packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_sqlite.py::test_db_file_path_without_directory \
  packages/dbgpt-ext/src/dbgpt_ext/datasource/rdbms/tests/test_conn_sqlite.py::test_db_dir_exist_dir
```

Result: `2 passed`.

# Snapshots:

N/A (backend-only change).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x]  I have already rebased the commits and make the commit message conform to the project standard.
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [ ]  Any dependent changes have been merged and published in downstream modules
