### PR TITLE
fix(awel): return view metadata in the flow-compat migration function

### DIFF
--- a/packages/dbgpt-core/src/dbgpt/util/cli/flow_compat.py
+++ b/packages/dbgpt-core/src/dbgpt/util/cli/flow_compat.py
@@ -175,7 +175,7 @@ def _update_template(
             if isinstance(old_metadata, ViewMetadata):
                 if not isinstance(obj_type, DAGNode):
                     return None
-                obj_type.metadata
+                return obj_type.metadata
             elif isinstance(old_metadata, ResourceMetadata):
                 metadata_attr = f"_resource_metadata_{obj_type.__name__}"
                 return getattr(obj_type, metadata_attr)


### PR DESCRIPTION
## Description

In `metadata_func` inside `packages/dbgpt-core/src/dbgpt/util/cli/flow_compat.py`, the `ViewMetadata` branch evaluated `obj_type.metadata` as a bare statement and fell through to an implicit `return None`, while the parallel `ResourceMetadata` branch correctly does `return getattr(obj_type, metadata_attr)`. As a result the legacy view-operator metadata was never migrated: `fill_flow_panel` (`core/awel/flow/flow_factory.py`) receives `None` and silently falls back. Added the missing `return`.

## How Has This Been Tested?

- `python -m py_compile` on the touched file
- Manual trace: the `ViewMetadata` branch now returns `obj_type.metadata` (a `ViewMetadata`), mirroring the `ResourceMetadata` branch
- Not run locally: the full legacy-template upgrade path needs a populated metadata DB

## Snapshots

N/A.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its rules
- [x] Commit messages conform to the project standard
