### PR TITLE
feat(connector): add Parallel Search MCP template

### DIFF
--- a/docs/docs/application/mcp_connectors.md
+++ b/docs/docs/application/mcp_connectors.md
@@ -15,7 +15,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io) is an open standar
 
 ## Highlights
 
-- **Built-in templates** — One-click activation for Feishu, DingTalk, Yuque, GitHub, Notion, Linear, Tavily, and DeepWiki.
+- **Built-in templates**: Activate Feishu, DingTalk, Yuque, GitHub, Notion, Linear, Tavily, Parallel Search, and DeepWiki.
 - **Custom MCP servers** — Connect any SSE or Streamable HTTP MCP endpoint with your own auth.
 - **Per-conversation selection** — Choose which connectors to attach in the composer; the agent's prompt stays focused and token-efficient.
 - **Human-in-the-loop confirmation** — Write actions (create / update / delete) pop a confirmation dialog before they run.
@@ -55,6 +55,7 @@ A connector lives in one of three states:
 | Notion | Document | Streamable HTTP | Pages and databases read / write |
 | Linear | Project | Streamable HTTP | Issues / projects collaboration |
 | Tavily | Search | Streamable HTTP | LLM-optimized web search, returns Markdown |
+| Parallel Search | Search | Streamable HTTP | Public web search and page content extraction, no Parallel API key required |
 | DeepWiki | Dev Tools | Streamable HTTP | AI reading & Q&A over any GitHub repo |
 
 ## Managing connectors
@@ -85,6 +86,17 @@ Click **Add Connector** to open the dialog:
 | **Connector description** | Optional. Shown in the agent's tool description. |
 
 For a custom server, just provide the endpoint URL, transport, and authentication. Credentials are encrypted before they are stored.
+
+### Connect Parallel Search without an API key
+
+1. Activate the **Parallel Search** template on the **Connectors** page.
+2. Enter `https://search.parallel.ai/mcp` as the server URL, select **Streamable HTTP**, and set **Auth type** to `none`. No Parallel account or API key is required.
+3. Save the connector, then inspect its `web_search` and `web_fetch` tools.
+4. Attach it to a conversation using **Select MCP** in the composer.
+
+Once attached, the agent can call these tools automatically. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. Free access is rate limited. Only include information you intend to send to this service. See the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp) for service details.
+
+Deselect the connector in the composer to stop using it in that conversation, or delete it from the **Connectors** page. Adding the template does not activate it or change existing connectors.
 
 ### Inspect the tools
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/application/mcp_connectors.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/application/mcp_connectors.md
@@ -15,7 +15,7 @@ title: MCP 连接器
 
 ## 功能亮点
 
-- **内置模板**——飞书、钉钉、语雀、GitHub、Notion、Linear、Tavily、DeepWiki 一键激活。
+- **内置模板**——飞书、钉钉、语雀、GitHub、Notion、Linear、Tavily、Parallel Search、DeepWiki 一键激活。
 - **自定义 MCP Server**——接入任意 SSE 或 Streamable HTTP 的 MCP 端点,自带鉴权。
 - **按对话选择**——在提问区勾选本轮要挂载的连接器,Agent 的 prompt 保持聚焦、节省 token。
 - **人工确认(HITL)**——写操作(创建 / 更新 / 删除)执行前弹出确认框。
@@ -55,6 +55,7 @@ graph LR
 | Notion | 知识管理 | Streamable HTTP | 页面 / 数据库读写 |
 | Linear | 项目 | Streamable HTTP | Issue / Project 协作 |
 | Tavily | 搜索增强 | Streamable HTTP | 为 LLM 优化的 Web 搜索,返回 Markdown |
+| Parallel Search | 搜索增强 | Streamable HTTP | 公开网页搜索与页面内容提取,无需 Parallel API Key |
 | DeepWiki | 研发工具 | Streamable HTTP | 对任意 GitHub 仓库的 AI 解读与问答 |
 
 ## 管理连接器
@@ -85,6 +86,17 @@ graph LR
 | **连接器描述** | 可选,会展示在 Agent 的工具描述中。 |
 
 对于自定义 Server,只需提供接入地址、传输协议和鉴权信息即可。凭据会在存储前加密。
