### PR TITLE
fix(model): return the config dict in the worker config handler

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/model/cluster/worker/manager.py
+++ b/packages/dbgpt-core/src/dbgpt/model/cluster/worker/manager.py
@@ -1396,7 +1396,7 @@ def _parse_config(config_file: str):
                 )
             return config_dict[0]
         else:
-            config_dict
+            return config_dict
 
     scan_model_providers()
 


### PR DESCRIPTION
## Description

In `_parse_config().config_handler` (`packages/dbgpt-core/src/dbgpt/model/cluster/worker/manager.py`), the list branch correctly returns `config_dict[0]`, but the dict branch was a bare expression:

```python
else:
    config_dict   # evaluated and discarded -> implicit None
```

Any `models.llms` / `models.embeddings` section parsed as a dict rather than a list of tables (e.g. a single `[models.llms]` TOML table, or a YAML/JSON object) therefore made `parse_config()` receive `None` and crash in `_convert_to_dataclass` with a confusing `'NoneType' object has no attribute 'get'`. Added the missing `return`.

## How Has This Been Tested?

- `python -m py_compile` on the touched file
- Manual trace: `config_handler({"name": "x"})` now returns the dict instead of `None`
- Not run locally: the full worker startup path (requires model runtime deps); the change is a one-line missing-return fix

## Snapshots

N/A — no UI changes.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its rules
- [x] Commit messages conform to the project standard
- [x] Code style (`make fmt-check`) not affected (one-line change inside an existing branch)