+
+### 无需 API Key 连接 Parallel Search
+
+1. 在**连接器管理**页激活 **Parallel Search** 模板。
+2. 将服务器 URL 设置为 `https://search.parallel.ai/mcp`,选择 **Streamable HTTP**,并将**认证方式**设为 `none`。无需 Parallel 账号或 API Key。
+3. 保存连接器,然后查看其 `web_search` 和 `web_fetch` 工具。
+4. 在提问区通过**选择 MCP** 将其挂载到对话中。
+
+挂载后,Agent 可以自动调用这些工具。查询、请求的 URL,以及提供的目标或上下文都会发送至 Parallel。免费访问有速率限制,请仅提供你愿意发送给该服务的信息。服务详情请参阅 [Parallel Search MCP 文档](https://docs.parallel.ai/integrations/mcp/search-mcp)。
+
+在提问区取消勾选该连接器,即可停止在当前对话中使用它;也可以在**连接器管理**页将其删除。添加模板不会自动激活它,也不会更改现有连接器。
 
 ### 查看工具
 

--- a/packages/dbgpt-ext/src/dbgpt_ext/connector/catalog.json
+++ b/packages/dbgpt-ext/src/dbgpt_ext/connector/catalog.json
@@ -71,6 +71,16 @@
       "read_actions": ["tavily_search", "tavily_extract", "tavily_crawl", "tavily_map"]
     },
     {
+      "type": "parallel",
+      "display_name": "Parallel Search",
+      "description": "网页搜索与内容提取，无需 Parallel 账号或 API Key，有使用限制；调用时查询、URL 和上下文会发送至 Parallel",
+      "icon": "parallel",
+      "category": "search",
+      "mcp_server": {"transport": "streamable_http"},
+      "confirm_actions": [],
+      "read_actions": ["web_search", "web_fetch"]
+    },
+    {
       "type": "deepwiki",
       "display_name": "DeepWiki",
       "description": "任意 GitHub 仓库的 AI 解读与问答",


### PR DESCRIPTION
# Description

Adds Parallel Search to the built-in MCP connector catalog so users can discover a web search and page extraction option that needs no Parallel account or API key. The connector guide includes the endpoint, Streamable HTTP transport, and `none` auth setting.

Tavily is already in the [connector catalog](https://github.com/eosphoros-ai/DB-GPT/blob/7c3cc2fd758bed3afef3a2d4c098d8a0c5ae3fab/packages/dbgpt-ext/src/dbgpt_ext/connector/catalog.json#L63-L72), so it is a useful comparison. In [Artificial Analysis's August 31 search benchmark](https://artificialanalysis.ai/agents/search-api#details), Parallel Search (advanced) scored **77% on BrowseComp versus 59% for Tavily Search (basic)**, an 18 percentage point gap. Parallel also scored **75 versus 66 on the overall Search Index** and **81 versus 74 on DeepSearchQA F1**. That is a good reason to give DB-GPT users another search option. These are Search API results with the [same answer model and benchmark harness](https://artificialanalysis.ai/methodology/search-api), not measured scores for this free MCP connector.

Users still activate the connector and attach it to a conversation. Once attached, the agent can call `web_search` and `web_fetch` automatically. Queries, URLs, and supplied context go to Parallel; free access is rate limited. The catalog description and setup guide disclose this. Existing connectors, routing, and confirmation behavior are unchanged. No dependencies or runtime code are added.

I work at Parallel, which operates this service.

# How Has This Been Tested?

- Loaded the edited catalog through `ConnectorManager.load_catalog`, then called `create_connector("parallel", credentials={}, extra_config={"server_uri": "https://search.parallel.ai/mcp", "transport": "streamable_http", "auth_type": "none"})`. Confirmed no auth headers, active status, and discovery of `mcp__parallel__web_search` and `mcp__parallel__web_fetch`.
- Called both tools through the returned `MCPToolPack.async_execute` using their routing names. Search returned 10 results; fetch of the public Search MCP documentation returned one result with no errors. Both MCP results had `isError: false`. Removing the connector cleared the active registry.
- All 23 existing connector-manager tests passed in an isolated import harness using the unchanged test file. The harness bypassed aggregate agent package initializers while using the actual connector, credential, resource, and MCP client implementations.
- `git diff --check` passed.

Checked with Python 3.11 and MCP 1.29.1 using prebuilt dependencies. Ordinary in-tree test collection required additional unrelated agent dependencies (`sqlparse` was missing), so the focused tests were run in isolation. No full application, browser UI, docs build, or repository-wide suite was run.

# Snapshots:

Not included; the existing connector card and form are reused.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already rebased the commits and make the commit message conform to the project standard.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (no runtime code changed)
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules (none required)
